### PR TITLE
Reflow the registry bullet after worktree joined it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,11 +112,11 @@ Rationale for code that does is a doc comment at the site — `ScratchRow`,
 - **`NO_COLOR` is deliberately not read** — one switch for every tool, where
   `SCRIV_NO_COLOR` is one for this. Printing reads `ctx.color()`, never the tty.
 - **`repo`/`file`/`branch`/`worktree`/`pr`/`history` are registries; `edit` is
-  not.** A
-  registry is a set, with `ls`/`sel` and verbs over it. `edit file`/`edit dir`
-  name what is looked for below `$PWD`, so neither has an `ls` — do not add
-  one, and do not file ambient-directory work under a noun group. `repo open`
-  is the sole exception, and only to skip a question it can already answer.
+  not.** A registry is a set, with `ls`/`sel` and verbs over it.
+  `edit file`/`edit dir` name what is looked for below `$PWD`, so neither has
+  an `ls` — do not add one, and do not file ambient-directory work under a noun
+  group. `repo open` is the sole exception, and only to skip a question it can
+  already answer.
 - **A verb is abbreviated in its own name, not an alias beside it.** `ls`, `sel`
   and `rm` get no long form (`list`, `co` and `switch` predate the rule). Groups
   take one letter — `r`, `f`, `b`, `w`, `e`, `h`, `c` — and `pc`, as `p` meets


### PR DESCRIPTION
Pure rewrap of one CLAUDE.md bullet; no rule changed.