### PR TITLE
Read the release pull request before deciding there is one

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -66,12 +66,19 @@ jobs:
       # request is rebuilt from main often enough that a second commit would
       # only be the one that keeps disappearing.
       - name: Date the changelog entry
-        if: steps.release-plz.outputs.pr != ''
         env:
           PR: ${{ steps.release-plz.outputs.pr }}
         run: |
-          branch=$(printf '%s' "$PR" | jq -r '.head_branch')
-          version=$(printf '%s' "$PR" | jq -r '.releases[0].version')
+          # Read the branch out before deciding there is one. A run with nothing
+          # to propose — the push that merged the last release pull request, and
+          # each one after it until something changes — reports the pull request
+          # as `{}`, which is neither absent nor a branch name.
+          branch=$(printf '%s' "${PR:-}" | jq -r '.head_branch // empty')
+          version=$(printf '%s' "${PR:-}" | jq -r '.releases[0].version // empty')
+          if [ -z "$branch" ] || [ -z "$version" ]; then
+            echo "No release pull request to date"
+            exit 0
+          fi
           # By explicit refspec: the checkout above narrows `remote.origin.fetch`
           # to `main`, so nothing here tracks a branch named after a release.
           git fetch --quiet origin "+refs/heads/$branch:refs/remotes/origin/$branch"


### PR DESCRIPTION
The push that merged v0.5.1 left the `release-plz` workflow red, after tagging had already succeeded: with no next version to propose the action reports `pr` as `{}`, the guard tested for an empty string, and `jq` handed `git` a branch named `null`.

- The branch and version are read out first; `// empty` covers both `{}` and an unset output.
- A run with neither says so and exits clean.
- Nothing about the tag, the build or the release changes — this failed in the job that proposes the next version, after the one that cuts them.

Docs: none. No `src/` change, so no CHANGELOG.md entry, no CLI help change and no re-recorded GIF.