### PR TITLE
Run release-plz where the crate compiles

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -28,7 +28,13 @@ jobs:
   # Tag the merged release pull request. Before the job below, so the tag it
   # reads as the current version is the one that just shipped.
   release:
-    runs-on: ubuntu-latest
+    # macOS for the same reason both CI jobs are: release-plz works out what
+    # changed by running `cargo package --allow-dirty --workspace`, which
+    # verifies the tarball by compiling it, and `src/proc.rs` fails that build
+    # anywhere but Apple Silicon. There is no flag for it — `publish_no_verify`
+    # reaches `cargo publish` and nothing else — so a Linux runner here is not
+    # a saving, it is the job failing before it reads a version.
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -42,7 +48,8 @@ jobs:
 
   release-pr:
     needs: release
-    runs-on: ubuntu-latest
+    # Compiles the crate too, as above.
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,10 +92,12 @@ tidiness: signal numbers past the POSIX five differ between Darwin and Linux,
 19 being `CONT` on one and `STOP` on the other, so a binary for the wrong
 platform suspends nothing and resumes what it should have stopped.
 
-Both CI jobs therefore run on `macos-latest`. A step that compiles the crate
-cannot be moved to a Linux runner to save time, and widening the target list is
-not a line in `dist-workspace.toml` — it is an audit of everything that assumed
-Darwin, the signal table first.
+Every job that compiles the crate therefore runs on `macos-latest`: both CI
+jobs, and both release-plz jobs, which compile it without saying so — working
+out what changed runs `cargo package`, and that verifies the tarball by building
+it. A step that compiles the crate cannot be moved to a Linux runner to save
+time, and widening the target list is not a line in `dist-workspace.toml` — it
+is an audit of everything that assumed Darwin, the signal table first.
 
 ## Rules for code that does not exist yet
 


### PR DESCRIPTION
`release-plz release-pr` failed on the first push to `main`. Determining the next version runs `cargo package --allow-dirty --workspace`, which verifies the tarball by compiling it, and `src/proc.rs` refuses to build off Apple Silicon.

- Both jobs move to `macos-latest`, the rule `ci.yml` already follows.
- No config avoids it: `publish_no_verify` only reaches `cargo publish`, and the packaging call passes no such flag.
- CLAUDE.md's "both CI jobs" now names every job that compiles the crate, since neither release-plz job looks like one.

Docs: CLAUDE.md *One platform*. No `src/` change, so no CHANGELOG.md entry, no CLI help change and no re-recorded GIF.