### PR TITLE
Cut the release bump loose from a static token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [main]
   pull_request:
+  # `release-prepare.yml` dispatches this against the branch carrying a version
+  # bump, the one way it can put the required checks on a pull request GitHub
+  # otherwise leaves unchecked.
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -36,28 +36,19 @@ jobs:
     # compile it belongs on `macos-latest` instead, or it will hit the target
     # guard in `src/proc.rs`.
     runs-on: ubuntu-latest
+    # `contents` pushes the bump branch, `pull-requests` opens the pull request
+    # and `actions` dispatches the checks it needs — see the last step.
+    permissions:
+      contents: write
+      pull-requests: write
+      actions: write
     steps:
-      # RELEASE_TOKEN, not GITHUB_TOKEN: GitHub runs no workflows on a pull
-      # request opened by GITHUB_TOKEN, and the `main` ruleset requires the
-      # `build` and `demo` checks on the branch tip. The bump would arrive
-      # unmergeable, with no check ever scheduled to satisfy it.
-      - name: Check the release token is present
-        env:
-          RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
-        run: |
-          test -n "$RELEASE_TOKEN" || {
-            echo "RELEASE_TOKEN is unset. It needs contents:write and" >&2
-            echo "pull-requests:write on this repository." >&2
-            exit 1
-          }
-
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: main
           # cargo-release refuses to run against a shallow history, and the
           # push below needs a real branch to build on.
           fetch-depth: 0
-          token: ${{ secrets.RELEASE_TOKEN }}
 
       # mise.toml pins cargo-release. Installing it any other way would put a
       # second version of the tool in the release path.
@@ -71,7 +62,7 @@ jobs:
 
       - name: Open the release pull request
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -eu
           ver=$(sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -1)
@@ -85,4 +76,12 @@ jobs:
             --body "Bump the version to $ver.
 
           Merge this, then dispatch \`release\` with the tag \`v$ver\`."
+          # The `main` ruleset requires `build` and `demo` on the branch tip,
+          # and nothing has scheduled them: GitHub answers an event raised with
+          # GITHUB_TOKEN either with no workflow run at all or, for the
+          # `pull_request` above, with one parked until a human approves it.
+          # `workflow_dispatch` is the exception it makes, so ask for the run
+          # outright. It reports both checks against the tip, which is what the
+          # ruleset reads.
+          gh workflow run ci.yml --ref "release-v$ver"
           echo "::notice::Opened the release pull request for v$ver"

--- a/README.md
+++ b/README.md
@@ -88,8 +88,8 @@ tarball, its checksum and its build provenance exist. There is no tag to push
 and none to get wrong. `.github/workflows/release.yml` is generated — change
 `dist-workspace.toml` and run `dist init`, never the workflow.
 
-`release-prepare` needs a `RELEASE_TOKEN` secret with `contents: write` and
-`pull-requests: write`. GitHub schedules no checks on a pull request opened by
-the default `GITHUB_TOKEN`, and the ruleset would never be satisfiable.
+`release-prepare` needs no secret of its own. It runs on the default
+`GITHUB_TOKEN` and dispatches `ci` against the bump branch, since GitHub leaves
+a pull request that token opened without the checks the ruleset asks for.
 
 `make release-dry-run` runs the same builds and releases nothing.


### PR DESCRIPTION
release-prepare has never once succeeded — every dispatch died at the guard checking for a RELEASE_TOKEN nobody had created.

The default GITHUB_TOKEN can do the work; what it cannot do is get GitHub to schedule the `build` and `demo` checks the `main` ruleset requires.

`workflow_dispatch` is the one event exempt from that, so the job asks for the ci run outright against the bump branch.

Job now requests `contents`, `pull-requests` and `actions` write instead of a secret.

Cost: ci gains a `workflow_dispatch` trigger, so anyone with write access can start it on any ref.

Untested until a real bump runs — the path only exists on dispatch.

CLI help unchanged. README's release section drops the secret. Nothing changed on screen, so docs/demo.gif stands.