### PR TITLE
Build for Apple Silicon and refuse everywhere else

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,11 @@ permissions:
   contents: read
 
 jobs:
+  # `macos-latest` is Apple Silicon, which is the only thing scriv builds for:
+  # `src/proc.rs` refuses to compile anywhere else. A cheaper Linux runner is
+  # not an option here, it is a build failure.
   build:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Install toolchain (pinned by rust-toolchain.toml)
@@ -22,28 +25,18 @@ jobs:
   # Plays the tape only. The GIF is re-recorded by hand (`make demo`), since the
   # render depends on the fonts installed on the machine.
   demo:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Install toolchain (pinned by rust-toolchain.toml)
         run: rustup show
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-      # Not charmbracelet/vhs-action: it hardcodes a search for ffmpeg-n5.1
-      # assets in BtbN/FFmpeg-Builds, which upstream has moved past.
+      # Homebrew, where the Linux job downloaded three release archives by hand:
+      # the formula pulls ttyd and ffmpeg itself, and this is the same install
+      # CLAUDE.md tells a maintainer to run before `make demo`.
       - name: Install VHS and its recorder dependencies
-        env:
-          VHS_VERSION: 0.11.0
-          TTYD_VERSION: 1.7.7
         run: |
           set -eux
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends ffmpeg
-          sudo curl -fsSL -o /usr/local/bin/ttyd \
-            "https://github.com/tsl0922/ttyd/releases/download/${TTYD_VERSION}/ttyd.x86_64"
-          sudo chmod +x /usr/local/bin/ttyd
-          curl -fsSL \
-            "https://github.com/charmbracelet/vhs/releases/download/v${VHS_VERSION}/vhs_${VHS_VERSION}_Linux_x86_64.tar.gz" \
-            | tar -xz -C /tmp
-          sudo install "/tmp/vhs_${VHS_VERSION}_Linux_x86_64/vhs" /usr/local/bin/vhs
+          brew install vhs
           vhs --version
       - run: make demo-check

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -31,6 +31,10 @@ jobs:
     # A fork dispatching this would open a pull request against its own copy
     # with credentials it does not have.
     if: github.repository == 'joakimen/scriv'
+    # Linux, though scriv only builds for Apple Silicon: cargo-release edits
+    # manifests and never compiles the crate. Anything added here that does
+    # compile it belongs on `macos-latest` instead, or it will hit the target
+    # guard in `src/proc.rs`.
     runs-on: ubuntu-latest
     steps:
       # RELEASE_TOKEN, not GITHUB_TOKEN: GitHub runs no workflows on a pull

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,19 @@ touches CI secrets, or publishes the crate.
    anything changed what a selector draws. CI only plays the tape, so a stale
    GIF is invisible. When nothing changed on screen, say so in the PR.
 
