### PR TITLE
Jump between a repository's worktrees with ctrl-t

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,14 +111,16 @@ Rationale for code that does is a doc comment at the site — `ScratchRow`,
   exits with the child's status rather than printing a vaguer line over git's.
 - **`NO_COLOR` is deliberately not read** — one switch for every tool, where
   `SCRIV_NO_COLOR` is one for this. Printing reads `ctx.color()`, never the tty.
-- **`repo`/`file`/`branch`/`pr`/`history` are registries; `edit` is not.** A
+- **`repo`/`file`/`branch`/`worktree`/`pr`/`history` are registries; `edit` is
+  not.** A
   registry is a set, with `ls`/`sel` and verbs over it. `edit file`/`edit dir`
   name what is looked for below `$PWD`, so neither has an `ls` — do not add
   one, and do not file ambient-directory work under a noun group. `repo open`
   is the sole exception, and only to skip a question it can already answer.
 - **A verb is abbreviated in its own name, not an alias beside it.** `ls`, `sel`
   and `rm` get no long form (`list`, `co` and `switch` predate the rule). Groups
-  take one letter — `r`, `f`, `b`, `e`, `h`, `c` — and `pc`, as `p` meets `pr`.
+  take one letter — `r`, `f`, `b`, `w`, `e`, `h`, `c` — and `pc`, as `p` meets
+  `pr`.
 - **Key bindings prefer `ctrl-<letter>` and never `alt-`**, which fish mostly
   presets. Displacing a fish preset is deliberate and named above
   `scriv_key_bindings`. Function keys are the fallback, `f4`/`f5` excepted.

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ scriv config check         # confirm it all resolves
 | `scriv repo` | `ls` `sel` `open` `clone` |
 | `scriv file` | `ls` `sel` `add` `rm` `prune` |
 | `scriv branch` | `ls` `sel` `checkout` |
+| `scriv worktree` | `ls` `sel` |
 | `scriv pr` | `ls` `sel` `checkout` `open` `merge` |
 | `scriv proc` | `ls` `sel` `kill` |
 | `scriv history` | `ls` `sel` |
@@ -43,11 +44,11 @@ scriv config check         # confirm it all resolves
 
 `ls` prints the set, `sel` fuzzy-selects one line of it, and the other verbs
 act. Every `sel` composes: `cd (scriv repo sel)`. Each group takes a one-letter
-abbreviation — `r`, `f`, `b`, `e`, `h`, `c`, and `pc` for `proc`.
+abbreviation — `r`, `f`, `b`, `w`, `e`, `h`, `c`, and `pc` for `proc`.
 
-In fish, `ctrl-r` searches history, `ctrl-o` jumps to a repository and `ctrl-g`
-checks out a branch; `f1`, `f3` and `f7` open a repository, a tracked file and a
-pull request.
+In fish, `ctrl-r` searches history, `ctrl-o` jumps to a repository, `ctrl-t` to
+a worktree of the one you are in, and `ctrl-g` checks out a branch; `f1`, `f3`
+and `f7` open a repository, a tracked file and a pull request.
 
 `scriv --help` covers the flags, the generated `config.toml` the settings.
 

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -12,3 +12,4 @@ pub mod history;
 pub mod pr;
 pub mod proc;
 pub mod repo;
+pub mod worktree;

--- a/src/cmd/repo.rs
+++ b/src/cmd/repo.rs
@@ -105,21 +105,6 @@ fn label_colors(labels: &Labels) -> std::collections::HashMap<&str, u8> {
         .collect()
 }
 
-/// The preview for a repository: its current branch and working-tree state,
-/// then recent commits. Both commands are local and take tens of milliseconds.
-///
-/// `--no-optional-locks` matters here: a plain `git status` rewrites the index,
-/// so scrolling past a repository would contend for its index lock.
-fn preview(path: &str) -> Preview {
-    let repo = select::quote(path);
-    Preview::Command(format!(
-        "git --no-optional-locks -C {repo} -c color.status=always status --short --branch \
-         | head -n 10; \
-         git --no-optional-locks -C {repo} log --color=always --max-count=20 --date=relative \
-         --format='%C(auto)%h%C(reset)  %C(blue)%an%C(reset)  %C(green)%ad%C(reset)  %s'"
-    ))
-}
-
 /// The selector rows for the discovered repositories: each prefixed with its
 /// label and coloured by it, paths rendered per `repo.display`. Every row's
 /// value is the absolute path, so a caller never re-expands `~`.
@@ -144,7 +129,7 @@ fn repo_rows(ctx: &Ctx, repos: &[FoundRepo]) -> Vec<SelectItem> {
                 RepoDisplay::Full => abs.clone(),
             };
             let row = format!("{label:<width$}  {shown}", label = repo.label);
