### PR TITLE
chore: release v0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ someone deciding whether to upgrade, not for someone reading the diff.
 
 ## Unreleased
 
+## 0.5.1 - 2026-08-13
+
 ### Added
 
 - An install script, published with every release:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1621,7 +1621,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scriv"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scriv"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 description = "Provides fuzzy-completion for various local and remote resources."
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `scriv`: 0.5.0 -> 0.5.1

<details><summary><i><b>Changelog</b></i></summary><p>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).