### PR TITLE
Release v0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1621,7 +1621,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scriv"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scriv"
-version = "0.3.2"
+version = "0.4.0"
 edition = "2024"
 description = "Provides fuzzy-completion for various local and remote resources."
 license = "MIT"


### PR DESCRIPTION
Bump the version to 0.4.0.

Minor rather than patch: this is the release that drops Intel macOS and both Linux targets, so anyone not on Apple Silicon stops getting binaries here.

Merge this, then dispatch `release` with the tag `v0.4.0`.