### PR TITLE
Add make release and release-tag targets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,17 @@ license = "MIT"
 repository = "https://github.com/joakimen/scriv"
 exclude = ["docs/", "demo/", ".github/", ".claude/", "prek.toml", "mise.toml"]
 
+# Config for `make release` / `make release-tag` (cargo-release). scriv ships as
+# GitHub release binaries (.github/workflows/release.yml), never to crates.io,
+# so publishing is off as a guardrail. The pushed tag is the whole release
+# trigger, named to match the `v*` that workflow listens for; releasing is
+# restricted to `main`, the branch the tag must sit on.
+[package.metadata.release]
+publish = false
+tag-name = "v{{version}}"
+tag-message = "Release v{{version}}"
+allow-branch = ["main"]
+
 [dependencies]
 anyhow = "1"
 clap = { version = "4", features = ["derive"] }

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,44 @@ install:
 hooks:
 	prek install --hook-type pre-commit --hook-type pre-push
 
+# Cut a release, step 1 of 2. Pick a bump level; cargo-release bumps the version
+# in Cargo.toml and Cargo.lock, then this opens a PR for the bump and arms squash
+# auto-merge. The bump lands through a PR rather than straight onto main because
+# the `main` ruleset requires the `build` and `demo` checks on the branch tip and
+# grants no bypass. cargo-release prints the resolved version and asks before it
+# changes anything. Run `make release-tag` once the PR has merged.
+.PHONY: release
+release:
+	@test "$$(git branch --show-current)" = main || { echo "release: run from main" >&2; exit 1; }
+	@git pull --ff-only
+	@printf 'Select release level:\n  1) patch\n  2) minor\n  3) major\n#? '; \
+	read level; \
+	case "$$level" in \
+	  1) level=patch ;; \
+	  2) level=minor ;; \
+	  3) level=major ;; \
+	  *) echo "release: invalid selection '$$level'" >&2; exit 1 ;; \
+	esac; \
+	cargo release version "$$level" --execute; \
+	ver=$$(sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -1); \
+	git switch -c "release-v$$ver"; \
+	git commit -am "Release v$$ver"; \
+	git push -u origin "release-v$$ver"; \
+	gh pr create --title "Release v$$ver" --body "Bump version to $$ver for release."; \
+	gh pr merge --squash --auto
+
+# Cut a release, step 2 of 2. Run once the `make release` PR has merged. Tags the
+# squash commit on `main` (name and message from [package.metadata.release]) and
+# pushes the tag on its own — the tag is a `refs/tags` ref the branch ruleset
+# does not govern, and it is what release.yml builds and publishes from.
+.PHONY: release-tag
+release-tag:
+	@git switch main
+	@git pull --ff-only
+	@cargo release tag --execute
+	@ver=$$(sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -1); \
+	SKIP=check git push origin "v$$ver"
+
 # Re-record docs/demo.gif. Local only — the render depends on installed fonts.
 # Requires vhs (brew install vhs).
 .PHONY: demo

--- a/README.md
+++ b/README.md
@@ -53,19 +53,26 @@ repository, a tracked file and a pull request.
 ```sh
 make                # fmt check, clippy, tests, release build
 make hooks          # install the git hooks in prek.toml
+make release        # bump the version and open the release PR
+make release-tag    # after the PR merges: tag main and push the tag
 make demo           # re-record docs/demo.gif
 make demo-fixture   # build the demo sandbox and poke at it by hand
 ```
 
 ## Releasing
 
-Bump `version` in `Cargo.toml`, refresh `Cargo.lock` (`cargo check`), and merge
-that as its own pull request. Then tag the merge commit on `main`:
+Releasing is two commands. The version bump lands through a PR because the
+`main` ruleset requires the `build` and `demo` checks on the branch tip, so it
+cannot be pushed straight to `main`.
 
 ```sh
-git checkout main && git pull
-git tag v0.3.0 && git push origin v0.3.0
+make release        # bump the version, open the PR, arm squash auto-merge
+# ...wait for the PR to merge...
+make release-tag    # tag the merged commit on main and push the tag
 ```
+
+`make release` prompts for a level (patch/minor/major); cargo-release shows the
+resolved version and asks before it changes anything.
 
 The tag is what releases: `.github/workflows/release.yml` builds macOS and Linux
 on x86_64 and arm64, attaches four tarballs with checksums and build

--- a/mise.toml
+++ b/mise.toml
@@ -1,9 +1,13 @@
 #:schema https://mise.jdx.dev/schema/mise.json
-# The one development tool nothing else here installs. Rust is absent because
+# The development tools nothing else here installs. Rust is absent because
 # rust-toolchain.toml pins it and rustup reads that file directly, and vhs is
 # absent because mise has no macOS build of the ttyd it shells out to — half a
 # recorder pinned in a second place is worse than the `brew install vhs` that
 # CLAUDE.md already names.
+#
+# cargo-release drives `make release` and `make release-tag`: the version bump
+# and the tag.
 
 [tools]
 prek = "0.4.11"
+cargo-release = "1.1.2"


### PR DESCRIPTION
One command bumps the version and opens the release PR; a second tags main after it merges.

- `make release` prompts for a level, bumps via cargo-release, opens the PR, arms squash auto-merge.
- `make release-tag` tags the merged commit on main and pushes the tag.
- The bump goes through a PR because the main ruleset blocks a direct push of the commit.
- The tag pushes directly, as the ruleset governs branches, not tags.
- cargo-release is pinned in mise.toml; its config sits in `[package.metadata.release]` with publish off.

README Releasing section and targets list updated. No CLI change; `docs/demo.gif` unchanged, as nothing on screen changed.