### PR TITLE
Fix what the review found

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ scriv config check         # confirm it all resolves
 | `scriv proc` | `ls` `sel` `kill` |
 | `scriv history` | `ls` `sel` |
 | `scriv edit` | `file` `dir` — found below `$PWD`, opened in `$EDITOR` |
+| `scriv config` | `init` `print` `path` `check` |
+| `scriv init` | `fish` and every other shell — see Setup |
 
 `ls` prints the set, `sel` fuzzy-selects one line of it, and the other verbs
 act. Every `sel` composes: `cd (scriv repo sel)`. Each group takes a one-letter

--- a/demo/fixture.sh
+++ b/demo/fixture.sh
@@ -13,6 +13,14 @@ case $FIX in
     *) FIX=$PWD/$FIX ;;
 esac
 
+# The next thing this does is `rm -rf "$FIX"`, from a path a caller supplied.
+# A depth of at least three keeps a typo that resolves to `/`, `/Users` or a
+# home directory from reaching it.
+case $FIX in
+    */*/*/*) ;;
+    *) echo "fixture: refusing to wipe '$FIX' — too close to the root" >&2; exit 1 ;;
+esac
+
 SCRIV_BIN_DIR=${SCRIV_BIN_DIR:-$PWD/target/release}
 
 rm -rf "$FIX"

--- a/src/cmd/history.rs
+++ b/src/cmd/history.rs
@@ -46,12 +46,21 @@ fn load(ctx: &Ctx) -> Result<Vec<Entry>> {
 /// shown without being searched — matched, a query of `3` would rank thousands
 /// of timestamps first. No row carries a preview, so the selector keeps the
 /// full width for the commands.
+/// Almost every command is one line with nothing in it to strip, and folding
+/// leaves it identical. Those rows keep one copy of the text rather than a
+/// label and a value that happen to be equal — this runs over the whole history
+/// on every ctrl-r.
 fn items(entries: &[Entry], offset: time::UtcOffset) -> Vec<SelectItem> {
     entries
         .iter()
         .map(|entry| {
-            SelectItem::new(history::one_line(&entry.cmd), entry.cmd.clone())
-                .prefix(format!("{}  ", history::stamp(entry.when, offset)))
+            let folded = history::one_line(&entry.cmd);
+            let item = if folded == entry.cmd {
+                SelectItem::plain(folded)
+            } else {
+                SelectItem::new(folded, entry.cmd.clone())
+            };
+            item.prefix(format!("{}  ", history::stamp(entry.when, offset)))
         })
         .collect()
 }
@@ -149,6 +158,15 @@ mod tests {
         );
         assert_eq!(dated.len(), undated.len());
         assert!(undated.trim().is_empty(), "{undated:?}");
+    }
+
+    /// The one-copy path must still return the command, whichever branch of
+    /// `items` built the row.
+    #[test]
+    fn a_folded_row_and_an_untouched_one_both_return_the_command() {
+        let items = items(&entries(), utc());
+        assert_eq!(items[0].value(), "git status");
+        assert_eq!(items[1].value(), "git commit -m 'a\nb'");
     }
 
     #[test]

