### PR TITLE
Give the git tag equivalent the tag name it needs

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ git switch main && git pull
 cargo release tag --execute && cargo release push --execute
 ```
 
-That last line tags the merged commit `v0.5.0` and pushes the tag; `git tag` and
-`git push origin v0.5.0` do the same thing. cargo-release is pinned in
+That last line tags the merged commit `v0.5.0` and pushes the tag; `git tag
+v0.5.0` and `git push origin v0.5.0` do the same thing. cargo-release is pinned in
 `mise.toml` and configured under `[package.metadata.release]` in `Cargo.toml`.
 
 The tag starts [dist](https://axodotdev.github.io/cargo-dist), configured in


### PR DESCRIPTION
`git tag` bare lists tags; `git tag v0.5.0` is what matches `cargo release tag`.

CLI help unchanged. Nothing changed on screen, so `docs/demo.gif` stands.