-            let item = SelectItem::new(row, abs.clone()).preview(preview(&abs));
+            let item = SelectItem::new(row, abs.clone()).preview(select::checkout_preview(&abs));
             match colors.get(repo.label.as_str()) {
                 Some(&color) => item.color(color),
                 None => item,

--- a/src/cmd/worktree.rs
+++ b/src/cmd/worktree.rs
@@ -1,0 +1,233 @@
+//! `scriv worktree` — list and select the working trees of the repository the
+//! shell is standing in.
+//!
+//! Switching to one is a `cd`, which a child process cannot do to its parent,
+//! so `sel` prints the path and the fish integration's ctrl-t moves there —
+//! the same split as `repo sel`.
+
+use anyhow::{Result, bail};
+
+use crate::git::{self, Worktree};
+use crate::path::display_path;
+use crate::select::SelectItem;
+use crate::{Ctx, select, term};
+
+/// Every working tree of the current repository, in git's order.
+fn load(ctx: &Ctx) -> Result<Vec<Worktree>> {
+    git::ensure_repo()?;
+    let worktrees = git::worktrees()?;
+    ctx.log
+        .info(&format!("found {} worktrees", worktrees.len()));
+    if worktrees.is_empty() {
+        bail!("no worktrees found");
+    }
+    Ok(worktrees)
+}
+
+/// The column widths a listing shares, so `worktree ls --status` and the
+/// selector draw the same row.
+///
+/// Widths are counted in characters, not bytes: `{:<width$}` pads by character
+/// count, so a byte length would over-pad a non-ASCII row.
+struct Columns {
+    head: usize,
+    tags: usize,
+}
+
+impl Columns {
+    fn of(worktrees: &[Worktree]) -> Self {
+        Self {
+            head: worktrees
+                .iter()
+                .map(|w| w.head_label().chars().count())
+                .max()
+                .unwrap_or(0),
+            tags: worktrees
+                .iter()
+                .map(|w| w.tags().join(" ").chars().count())
+                .max()
+                .unwrap_or(0),
+        }
+    }
+
+    /// Render one row: the current-tree marker, what the tree has checked out,
+    /// any state tag, and `path` as the caller wants it shown. The tag column
+    /// is dropped entirely when no tree carries one, which is the usual case.
+    fn row(&self, worktree: &Worktree, path: &str) -> String {
+        let marker = if worktree.current { "*" } else { " " };
+        let mut row = format!(
+            "{marker} {head:<width$}",
+            head = worktree.head_label(),
+            width = self.head,
+        );
+        if self.tags > 0 {
+            row.push_str(&format!(
+                "  {tags:<width$}",
+                tags = worktree.tags().join(" "),
+                width = self.tags,
+            ));
+        }
+        row.push_str("  ");
+        row.push_str(path);
+        row
+    }
+}
+
+/// `scriv worktree ls` — print the path of each working tree, one per line,
+/// home-collapsed unless `absolute`.
+///
+/// `--status` adds the current-tree marker, what it has checked out, and any
+/// `locked` or `prunable` tag. Colour follows the same mapping as the selector
+/// and is dropped when stdout is not a terminal.
+pub fn ls(ctx: &Ctx, absolute: bool, status: bool) -> Result<()> {
+    let worktrees = load(ctx)?;
+    let color = ctx.color();
+    let columns = Columns::of(&worktrees);
+
+    let mut out = term::Listing::stdout();
+    for worktree in &worktrees {
+        let path = worktree.path.to_string_lossy();
+        let path = display_path(&path, ctx.home_str(), absolute);
+        let line = if status {
+            let row = columns.row(worktree, &path);
+            match worktree.color() {
+                Some(index) => term::paint(&row, index, color),
+                None => row,
+            }
+        } else {
+            path
+        };
+        if !out.line(&line)? {
+            break;
+        }
+    }
+    Ok(())
+}
+
+/// Build the selector rows, tinted by [`Worktree::color`]. Every row's value is
+/// the absolute path, so the shell `cd`s without re-expanding `~`.
+fn items(worktrees: &[Worktree], home: &str) -> Vec<SelectItem> {
+    let columns = Columns::of(worktrees);
+    worktrees
+        .iter()
+        .map(|worktree| {
+            let abs = worktree.path.to_string_lossy().into_owned();
+            let label = columns.row(worktree, &display_path(&abs, home, false));
+            let item = SelectItem::new(label, abs.clone()).preview(select::checkout_preview(&abs));
+            match worktree.color() {
+                Some(color) => item.color(color),
+                None => item,
+            }
+        })
+        .collect()
+}
+
+/// `scriv worktree sel` — fuzzy-select a working tree and print its absolute
+/// path, which is what a shell needs to `cd` there.
+pub fn sel(ctx: &Ctx) -> Result<()> {
+    let worktrees = load(ctx)?;
+    let choice = select::select_one(
+        items(&worktrees, ctx.home_str()),
+        "Select a worktree",
+        &ctx.config.selector,
+    )?;
+    println!("{choice}");
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::select::Preview;
+
+    fn worktrees() -> Vec<Worktree> {
+        git::mark_current(
+            git::parse_worktrees(
+                "worktree /home/u/dev/scriv\n\
+                 HEAD 950547ef3af47b2e60406bd23e530bdb1e226c6e\n\
+                 branch refs/heads/main\n\
+                 \n\
+                 worktree /home/u/dev/scriv/.claude/worktrees/feat\n\
+                 HEAD 32bb788aa1c04d9ee4d1e5a8b0e0b8d1c2f3a4b5\n\
+                 branch refs/heads/feat/x\n",
+            ),
+            Some(std::path::Path::new("/home/u/dev/scriv")),
+            std::path::Path::to_path_buf,
+        )
+    }
+
+    #[test]
+    fn rows_mark_the_current_tree_and_return_its_path() {
+        let items = items(&worktrees(), "/home/u");
+        assert!(items[0].label.starts_with("* main"), "{}", items[0].label);
+        assert!(items[1].label.starts_with("  feat/x"), "{}", items[1].label);
+        assert_eq!(items[0].value(), "/home/u/dev/scriv");
+        assert_eq!(items[0].color, Some(2), "the current tree is green");
+        assert_eq!(items[1].color, None);
+    }
+
+    /// The label is what the shell would have to re-expand; the value is not.
+    #[test]
+    fn rows_show_a_collapsed_path_and_return_an_absolute_one() {
+        let items = items(&worktrees(), "/home/u");
+        assert!(
+            items[0].label.ends_with("~/dev/scriv"),
+            "{}",
+            items[0].label
+        );
+        assert_eq!(items[0].value(), "/home/u/dev/scriv");
+    }
+
+    #[test]
+    fn columns_align() {
+        let items = items(&worktrees(), "/home/u");
+        assert_eq!(
+            items[0].label.find("~/dev/scriv"),
+            items[1].label.find("~/dev/scriv"),
+            "the path column is ragged: {:?}",
+            items.iter().map(|i| &i.label).collect::<Vec<_>>(),
+        );
+    }
+
+    /// The tag column costs two spaces on every row, which the common
+    /// repository — no locked or prunable tree — should not pay.
+    #[test]
+    fn the_tag_column_appears_only_when_a_tree_carries_a_tag() {
+        let plain = worktrees();
+        let untagged = Columns::of(&plain).row(&plain[0], "~/p");
+        assert_eq!(untagged, "* main    ~/p", "main is padded to `feat/x`");
+
+        let mut tagged = plain;
+        tagged[1].locked = true;
+        let columns = Columns::of(&tagged);
+        assert_eq!(columns.row(&tagged[1], "~/q"), "  feat/x  locked  ~/q");
+        assert!(
+            columns.row(&tagged[0], "~/p").len() > untagged.len(),
+            "the untagged row did not make room for the tag column",
+        );
+    }
+
+    #[test]
+    fn column_width_counts_characters_not_bytes() {
+        let rows = git::parse_worktrees(
+            "worktree /home/u/café\nHEAD abc\nbranch refs/heads/café\n\
+             worktree /home/u/b\nHEAD def\nbranch refs/heads/b\n",
+        );
+        let label = &items(&rows, "/home/u")[0].label;
+        assert!(
+            label.starts_with("  café  ~/café"),
+            "column padded past the longest name: {label:?}",
+        );
+    }
+
+    #[test]
+    fn preview_reads_the_tree_without_taking_its_index_lock() {
+        let items = items(&worktrees(), "/home/u");
+        let Some(Preview::Command(cmd)) = &items[0].preview else {
+            panic!("expected a command preview");
+        };
+        assert!(cmd.contains("-C '/home/u/dev/scriv'"), "{cmd}");
+        assert!(cmd.contains("--no-optional-locks"), "{cmd}");
+        assert!(cmd.contains("--max-count=20"), "unbounded log: {cmd}");
+    }
+}

--- a/src/git.rs
+++ b/src/git.rs
@@ -1,8 +1,8 @@
-//! Git branch enumeration and checkout.
+//! Git branch enumeration and checkout, and the repository's worktrees.
 //!
 //! The decisions — which refs are local, which are remote-only, what a checkout
 //! of a given name means — are pure functions over plain data
-//! ([`parse_ref_lines`], [`classify`], [`resolve`]).
+//! ([`parse_ref_lines`], [`classify`], [`resolve`], [`parse_worktrees`]).
 //!
 //! One `for-each-ref` over `refs/heads` and `refs/remotes` enumerates both in a
 //! pass already ordered by commit recency; [`by_relevance`] regroups it without
@@ -10,7 +10,7 @@
 
 use std::collections::HashSet;
 use std::io::ErrorKind;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
 use anyhow::{Context, Result, anyhow, bail};
@@ -288,6 +288,141 @@ pub fn resolve(branches: &[Branch], input: &str) -> Checkout {
     Checkout::Switch(input.to_string())
 }
 
+/// A working tree of the repository: the main one, or one added with
+/// `git worktree add`.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct Worktree {
+    /// Absolute path to the tree, as git reports it.
+    pub path: PathBuf,
+    /// Short branch name, empty when HEAD is detached or the tree is bare.
+    pub branch: String,
+    /// Full HEAD commit, empty for a bare tree — which has no HEAD.
+    pub head: String,
+    /// A bare repository: nothing checked out, and nowhere to work.
+    pub bare: bool,
+    /// Held by `git worktree lock`, so pruning leaves it alone.
+    pub locked: bool,
+    /// git can no longer use it — most often because its directory is gone.
+    pub prunable: bool,
+    /// Whether this is the tree the working directory is in.
+    pub current: bool,
+}
+
+/// How much of a commit to show where a branch name would be. Fixed rather than
+/// git's `core.abbrev`, which grows with the repository and would make the
+/// column's width depend on which one is being listed; 7 is what git itself
+/// shows in a repository of ordinary size.
+const SHORT_COMMIT: usize = 7;
+
+impl Worktree {
+    /// What identifies the tree beside its path: the branch it has checked out,
+    /// the commit a detached HEAD sits on, or that the repository is bare.
+    /// Parenthesised where it is not a branch name, so the two never read alike.
+    pub fn head_label(&self) -> String {
+        if self.bare {
+            return "(bare)".to_string();
+        }
+        if !self.branch.is_empty() {
+            return self.branch.clone();
+        }
+        let short: String = self.head.chars().take(SHORT_COMMIT).collect();
+        format!("({short})")
+    }
+
+    /// Short tags for the states worth flagging, for when colour is
+    /// unavailable. An ordinary tree has none.
+    pub fn tags(&self) -> Vec<&'static str> {
+        let mut tags = Vec::new();
+        if self.locked {
+            tags.push("locked");
+        }
+        if self.prunable {
+            tags.push("prunable");
+        }
+        tags
+    }
+
+    /// ANSI 256-colour index for the row, or `None` for an ordinary tree, which
+    /// keeps the terminal's foreground. Standard hues, so they follow the theme.
+    pub fn color(&self) -> Option<u8> {
+        // Checked before `current`: a tree git cannot use is not one to enter,
+        // and that outranks where the shell happens to be standing.
+        if self.prunable {
+            return Some(8); // grey — nothing to switch to
+        }
+        if self.current {
+            return Some(2); // green — where you already are
+        }
+        if self.branch.is_empty() {
+            return Some(3); // yellow — detached or bare, so no branch to land on
+        }
+        None
+    }
+}
+
+/// Parse `git worktree list --porcelain`.
+///
+/// Each record opens with a `worktree <path>` line and is followed by its
+/// attributes, one per line, valueless where the attribute is a flag. A record
+/// is closed by the next `worktree` line rather than by the blank line between
+/// them, so an attribute git adds later cannot be mistaken for a new record.
+pub fn parse_worktrees(output: &str) -> Vec<Worktree> {
+    let mut worktrees = Vec::new();
+    let mut current: Option<Worktree> = None;
+
+    for line in output.lines() {
+        let (key, value) = line.split_once(' ').unwrap_or((line, ""));
+        if key == "worktree" {
+            worktrees.extend(current.take());
+            if !value.is_empty() {
+                current = Some(Worktree {
+                    path: PathBuf::from(value),
+                    ..Worktree::default()
+                });
+            }
+            continue;
+        }
+        // Attributes before the first `worktree` line belong to nothing.
+        let Some(worktree) = current.as_mut() else {
+            continue;
+        };
+        match key {
+            "HEAD" => worktree.head = value.to_string(),
+            "branch" => worktree.branch = value.strip_prefix("refs/heads/").unwrap_or(value).into(),
+            "bare" => worktree.bare = true,
+            // Both carry an optional reason, which the listing has no room for.
+            "locked" => worktree.locked = true,
+            "prunable" => worktree.prunable = true,
+            _ => {}
+        }
+    }
+
+    worktrees.extend(current);
+    worktrees
+}
+
+/// Mark the tree `here` is inside, so a listing can point at it.
+///
+/// `resolve` is `canonicalize`: git prints the real path of every worktree
+/// while the working directory may have reached one through a symlink, and only
+/// the resolved forms compare equal. What is displayed stays as git gave it.
+pub fn mark_current(
+    worktrees: Vec<Worktree>,
+    here: Option<&Path>,
+    resolve: impl Fn(&Path) -> PathBuf,
+) -> Vec<Worktree> {
+    let Some(here) = here.map(&resolve) else {
+        return worktrees;
+    };
+    worktrees
+        .into_iter()
+        .map(|worktree| Worktree {
+            current: resolve(&worktree.path) == here,
+            ..worktree
+        })
+        .collect()
+}
+
 /// Run git with `args`, capturing stdout.
 fn capture(args: &[&str]) -> Result<String> {
     let output = Command::new("git")
@@ -379,6 +514,18 @@ pub fn branches() -> Result<Vec<Branch>> {
     ])
     .context("listing branches")?;
     Ok(by_relevance(classify(&parse_ref_lines(&out))))