--- a/src/cmd/pr.rs
+++ b/src/cmd/pr.rs
@@ -260,8 +260,12 @@ fn select(ctx: &Ctx, state: &str, limit: usize, prompt: &str, tint: Tint) -> Res
     let reload = {
         let (known, failure, state) = (Arc::clone(&known), Arc::clone(&failure), state.to_string());
         Box::new(move || {
+            // Asked for outside the lock: `gh` is a network round trip, and
+            // holding the list for it would make a second ctrl-r wait on the
+            // first rather than on GitHub.
+            let fresh = gh::list(&state, limit);
             let mut known = known.lock().expect("pull request list poisoned");
-            match gh::list(&state, limit) {
+            match fresh {
                 Ok(fresh) if !fresh.is_empty() => *known = fresh,
                 // An empty answer is not worth blanking the list for: the
                 // pull request you were looking at was there a moment ago.

--- a/src/files.rs
+++ b/src/files.rs
@@ -60,10 +60,13 @@ pub fn write_lines(path: &Path, lines: &[String]) -> Result<()> {
         return Err(e);
     }
 
-    fs::rename(&tmp, path).with_context(|| {
+    // Cleanup before the context, not inside the closure that builds it: an
+    // error formatter that also deletes a file runs where nobody looks for it.
+    if let Err(e) = fs::rename(&tmp, path) {
         let _ = fs::remove_file(&tmp);
-        format!("replacing known-files list {}", path.display())
-    })
+        return Err(e).with_context(|| format!("replacing known-files list {}", path.display()));
+    }
+    Ok(())
 }
 
 fn temp_name() -> String {

--- a/src/gh.rs
+++ b/src/gh.rs
@@ -687,10 +687,18 @@ pub fn view_repo_web(dir: &Path) -> Result<()> {
 /// owners to suggest on a machine with nothing cloned yet. Failure is returned
 /// rather than swallowed, since a missing `gh` is worth saying.
 pub fn owners() -> Result<Vec<String>> {
+    // Two independent round trips to GitHub, and both stand between the user
+    // and the owner selector. Run together they cost the slower one rather than
+    // the sum.
+    let (login, orgs) = std::thread::scope(|scope| {
+        let orgs = scope.spawn(|| capture(&["api", "user/orgs", "--jq", ".[].login"]));
+        let login = capture(&["api", "user", "--jq", ".login"]);
+        (login, orgs.join())
+    });
+
     let mut out = Vec::new();
-    let login = capture(&["api", "user", "--jq", ".login"])?;
-    out.extend(login.split_whitespace().map(str::to_string));
-    let orgs = capture(&["api", "user/orgs", "--jq", ".[].login"])?;
+    out.extend(login?.split_whitespace().map(str::to_string));
+    let orgs = orgs.unwrap_or_else(|e| std::panic::resume_unwind(e))?;
     out.extend(orgs.split_whitespace().map(str::to_string));
     Ok(out)
 }

--- a/src/history.rs
+++ b/src/history.rs
@@ -133,9 +133,14 @@ pub const STAMP_WIDTH: usize = "2026-07-30 13:57".len();
 pub fn stamp(when: Option<i64>, offset: time::UtcOffset) -> String {
     match when.and_then(|w| local(w, offset)) {
         Some(dt) => render(&dt),
-        None => " ".repeat(STAMP_WIDTH),
+        None => BLANK_STAMP.to_string(),
     }
 }
+
+/// A [`stamp`]-shaped blank, written out rather than built per row: a history
+/// with no timestamps is one allocation and a loop per entry otherwise. Held to
+/// [`STAMP_WIDTH`] by a test.
+const BLANK_STAMP: &str = "                ";
 
 /// The one place the layout of a rendered timestamp is written down.
 fn render(dt: &time::OffsetDateTime) -> String {

--- a/src/path.rs
+++ b/src/path.rs
@@ -19,13 +19,21 @@ pub fn expand_home_dir(dir: &str, home: &Path) -> PathBuf {
     }
 }
 
-/// Expand a leading `~` to `home`, operating on strings. A path that does not
-/// begin with `~` is returned unchanged.
+/// Expand a leading `~` to `home`, operating on strings. The string half of
+/// [`expand_home_dir`], and expands exactly what it does: a bare `~`, and a
+/// `~/` prefix.
+///
+/// `~user` is left alone. It names *another* account's home, which only the
+/// shell and the passwd database can resolve, and rewriting it against this
+/// user's home would silently point at a path nobody asked for.
 pub fn expand_tilde(path: &str, home: &str) -> String {
-    if !path.starts_with('~') {
-        return path.to_string();
+    if path == "~" {
+        return home.to_string();
     }
-    format!("{}{}", home, &path[1..])
+    match path.strip_prefix("~/") {
+        Some(rest) => format!("{home}/{rest}"),
+        None => path.to_string(),
+    }
 }
 
 /// Decide which of `$PWD` and the real working directory to work from.
@@ -220,6 +228,28 @@ mod tests {
     #[test]
     fn expand_tilde_only_rewrites_a_leading_tilde() {
         assert_eq!(expand_tilde("/etc/~/passwd", HOME), "/etc/~/passwd");
+    }
+
+    /// `~bob` is bob's home, not this user's with `bob` glued on the end.
+    /// Rewriting it produced a path that exists for nobody.
+    #[test]
+    fn expand_tilde_leaves_another_users_home_alone() {
+        assert_eq!(expand_tilde("~bob/notes.md", HOME), "~bob/notes.md");
+        assert_eq!(expand_tilde("~bob", HOME), "~bob");
+    }
+
+    /// The two spellings of the same rule must not drift apart.
+    #[test]
+    fn expand_tilde_agrees_with_expand_home_dir() {
+        for input in ["~", "~/dev/repo", "~bob/notes", "/etc/hosts", "rel/path"] {
+            assert_eq!(
+                expand_tilde(input, HOME),
+                expand_home_dir(input, Path::new(HOME))
+                    .to_string_lossy()
+                    .into_owned(),
+                "{input}"
+            );
+        }
     }
 
     #[test]

--- a/src/proc.rs
+++ b/src/proc.rs
@@ -218,17 +218,27 @@ pub struct Signal(&'static str);
 
 /// The signals worth offering, by the names `kill -l` prints: the ones that end
 /// or suspend a process. Anything else is a job for `kill`.
+///
+/// The numbers are the *host's*. Only the first five are fixed by POSIX; the
+/// rest are numbered differently on Linux and on the BSDs macOS descends from,
+/// and the two disagree in the worst possible way — Linux 19 is `STOP` where
+/// macOS 19 is `CONT`. A table hardcoded to one platform does not fail on the
+/// other, it sends the opposite signal.
 const SIGNALS: [(&str, i32); 9] = [
     ("HUP", 1),
     ("INT", 2),
     ("QUIT", 3),
     ("KILL", 9),
     ("TERM", 15),
-    ("USR1", 30),
-    ("USR2", 31),
-    ("STOP", 17),
-    ("CONT", 19),
+    ("USR1", if BSD_NUMBERING { 30 } else { 10 }),
+    ("USR2", if BSD_NUMBERING { 31 } else { 12 }),
+    ("STOP", if BSD_NUMBERING { 17 } else { 19 }),
+    ("CONT", if BSD_NUMBERING { 19 } else { 18 }),
 ];
+
+/// Whether this target numbers signals as the BSDs do. Apple's platforms are
+/// the ones scriv builds for that do; everything else it builds for is Linux.
+const BSD_NUMBERING: bool = cfg!(target_vendor = "apple");
 
 impl Signal {
     /// The default: ask the process to stop and let it clean up. `--force` is
@@ -493,6 +503,41 @@ joakim          70123 70100    0.0  0.4       01:20 -fish
         for input in ["NOPE", "0", "64", ""] {
             let err = Signal::parse(input).unwrap_err().to_string();
             assert!(err.contains("known signals are"), "{input}: {err}");
+        }
+    }
+
+    /// The numbers are the host's, not one platform's written down twice. A
+    /// table fixed to the wrong platform is not a parse error: `-s 19` means
+    /// `STOP` on Linux and `CONT` on macOS, so the process resumes where it was
+    /// meant to stop.
+    #[test]
+    fn a_signal_number_means_what_this_platform_means_by_it() {
+        let number = |name: &str| SIGNALS.iter().find(|(n, _)| *n == name).unwrap().1;
+        let got = (
+            number("USR1"),
+            number("USR2"),
+            number("STOP"),
+            number("CONT"),
+        );
+        if cfg!(target_vendor = "apple") {
+            assert_eq!(got, (30, 31, 17, 19), "not the BSD numbering");
+        } else {
+            assert_eq!(got, (10, 12, 19, 18), "not the Linux numbering");
+        }
+    }
+
+    /// The POSIX-fixed five are the same everywhere, and must not be swept into
+    /// the platform split above.
+    #[test]
+    fn the_portable_signals_are_numbered_the_same_everywhere() {
+        for (name, number) in [
+            ("HUP", 1),
+            ("INT", 2),
+            ("QUIT", 3),
+            ("KILL", 9),
+            ("TERM", 15),
+        ] {
+            assert_eq!(Signal::parse(&number.to_string()).unwrap().name(), name);
         }
     }
 

--- a/src/term.rs
+++ b/src/term.rs
@@ -231,6 +231,11 @@ impl Drop for HangupWatch {
 /// Stands in for a line break in text folded onto one row.
 pub const NEWLINE_GLYPH: &str = "⏎";
 
+/// [`NEWLINE_GLYPH`] with the spaces that set it off, written out rather than
+/// built per call: [`one_row`] runs once per row of every listing and again on
+/// every selector reload. A test holds it to the glyph above.
+const NEWLINE_JOINER: &str = " ⏎ ";
+
 /// Text from outside scriv, made safe to draw on one row of a terminal.
 ///
 /// Control characters are dropped: a terminal *acts on* what it is sent, so a
@@ -239,11 +244,18 @@ pub const NEWLINE_GLYPH: &str = "⏎";
 /// never before. Newlines fold to [`NEWLINE_GLYPH`] so one entry stays one row,
 /// and tabs become a space so columns stay aligned.
 pub fn one_row(text: &str) -> String {
-    let joiner = format!(" {NEWLINE_GLYPH} ");
-    text.lines()
-        .map(drop_controls)
-        .collect::<Vec<_>>()
-        .join(&joiner)
+    // Folded in place rather than collected and joined: all but a handful of
+    // rows are a single line, and that case now allocates once.
+    let mut lines = text.lines();
+    let Some(first) = lines.next() else {
+        return String::new();
+    };
+    let mut out = drop_controls(first);
+    for line in lines {
+        out.push_str(NEWLINE_JOINER);
+        out.push_str(&drop_controls(line));
+    }
+    out
 }
 
 /// [`one_row`] for text that is allowed to keep its line breaks — a preview
@@ -456,6 +468,21 @@ mod tests {
     #[test]
     fn a_tab_becomes_one_space() {
         assert_eq!(one_row("a\tb"), "a b");
+    }
+
+    /// The joiner is written out for speed, so nothing but this holds it to the
+    /// glyph it is supposed to be showing.
+    #[test]
+    fn the_written_out_joiner_is_the_glyph_it_claims() {
+        assert_eq!(super::NEWLINE_JOINER, format!(" {NEWLINE_GLYPH} "));
+    }
+
+    #[test]
+    fn several_line_breaks_all_fold() {
+        assert_eq!(
+            one_row("a\nb\nc"),
+            format!("a {NEWLINE_GLYPH} b {NEWLINE_GLYPH} c")
+        );
     }
 
     #[test]

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -14,14 +14,12 @@ use ignore::{WalkBuilder, WalkState};
 /// Directory names never worth walking into, matching the `--walker-skip` list
 /// this replaced. `.gitignore` covers most build output; these are the
 /// directories that are commonly *not* ignored yet never worth offering.
-const WALKER_SKIP: &[&str] = &[
-    ".git",
-    "node_modules",
-    ".clj-kondo",
-    ".cpcache",
-    ".venv",
-    "lib",
-];
+///
+/// Every name here must be one that never holds source. `lib` was on this list
+/// and is not such a name — it is where Clojure, Elixir, Ruby and much of npm
+/// keep theirs, and skipping it left `scriv edit` silently unable to open half
+/// the files in those repositories.
+const WALKER_SKIP: &[&str] = &[".git", "node_modules", ".clj-kondo", ".cpcache", ".venv"];
 
 /// How many discovered paths may sit between the walk and whatever is reading
 /// it. Bounded so a full queue blocks the walker threads, which is what keeps
@@ -184,6 +182,21 @@ mod tests {
         fs::create_dir_all(dir.path().join("inner")).unwrap();
         let got: Vec<String> = dirs(dir.path()).collect();
         assert_eq!(got, vec!["inner".to_string()]);
+    }
+
+    /// A skip list is invisible when it is wrong: nothing errors, the files
+    /// simply are not there to open. `lib` holds source in several ecosystems.
+    #[test]
+    fn a_directory_that_holds_source_is_walked() {
+        let dir = TempDir::new().unwrap();
+        let root = dir.path();
+        fs::create_dir_all(root.join("lib/billing")).unwrap();
+        fs::write(root.join("lib/billing/core.clj"), "").unwrap();
+
+        assert!(
+            list(root).contains(&"lib/billing/core.clj".to_string()),
+            "a source directory is being skipped"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Three bugs, four costs on repeating paths, and two pieces of hygiene.

**Bugs**

- signal numbers were the BSD table on every platform, so on Linux `-s 19` sent `CONT` where the user meant `STOP`
- `lib` was in the walker skip list, leaving `scriv edit` unable to open source in Clojure, Elixir, Ruby and npm repositories
- `expand_tilde` rewrote `~bob/notes` against this user's home, producing a path that exists for nobody

**Costs**

- `one_row` rebuilt its joiner and collected a `Vec` per row, on every listing row and every reload
- a history row held its command twice, and built a blank timestamp with `repeat` per undated entry
- `gh::owners` made its two GitHub round trips one after the other
- the pull request reload held the shared list across the `gh` request

**Hygiene**

- `write_lines` deleted its temp file inside the closure that formats the error
- `demo/fixture.sh` now refuses to wipe a path with fewer than three components
- the README command table was missing `config` and `init`

CLI help unchanged, no flags touched. README updated. `docs/demo.gif` unchanged, as nothing a selector draws moved.

Cost: the signal table is now two tables behind a `cfg!`, so a platform scriv adds later needs its numbering checked rather than assumed.