### PR TITLE
Title releases with the version, and date them a line below

### DIFF
--- a/.github/date-changelog.sh
+++ b/.github/date-changelog.sh
@@ -1,12 +1,18 @@
 #!/bin/sh
-# Give the `## Unreleased` section a dated version heading below it, leaving the
-# heading itself in place for the next change to be written under.
+# Give the `## Unreleased` section a version heading and a release date below
+# it, leaving the heading itself in place for the next change to be written
+# under.
 #
 # dist finds a release's notes by matching the version against these headings,
-# so the heading has to exist by the time the tag is pushed. release-plz bumps
-# the version but never touches this file — it would replace hand-written prose
-# with commit subjects — which leaves this, run against the release pull request
-# in .github/workflows/release-plz.yml.
+# so the heading has to exist by the time the tag is pushed. It also takes the
+# heading verbatim as the GitHub release title, which is why the date is a line
+# of its own: a title reading `0.5.1 - 2026-08-13` repeats the date GitHub
+# already prints beside it, and matches none of the releases cut before dist
+# read this file at all.
+#
+# release-plz bumps the version but never touches this file — it would replace
+# hand-written prose with commit subjects — which leaves this, run against the
+# release pull request in .github/workflows/release-plz.yml.
 #
 # Running it twice for the same version changes nothing, which is what the
 # release pull request being rebuilt on every push to main asks of it.
@@ -15,14 +21,20 @@ set -eu
 version=${1:?usage: date-changelog.sh <version>}
 cd "$(dirname "$0")/.."
 
-if grep -q "^## $version - " CHANGELOG.md; then
-	echo "CHANGELOG.md already has a heading for $version"
+if grep -q "^## v$version\$" CHANGELOG.md; then
+	echo "CHANGELOG.md already has a heading for v$version"
 	exit 0
 fi
 
-awk -v heading="## $version - $(date -u +%Y-%m-%d)" '
+awk -v version="$version" -v date="$(date -u +%Y-%m-%d)" '
 	{ print }
-	/^## Unreleased$/ && !done { print ""; print heading; done = 1 }
+	/^## Unreleased$/ && !done {
+		print ""
+		print "## v" version
+		print ""
+		print "*Released " date "*"
+		done = 1
+	}
 	END { if (!done) exit 1 }
 ' CHANGELOG.md > CHANGELOG.md.tmp || {
 	rm -f CHANGELOG.md.tmp
@@ -31,4 +43,4 @@ awk -v heading="## $version - $(date -u +%Y-%m-%d)" '
 }
 
 mv CHANGELOG.md.tmp CHANGELOG.md