+}
+
+/// Every working tree of the repository, in git's own order: the main tree
+/// first, then the linked ones as they were added. The tree the working
+/// directory is in is marked rather than moved, since where you already are is
+/// rarely where you are going.
+pub fn worktrees() -> Result<Vec<Worktree>> {
+    let out = capture(&["worktree", "list", "--porcelain"]).context("listing worktrees")?;
+    let worktrees = parse_worktrees(&out);
+    Ok(mark_current(worktrees, repo_root().as_deref(), |path| {
+        path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
+    }))
 }
 
 /// Refresh remote-tracking refs, dropping ones deleted upstream.
@@ -640,5 +787,146 @@ mod tests {
             resolve(&sample(), "nope"),
             Checkout::Switch("nope".to_string())
         );
+    }
+
+    /// Exactly what `git worktree list --porcelain` writes: a main tree, a
+    /// linked one, a detached one, a locked one and a tree whose directory has
+    /// been deleted.
+    const WORKTREE_LIST: &str = "\
+worktree /home/u/dev/scriv
+HEAD 950547ef3af47b2e60406bd23e530bdb1e226c6e
+branch refs/heads/main
+
+worktree /home/u/dev/scriv/.claude/worktrees/feat
+HEAD 32bb788aa1c04d9ee4d1e5a8b0e0b8d1c2f3a4b5
+branch refs/heads/feat/x
+
+worktree /home/u/dev/scriv/.claude/worktrees/spike
+HEAD cd7eff2bbb1c04d9ee4d1e5a8b0e0b8d1c2f3a4b
+detached
+
+worktree /home/u/dev/scriv/.claude/worktrees/held
+HEAD ec4b8dfccc1c04d9ee4d1e5a8b0e0b8d1c2f3a4b
+branch refs/heads/held
+locked waiting on review
+
+worktree /home/u/dev/scriv/.claude/worktrees/gone
+HEAD 88a2dedddd1c04d9ee4d1e5a8b0e0b8d1c2f3a4b
+branch refs/heads/gone
+prunable gitdir file points to non-existent location
+";
+
+    #[test]
+    fn parses_every_worktree_record() {
+        let got = parse_worktrees(WORKTREE_LIST);
+        assert_eq!(got.len(), 5);
+        assert_eq!(got[0].path, PathBuf::from("/home/u/dev/scriv"));
+        assert_eq!(got[0].branch, "main", "the ref prefix survived");
+        assert_eq!(got[1].branch, "feat/x", "a branch name may contain a slash");
+        assert!(got[2].branch.is_empty(), "a detached HEAD has no branch");
+        assert!(got[3].locked);
+        assert!(got[4].prunable);
+    }
+
+    /// A reason on `locked` or `prunable` is words, not a value to be parsed.
+    #[test]
+    fn a_state_with_a_reason_is_still_that_state() {
+        let got = parse_worktrees(WORKTREE_LIST);
+        assert_eq!(got[3].tags(), vec!["locked"]);
+        assert_eq!(got[4].tags(), vec!["prunable"]);
+        assert!(got[0].tags().is_empty(), "an ordinary tree carries no tag");
+    }
+
+    #[test]
+    fn a_bare_repository_has_no_head_to_report() {
+        let got = parse_worktrees("worktree /home/u/dev/mirror.git\nbare\n");
+        assert_eq!(got.len(), 1);
+        assert!(got[0].bare);
+        assert_eq!(got[0].head_label(), "(bare)");
+    }
+
+    /// The column reads as a branch name only when it is one.
+    #[test]
+    fn a_detached_head_shows_the_commit_it_sits_on() {
+        let got = parse_worktrees(WORKTREE_LIST);
+        assert_eq!(got[0].head_label(), "main");
+        assert_eq!(got[2].head_label(), "(cd7eff2)");
+    }
+
+    #[test]
+    fn attributes_belong_to_the_record_that_opened() {
+        // No blank line between the records, and an attribute git might add
+        // after the ones known here.
+        let got = parse_worktrees(
+            "worktree /a\nHEAD abc\nbranch refs/heads/a\nsomething-new value\nworktree /b\nHEAD def\ndetached\n",
+        );
+        assert_eq!(got.len(), 2);
+        assert_eq!(got[0].branch, "a");
+        assert_eq!(got[1].path, PathBuf::from("/b"));
+        assert!(got[1].branch.is_empty());
+    }
+
+    #[test]
+    fn nothing_is_parsed_from_nothing() {
+        assert!(parse_worktrees("").is_empty());
+        // Attributes with no record to attach to are dropped, not panicked on.
+        assert!(parse_worktrees("HEAD abc\nbranch refs/heads/a\n").is_empty());
+    }
+
+    #[test]
+    fn the_current_tree_is_the_one_the_shell_is_in() {
+        let here = Path::new("/home/u/dev/scriv/.claude/worktrees/feat");
+        let got = mark_current(
+            parse_worktrees(WORKTREE_LIST),
+            Some(here),
+            Path::to_path_buf,
+        );
+        assert_eq!(
+            got.iter().filter(|w| w.current).count(),
+            1,
+            "exactly one tree is the current one",
+        );
+        assert!(got[1].current);
+        assert_eq!(got[1].color(), Some(2), "the current tree is green");
+    }
+
+    /// git prints the real path of a worktree; the working directory may have
+    /// reached it through a symlink, as `/tmp` is on macOS.
+    #[test]
+    fn the_current_tree_is_found_through_a_symlink() {
+        let got = mark_current(
+            parse_worktrees("worktree /private/tmp/wt\nHEAD abc\nbranch refs/heads/main\n"),
+            Some(Path::new("/tmp/wt")),
+            |path| match path.strip_prefix("/tmp") {
+                Ok(rest) => Path::new("/private/tmp").join(rest),
+                Err(_) => path.to_path_buf(),
+            },
+        );
+        assert!(got[0].current, "the symlinked path did not match");
+        assert_eq!(
+            got[0].path,
+            PathBuf::from("/private/tmp/wt"),
+            "resolving must not rewrite what is displayed",
+        );
+    }
+
+    #[test]
+    fn outside_a_repository_no_tree_is_current() {
+        let got = mark_current(parse_worktrees(WORKTREE_LIST), None, Path::to_path_buf);
+        assert!(got.iter().all(|w| !w.current));
+    }
+
+    /// A tree git cannot use is not one to switch to, whichever one the shell
+    /// is standing in.
+    #[test]
+    fn an_unusable_tree_is_greyed_even_when_it_is_the_current_one() {
+        let got = mark_current(
+            parse_worktrees(WORKTREE_LIST),
+            Some(Path::new("/home/u/dev/scriv/.claude/worktrees/gone")),
+            Path::to_path_buf,
+        );
+        assert_eq!(got[4].color(), Some(8));
+        assert_eq!(got[2].color(), Some(3), "a detached tree is yellow");
+        assert_eq!(got[0].color(), None, "an ordinary tree keeps the default");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
-//! `scriv` — select repositories, files, git branches, GitHub pull requests and
-//! running processes from one fuzzy finder.
+//! `scriv` — select repositories, files, git branches and worktrees, GitHub
+//! pull requests and running processes from one fuzzy finder.
 //!
 //! The crate is split into an I/O-free core and an imperative shell: the
 //! [`cmd`] modules read the environment, touch the filesystem, shell out to

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,10 +2,10 @@
 //! dispatch to the [`cmd`] implementations. All decision logic lives in the
 //! library crate.
 //!
-//! Top-level commands: `repo`, `file`, `branch`, `pr`, `proc` and `history`
-//! work with the things scriv finds; `edit` opens a file from the directory the
-//! user is in; `config` manages its configuration; `init` prints shell
-//! integration.
+//! Top-level commands: `repo`, `file`, `branch`, `worktree`, `pr`, `proc` and
+//! `history` work with the things scriv finds; `edit` opens a file from the
+//! directory the user is in; `config` manages its configuration; `init` prints
+//! shell integration.
 
 use std::process::ExitCode;
 
@@ -115,6 +115,20 @@ enum Command {
     Branch {
         #[command(subcommand)]
         command: BranchCmd,
+    },
+    /// Manage this repository's worktrees
+    ///
+    /// Lists the working trees of the repository you are standing in — the one
+    /// cloned and every one added with `git worktree add` — in git's own order,
+    /// the main tree first. The tree you are in is marked rather than moved to
+    /// the top, since it is not the one you are switching to.
+    ///
+    /// Switching to a worktree is a `cd`, which only a shell can perform, so
+    /// `sel` prints the path; the fish integration binds that to ctrl-t.
+    #[command(visible_alias = "w")]
+    Worktree {
+        #[command(subcommand)]
+        command: WorktreeCmd,
     },
     /// Manage GitHub PRs
     ///
@@ -324,6 +338,23 @@ enum BranchCmd {
         #[command(flatten)]
         scope: BranchScope,
     },
+}
+
+#[derive(Subcommand)]
+enum WorktreeCmd {
+    /// List this repository's worktrees
+    #[command(visible_alias = "list")]
+    Ls {
+        /// Return absolute file paths
+        #[arg(short = 'A', long)]
+        absolute_paths: bool,
+        /// Show the current-worktree marker, what each has checked out, and
+        /// whether it is locked or prunable
+        #[arg(long)]
+        status: bool,
+    },
+    /// Fuzzy-select a worktree and print its absolute path
+    Sel,
 }
 
 /// Which pull requests a `pr` subcommand fetches, shared by all three.
@@ -571,6 +602,13 @@ fn run(cli: Cli) -> anyhow::Result<()> {
             BranchCmd::Checkout { branch, scope } => {
                 cmd::branch::checkout(&ctx, branch.as_deref(), scope.filter(), scope.fetch)
             }
+        },
+        Command::Worktree { command } => match command {
+            WorktreeCmd::Ls {
+                absolute_paths,
+                status,
+            } => cmd::worktree::ls(&ctx, absolute_paths, status),
+            WorktreeCmd::Sel => cmd::worktree::sel(&ctx),
         },
         Command::Pr { command } => match command {
             PrCmd::Ls { status, scope } => cmd::pr::ls(&ctx, &scope.state, scope.limit, status),

--- a/src/select.rs
+++ b/src/select.rs
@@ -71,6 +71,22 @@ pub fn dir_preview(path: &str) -> Preview {
     Preview::Command(format!("ls -Ap -- {path} 2>&1 | head -n 200"))
 }
 
+/// The preview for a git checkout — a repository or one of its worktrees: the
+/// current branch and working-tree state, then recent commits. Both commands
+/// are local and take tens of milliseconds.
+///
+/// `--no-optional-locks` matters here: a plain `git status` rewrites the index,
+/// so scrolling past a checkout would contend for its index lock.
+pub fn checkout_preview(path: &str) -> Preview {
+    let checkout = quote(path);
+    Preview::Command(format!(
+        "git --no-optional-locks -C {checkout} -c color.status=always status --short --branch \
+         | head -n 10; \
+         git --no-optional-locks -C {checkout} log --color=always --max-count=20 --date=relative \
+         --format='%C(auto)%h%C(reset)  %C(blue)%an%C(reset)  %C(green)%ad%C(reset)  %s'"
+    ))
+}
+
 /// The command behind [`Preview::File`] and [`file_preview`].
 fn file_preview_cmd(path: &str) -> String {
     let path = quote(path);

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -48,6 +48,14 @@ function scriv-repo-cd --description "Select a repository and cd into it"
     test -n "$dir"; and cd $dir
 end
 
+# The same jump, but within the repository you are already in: a worktree is a
+# checkout of it elsewhere on disk, and switching to one is nothing but this `cd`.
+function scriv-worktree-cd --description "Select a git worktree and cd into it"
+    set -l dir (command scriv worktree sel)
+    or return
+    test -n "$dir"; and cd $dir
+end
+
 # Run a command as though it had been typed at the prompt, putting back whatever
 # was already on the command line afterwards.
 #
@@ -132,11 +140,13 @@ end
 # What each binding displaces, since ctrl-o and ctrl-q are the only keys free in
 # fish and only the first is taken — `scriv edit` has the `fe` function instead:
 # ctrl-g over `cancel` (escape and ctrl-c both still do that), ctrl-r over
-# `history-pager`, and up over `up-line` — which scriv-history-up hands back
-# wherever the selector would be wrong. ctrl-p/ctrl-n are deliberately left as
-# `up-line`/`down-line`. f1, f3 and f7 displace nothing; f4 and f5 are skipped
-# because users' own tools cluster there. alt-<letter> is not free: fish presets
-# alt-b, alt-e, alt-o and alt-p among others.
+# `history-pager`, ctrl-t over `transpose-chars` — swapping the two characters
+# around the cursor, which is worth less than a jump between worktrees — and up
+# over `up-line`, which scriv-history-up hands back wherever the selector would
+# be wrong. ctrl-p/ctrl-n are deliberately left as `up-line`/`down-line`. f1, f3
+# and f7 displace nothing; f4 and f5 are skipped because users' own tools cluster
+# there. alt-<letter> is not free: fish presets alt-b, alt-e, alt-o and alt-p
+# among others.
 #
 # Rebind by calling `bind` yourself after `scriv_key_bindings`; the last binding
 # for a key wins.
@@ -146,6 +156,7 @@ end
 # running them as a command would submit what they had just put on the line.
 function scriv_key_bindings --description "Bind scriv selectors to keys"
     bind ctrl-o "scriv-run-as-command scriv-repo-cd"
+    bind ctrl-t "scriv-run-as-command scriv-worktree-cd"
     bind f1     "scriv-run-as-command scriv-repo-open"
     bind f3     "scriv-run-as-command scriv-file-edit"
     bind ctrl-g "scriv-run-as-command scriv-branch-checkout"
@@ -168,6 +179,7 @@ mod tests {
     fn fish_emits_helper_functions() {
         let out = integration(Shell::Fish, &mut dummy());
         assert!(out.contains("function scriv-repo-cd"));
+        assert!(out.contains("function scriv-worktree-cd"));
         assert!(out.contains("function scriv-run-as-command"));
         assert!(out.contains("function scriv-restore-command-line"));
         assert!(out.contains("function scriv-repo-open"));
@@ -186,6 +198,7 @@ mod tests {
         let out = integration(Shell::Fish, &mut dummy());
         assert!(out.contains("complete -c scriv"));
         assert!(out.contains("bind ctrl-o"));
+        assert!(out.contains("bind ctrl-t"));
         assert!(out.contains("bind f1"));
         assert!(out.contains("bind f3"));
         assert!(out.contains("bind f7"));
@@ -288,7 +301,7 @@ mod tests {
     #[test]
     fn bindings_that_produce_output_run_through_the_command_line() {
         let out = integration(Shell::Fish, &mut dummy());
-        for key in ["ctrl-o", "f1", "f3", "ctrl-g", "f7"] {
+        for key in ["ctrl-o", "ctrl-t", "f1", "f3", "ctrl-g", "f7"] {
             let bind = binding_for(&out, key);
             assert!(
                 bind.contains("scriv-run-as-command"),

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -161,7 +161,7 @@ fn help_lists_every_top_level_command() {
     let run = sandbox.run(&["--help"]);
     run.ok();
     for command in [
-        "repo", "file", "edit", "branch", "pr", "proc", "history", "config", "init",
+        "repo", "file", "edit", "branch", "worktree", "pr", "proc", "history", "config", "init",
     ] {
         assert!(
             run.stdout.contains(command),
@@ -217,7 +217,7 @@ fn help_names_the_aliases_the_binary_accepts() {
     let sandbox = Sandbox::new();
     let top = sandbox.run(&["--help"]);
     top.ok();
-    for alias in ["r", "f", "e", "b", "pc", "h", "c"] {
+    for alias in ["r", "f", "e", "b", "w", "pc", "h", "c"] {
         assert!(
             top.stdout.contains(&format!("[aliases: {alias}]")),
             "`{alias}` is accepted but unmentioned:\n{}",
@@ -256,6 +256,7 @@ fn the_documented_abbreviations_resolve() {
         &["r", "--help"][..],
         &["e", "--help"][..],
         &["b", "--help"][..],
+        &["w", "--help"][..],
         &["f", "--help"][..],
         &["h", "--help"][..],
         &["pc", "--help"][..],
@@ -290,7 +291,9 @@ fn edit_dir_opens_the_directories_it_is_given() {
 #[test]
 fn every_registry_exposes_sel() {
     let sandbox = Sandbox::new();
-    for group in ["repo", "file", "branch", "pr", "proc", "history"] {
+    for group in [
+        "repo", "file", "branch", "worktree", "pr", "proc", "history",
+    ] {
         sandbox.run(&[group, "sel", "--help"]).ok();
     }
 }
@@ -574,6 +577,118 @@ fn repo_ls_reports_a_missing_root() {
     let run = sandbox.run(&["repo", "ls"]);
     run.code(1);
     assert!(run.stderr.contains("not/here"), "{}", run.stderr);
+}
+
+// --- worktrees --------------------------------------------------------------
+
+/// A real repository with one linked worktree, since `scriv worktree` reads
+/// git rather than the filesystem.
+///
+/// `git worktree add` needs a commit to point the new tree at, and the sandbox
+/// has no git identity to make one with — hence the author and committer in
+/// the environment, and the two `GIT_CONFIG_*` variables that keep the machine
+/// running the test out of the result.
+fn mk_worktree_repo(root: &Path) -> (PathBuf, PathBuf) {
+    let main = root.join("scriv");
+    std::fs::create_dir_all(&main).unwrap();
+
+    for args in [
+        &["init", "-b", "main"][..],
+        &["commit", "--allow-empty", "-m", "init"][..],
+        &["worktree", "add", "-b", "feat", "../feat"][..],
+    ] {
+        let out = Command::new("git")
+            .args(args)
+            .current_dir(&main)
+            .env_clear()
+            .env("PATH", std::env::var("PATH").unwrap_or_default())
+            .env("HOME", root)
+            .env("GIT_CONFIG_GLOBAL", "/dev/null")
+            .env("GIT_CONFIG_SYSTEM", "/dev/null")
+            .env("GIT_AUTHOR_NAME", "scriv tests")
+            .env("GIT_AUTHOR_EMAIL", "tests@example.invalid")
+            .env("GIT_COMMITTER_NAME", "scriv tests")
+            .env("GIT_COMMITTER_EMAIL", "tests@example.invalid")
+            .output()
+            .expect("running git");
+        assert!(
+            out.status.success(),
+            "git {args:?} failed: {}",
+            String::from_utf8_lossy(&out.stderr),
+        );
+    }
+
+    (main, root.join("feat"))
+}
+
+/// git reports the real path of a worktree, and a temporary directory on macOS
+/// is reached through a symlink.
+fn real(path: &Path) -> String {
+    path.canonicalize().unwrap().to_string_lossy().into_owned()
+}
+
+#[test]
+fn worktree_ls_lists_the_main_tree_and_the_linked_one() {
+    let sandbox = Sandbox::new();
+    let (main, feat) = mk_worktree_repo(sandbox.home());
+
+    let run = sandbox.run_in(&main, &["worktree", "ls", "--absolute-paths"]);
+    run.ok();
+    assert_eq!(run.lines(), vec![real(&main), real(&feat)]);
+}
+
+/// Which tree is current is the whole question the selector answers, and it is
+/// the one the shell is standing in — not the one git happens to list first.
+#[test]
+fn worktree_ls_status_marks_the_tree_the_shell_is_in() {
+    let sandbox = Sandbox::new();
+    let (main, feat) = mk_worktree_repo(sandbox.home());
+
+    let from_linked = sandbox.run_in(&feat, &["worktree", "ls", "--status", "-A"]);
+    from_linked.ok();
+    let lines = from_linked.lines();
+    assert!(lines[0].starts_with("  main "), "{lines:?}");
+    assert!(lines[1].starts_with("* feat "), "{lines:?}");
+    assert!(lines[1].ends_with(&real(&feat)), "{lines:?}");
+
+    let from_main = sandbox.run_in(&main, &["worktree", "ls", "--status", "-A"]);
+    from_main.ok();
+    assert!(
+        from_main.lines()[0].starts_with("* main "),
+        "{:?}",
+        from_main.lines()
+    );
+}
+
+/// `~` is for reading, `-A` is for piping. `HOME` is overridden with its
+/// resolved form because git reports resolved paths, and a `~` is only
+/// recognisable in one that shares its prefix.
+#[test]
+fn worktree_ls_collapses_home_unless_asked_for_absolute_paths() {
+    let sandbox = Sandbox::new();
+    let (main, feat) = mk_worktree_repo(sandbox.home());
+    let home = sandbox.home().canonicalize().unwrap();
+    let env = [("HOME", home.to_str().unwrap())];
+
+    let collapsed = sandbox.run_full(&main, &["worktree", "ls"], &env);
+    collapsed.ok();
+    assert_eq!(collapsed.lines(), vec!["~/scriv", "~/feat"]);
+
+    let absolute = sandbox.run_full(&main, &["worktree", "ls", "-A"], &env);
+    absolute.ok();
+    assert_eq!(absolute.lines(), vec![real(&main), real(&feat)]);
+}
+
+#[test]
+fn worktree_ls_outside_a_repository_says_so() {
+    let sandbox = Sandbox::new();
+    let run = sandbox.run(&["worktree", "ls"]);
+    run.code(1);
+    assert!(
+        run.stderr.contains("not inside a git repository"),
+        "{}",
+        run.stderr
+    );
 }
 
 // --- the known-files list ---------------------------------------------------
@@ -1122,6 +1237,7 @@ fn init_fish_emits_functions_bindings_and_completions() {
     run.ok();
     for needle in [
         "function scriv-repo-cd",
+        "function scriv-worktree-cd",
         "function scriv-history-select",
         "function fe",
         "function scriv_key_bindings",


### PR DESCRIPTION
`scriv worktree ls` prints the working trees of the repository you are in, `sel` prints the one you choose.

Rows show the branch, the commit under a detached HEAD, or that the repository is bare.

The tree the shell is standing in is marked, not lifted to the top.

A locked or prunable tree is tagged and greyed.

fish binds ctrl-t to the `cd`, displacing `transpose-chars`.

CLI help: the group and both subcommands carry doc comments; `EXAMPLES` stays at three lines.

README: one new row in the command table, `w` in the abbreviations, ctrl-t in the key-binding sentence.

demo.gif: unchanged, since nothing the tape records draws differently.

The repository preview moved to `select::checkout_preview` for the second caller.