+## One platform
+
+scriv builds for `aarch64-apple-darwin` and nothing else, and `src/proc.rs`
+fails the build anywhere else rather than letting it through. That guard is not
+tidiness: signal numbers past the POSIX five differ between Darwin and Linux,
+19 being `CONT` on one and `STOP` on the other, so a binary for the wrong
+platform suspends nothing and resumes what it should have stopped.
+
+Both CI jobs therefore run on `macos-latest`. A step that compiles the crate
+cannot be moved to a Linux runner to save time, and widening the target list is
+not a line in `dist-workspace.toml` — it is an audit of everything that assumed
+Darwin, the signal table first.
+
 ## Rules for code that does not exist yet
 
 Rationale for code that does is a doc comment at the site — `ScratchRow`,

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ Provides fuzzy-completion for various local and remote resources.
 mise use -g github:joakimen/scriv    # or: cargo install --path .
 ```
 
-macOS and Linux. Needs `git`; `gh` for pull requests and `repo clone`/`open`.
+macOS on Apple Silicon. Needs `git`; `gh` for pull requests and
+`repo clone`/`open`.
 
 ## Setup
 
@@ -80,9 +81,9 @@ request. That pull request is the review point, and it exists because the `main`
 ruleset requires the `build` and `demo` checks on the branch tip.
 
 `release` belongs to [dist](https://axodotdev.github.io/cargo-dist), configured
-in `dist-workspace.toml`: it refuses a version no package carries, builds macOS
-and Linux on x86_64 and arm64, and creates the tag and the release together once
-four tarballs with checksums and build provenance exist. There is no tag to push
+in `dist-workspace.toml`: it refuses a version no package carries, builds
+`aarch64-apple-darwin`, and creates the tag and the release together once the
+tarball, its checksum and its build provenance exist. There is no tag to push
 and none to get wrong. `.github/workflows/release.yml` is generated — change
 `dist-workspace.toml` and run `dist init`, never the workflow.
 

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -9,16 +9,10 @@ cargo-dist-version = "0.32.0"
 ci = "github"
 # scriv ships as release binaries only. No installer scripts, no crates.io.
 installers = []
-# Do not add a `macos-13` runner back for x86_64-apple-darwin. GitHub retired
-# that label, and a job asking for it does not fail — it queues until it
-# expires, which held the v0.2.1 release for hours without ever reporting an
-# error. dist picks the runner itself, which is the point.
-targets = [
-    "aarch64-apple-darwin",
-    "x86_64-apple-darwin",
-    "aarch64-unknown-linux-gnu",
-    "x86_64-unknown-linux-gnu",
-]
+# One target, and the crate refuses to build for any other — see the guard in
+# `src/proc.rs`. Adding one back is not a line here: it means finding every
+# place that assumed Apple Silicon, starting with the signal numbers.
+targets = ["aarch64-apple-darwin"]
 # The release is triggered by `make release-run`, not by a pushed tag: dist
 # creates the tag itself once the build is green. A tag a human forgets to push
 # is the failure this buys off — v0.3.1 sat untagged and unreleased on `main`.

--- a/src/proc.rs
+++ b/src/proc.rs
@@ -216,29 +216,31 @@ pub fn preview(p: &Process) -> String {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Signal(&'static str);
 
+/// scriv builds for Apple Silicon and refuses anywhere else, and this table is
+/// why the refusal is a compile error rather than a line in the README. Only
+/// the first five signals below are numbered by POSIX. The rest are Darwin's,
+/// and Linux disagrees in the worst possible way: 19 is `CONT` here and `STOP`
+/// there, so the same table on the wrong platform does not fail — it resumes
+/// the process the user meant to suspend.
+#[cfg(not(target_vendor = "apple"))]
+compile_error!(
+    "scriv supports macOS on Apple Silicon only: its signal numbers are Darwin's, \
+     and elsewhere they name a different signal than the one asked for"
+);
+
 /// The signals worth offering, by the names `kill -l` prints: the ones that end
 /// or suspend a process. Anything else is a job for `kill`.
-///
-/// The numbers are the *host's*. Only the first five are fixed by POSIX; the
-/// rest are numbered differently on Linux and on the BSDs macOS descends from,
-/// and the two disagree in the worst possible way — Linux 19 is `STOP` where
-/// macOS 19 is `CONT`. A table hardcoded to one platform does not fail on the
-/// other, it sends the opposite signal.
 const SIGNALS: [(&str, i32); 9] = [
     ("HUP", 1),
     ("INT", 2),
     ("QUIT", 3),
     ("KILL", 9),
     ("TERM", 15),
-    ("USR1", if BSD_NUMBERING { 30 } else { 10 }),
-    ("USR2", if BSD_NUMBERING { 31 } else { 12 }),
-    ("STOP", if BSD_NUMBERING { 17 } else { 19 }),
-    ("CONT", if BSD_NUMBERING { 19 } else { 18 }),
+    ("USR1", 30),
+    ("USR2", 31),
+    ("STOP", 17),
+    ("CONT", 19),
 ];
-
-/// Whether this target numbers signals as the BSDs do. Apple's platforms are
-/// the ones scriv builds for that do; everything else it builds for is Linux.
-const BSD_NUMBERING: bool = cfg!(target_vendor = "apple");
 
 impl Signal {
     /// The default: ask the process to stop and let it clean up. `--force` is
@@ -506,30 +508,27 @@ joakim          70123 70100    0.0  0.4       01:20 -fish
         }
     }
 
-    /// The numbers are the host's, not one platform's written down twice. A
-    /// table fixed to the wrong platform is not a parse error: `-s 19` means
-    /// `STOP` on Linux and `CONT` on macOS, so the process resumes where it was
-    /// meant to stop.
+    /// Darwin's numbers, which the compile guard above is what makes safe to
+    /// write down flat. Getting these wrong is not a parse error: `-s 19` is
+    /// `CONT` here and `STOP` on Linux, so a process meant to be suspended
+    /// carries on instead.
     #[test]
-    fn a_signal_number_means_what_this_platform_means_by_it() {
+    fn the_signal_numbers_are_darwins() {
         let number = |name: &str| SIGNALS.iter().find(|(n, _)| *n == name).unwrap().1;
-        let got = (
-            number("USR1"),
-            number("USR2"),
-            number("STOP"),
-            number("CONT"),
+        assert_eq!(
+            (
+                number("USR1"),
+                number("USR2"),
+                number("STOP"),
+                number("CONT"),
+            ),
+            (30, 31, 17, 19),
         );
-        if cfg!(target_vendor = "apple") {
-            assert_eq!(got, (30, 31, 17, 19), "not the BSD numbering");
-        } else {
-            assert_eq!(got, (10, 12, 19, 18), "not the Linux numbering");
-        }
     }
 
-    /// The POSIX-fixed five are the same everywhere, and must not be swept into
-    /// the platform split above.
+    /// The POSIX-fixed five, which are the same wherever they are read.
     #[test]
-    fn the_portable_signals_are_numbered_the_same_everywhere() {
+    fn the_portable_signals_are_numbered_as_posix_says() {
         for (name, number) in [
             ("HUP", 1),
             ("INT", 2),


### PR DESCRIPTION
scriv shipped four targets and was tested on one. The Linux binaries carried a wrong-signal bug for their whole life because nothing ran there.

- `aarch64-apple-darwin` is the only target dist builds
- a `compile_error!` refuses any non-Apple target, so the flat Darwin signal table cannot silently mis-signal from a source build
- both CI jobs move to `macos-latest`, which is now the only place the crate compiles
- the demo job installs vhs via Homebrew instead of three hand-fetched Linux archives
- `release-prepare` stays on Linux and documents why it is safe there

CLI help unchanged, no flags touched. README `Install` line and releasing section updated, CLAUDE.md gained a section on the single platform. `docs/demo.gif` unchanged, as nothing a selector draws moved.

Cost: users on Intel Macs and Linux lose their binaries at the next release, and a source build now fails loudly rather than producing a working-looking one. CI wall time goes up, as macOS runners are slower than the Linux ones they replace.