-echo "CHANGELOG.md: dated $version"
+echo "CHANGELOG.md: dated v$version"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,17 @@ versioning](https://semver.org): while scriv is `0.x`, a new command or flag is
 a minor and a fix is a patch.
 
 The entry for a version is what its GitHub release says, so it is written for
-someone deciding whether to upgrade, not for someone reading the diff.
+someone deciding whether to upgrade, not for someone reading the diff. Its
+heading is that release's title, which is why the date sits on a line below
+instead of in it: GitHub prints the date beside the title already. Both lines
+are written by `.github/date-changelog.sh` when the release pull request is
+raised, never by hand.
 
 ## Unreleased
 
-## 0.5.1 - 2026-08-13
+## v0.5.1
+
+*Released 2026-08-13*
 
 ### Added
 
@@ -17,7 +23,9 @@ someone deciding whether to upgrade, not for someone reading the diff.
   `curl -LsSf https://github.com/joakimen/scriv/releases/latest/download/scriv-installer.sh | sh`.
   It installs into `~/.local/bin`.
 
-## 0.5.0 - 2026-08-12
+## v0.5.0
+
+*Released 2026-08-12*
 
 ### Added
 
@@ -29,7 +37,9 @@ someone deciding whether to upgrade, not for someone reading the diff.
 - A release is cut by pushing a tag, rather than by dispatching a workflow that
   needed a personal access token to open its own pull request.
 
-## 0.4.0 - 2026-08-11
+## v0.4.0
+
+*Released 2026-08-11*
 
 ### Changed
 
@@ -38,21 +48,27 @@ someone deciding whether to upgrade, not for someone reading the diff.
   one and `STOP` on the other — so a binary for the wrong platform resumed the
   process it was told to suspend.
 
-## 0.3.2 - 2026-08-11
+## v0.3.2
+
+*Released 2026-08-11*
 
 ### Changed
 
 - Releases are built and published by GitHub Actions. Nothing is compiled or
   signed on a maintainer's machine.
 
-## 0.3.1 - 2026-08-11
+## v0.3.1
+
+*Released 2026-08-11*
 
 ### Changed
 
 - ctrl-q is left unbound, for your own use; `scriv edit` is reached through the
   `fe` function instead.
 
-## 0.3.0 - 2026-08-10
+## v0.3.0
+
+*Released 2026-08-10*
 
 ### Added
 
@@ -76,7 +92,9 @@ someone deciding whether to upgrade, not for someone reading the diff.
 - A selector no longer spins at full CPU after its terminal goes away.
 - A key binding no longer draws over the output it just produced.
 
-## 0.2.1 - 2026-07-30
+## v0.2.1
+
+*Released 2026-07-30*
 
 ### Added
 
@@ -88,7 +106,9 @@ someone deciding whether to upgrade, not for someone reading the diff.
 - A listing ends quietly when its reader stops reading, so `scriv history ls |
   head` no longer ends in a panic.
 
-## 0.2.0 - 2026-07-30
+## v0.2.0
+
+*Released 2026-07-30*
 
 Rewritten in Rust, with the fuzzy finder compiled in rather than shelled out to.
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,8 @@ Nothing is run by hand.
 
 Every push to `main` runs [release-plz](https://release-plz.dev), which keeps a
 pull request open proposing the next version: the bump in `Cargo.toml` and
-`Cargo.lock`, and the `## Unreleased` section of `CHANGELOG.md` dated with it.
+`Cargo.lock`, and the version heading and release date that `## Unreleased`
+work in `CHANGELOG.md` is filed under.
 Merging that pull request tags the merge commit `v0.5.1` and pushes the tag.
 Leaving it open holds the version, which is the answer to a run of pull requests
 that only touched docs, `demo/` or CI.
@@ -87,9 +88,9 @@ next push to `main` rebuilds that branch from scratch.
 The tag starts [dist](https://axodotdev.github.io/cargo-dist), configured in
 `dist-workspace.toml`: it refuses a version no package carries, builds
 `aarch64-apple-darwin`, writes the install script, and publishes the release
-once the tarball, its checksum and its build provenance exist. The release notes
-are that version's section of `CHANGELOG.md`, so an entry written under
-`## Unreleased` while the work was done is what a reader sees.
+once the tarball, its checksum and its build provenance exist. The release takes
+its title and notes from that version's section of `CHANGELOG.md`, so an entry
+written under `## Unreleased` while the work was done is what a reader sees.
 `.github/workflows/release.yml` is generated — change `dist-workspace.toml` and
 run `dist init`, never the workflow.
 


### PR DESCRIPTION
dist takes the changelog heading verbatim as the release title, so v0.5.1 landed as `0.5.1 - 2026-08-13` where every earlier release is `v0.5.0` and the like.

- Headings become `## v<version>`, with `*Released <date>*` on the line below.
- Verified with `dist plan --tag=v0.5.1` against the pinned dist 0.32.0: title `v0.5.1`, notes intact.
- Existing entries converted, so the file dates every release the same way.
- The published v0.5.1 release is renamed separately; nothing here touches it.

Docs: CHANGELOG.md preamble now says why the date is not in the heading, README *Releasing* follows. No `src/` change, so no CHANGELOG.md entry, no CLI help change and no re-recorded GIF.