### PR TITLE
Colour the clone list by visibility, and drop archived repositories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ raised, never by hand.
 
 ## Unreleased
 
+### Added
+
+- `scriv repo clone` colours its list by who can see a repository: private is
+  yellow, internal magenta, public the terminal's own foreground. A repository
+  you already have stays grey.
+- `scriv repo clone --archived` lists an owner's archived repositories, which
+  are now left out by default.
+
 ## v0.5.1
 
 *Released 2026-08-13*

--- a/src/cmd/repo.rs
+++ b/src/cmd/repo.rs
@@ -295,7 +295,13 @@ fn repo_preview(repo: &Repo, present: Option<&Path>) -> Preview {
     if !repo.pushed_date().is_empty() {
         facts.push(format!("pushed {}", repo.pushed_date()));
     }
-    facts.extend(repo.tags().iter().map(|t| t.to_string()));
+    let visibility = repo.visibility();
+    for tag in repo.tags() {
+        facts.push(match visibility.color() {
+            Some(color) if tag == visibility.tag() => term::paint(tag, color, true),
+            _ => tag.to_string(),
+        });
+    }
     if !facts.is_empty() {
         out.push_str(&facts.join("  ·  "));
         out.push('\n');
@@ -346,10 +352,15 @@ fn repo_items(repos: &[Repo], root: &Path) -> Vec<SelectItem> {
             );
             let item = SelectItem::new(label.trim_end(), repo.name_with_owner.clone())
                 .preview(repo_preview(repo, present.then_some(dest.as_path())));
-            if present {
-                item.color(PRESENT_COLOR)
+            // Being on disk outranks visibility: it is the one thing that
+            // changes what selecting the row does.
+            match if present {
+                Some(PRESENT_COLOR)
             } else {
-                item
+                repo.visibility().color()
+            } {
+                Some(color) => item.color(color),
+                None => item,
             }
         })
         .collect()
@@ -405,9 +416,10 @@ fn clone_all(ctx: &Ctx, root: &Path, repos: &[String]) -> Result<usize> {
 ///
 /// With no argument, select an owner (from the config, the root, and `gh`, with
 /// anything typed accepted), then one or more of that owner's repositories.
-/// `owner/repo` skips both selectors. Everything lands at
+/// `owner/repo` skips both selectors, `archived` widens the list to the
+/// repositories GitHub has retired. Everything lands at
 /// `<root>/<owner>/<repo>`, which is where discovery looks.
-pub fn clone(ctx: &Ctx, target: Option<&str>, limit: usize) -> Result<()> {
+pub fn clone(ctx: &Ctx, target: Option<&str>, limit: usize, archived: bool) -> Result<()> {
     let root = clone_root(ctx)?;
 
     // `owner/repo` names a repository outright; there is nothing to choose.
@@ -424,11 +436,11 @@ pub fn clone(ctx: &Ctx, target: Option<&str>, limit: usize) -> Result<()> {
     // as an argument and gets the same check.
     check_slug(&owner)?;
 
-    let repos = gh::list_repos(&owner, limit)?;
+    let repos = gh::list_repos(&owner, limit, archived)?;
     ctx.log
         .info(&format!("{} repositories for {owner}", repos.len()));
     if repos.is_empty() {
-        bail!("no repositories found for {owner}");
+        bail!("{}", empty_message(&owner, archived));
     }
     if repos.len() == limit {
         eprintln!(
@@ -445,6 +457,17 @@ pub fn clone(ctx: &Ctx, target: Option<&str>, limit: usize) -> Result<()> {
         return Ok(());
     }
     finish(ctx, &root, chosen)
+}
+
+/// What to say when an owner has nothing to offer. An owner whose every
+/// repository is archived looks exactly like a misspelt one, so the default
+/// filter names itself rather than leaving the user to doubt the owner.
+fn empty_message(owner: &str, archived: bool) -> String {
+    if archived {
+        format!("no repositories found for {owner}")
+    } else {
+        format!("no unarchived repositories found for {owner}; pass --archived to include those")
+    }
 }
 
 /// Reject a name that is not one GitHub could have issued. A slug is both a
@@ -494,10 +517,10 @@ mod tests {
         gh::parse_repos(
             r#"[
             {"nameWithOwner":"acme/billing-api","description":"Meters usage",
-             "isPrivate":true,"isArchived":false,"isFork":false,
+             "visibility":"PRIVATE","isArchived":false,"isFork":false,
              "primaryLanguage":{"name":"Rust"},"pushedAt":"2026-07-27T09:12:33Z"},
             {"nameWithOwner":"acme/old-thing","description":"",
-             "isPrivate":false,"isArchived":true,"isFork":true,
+             "visibility":"PUBLIC","isArchived":true,"isFork":true,
              "primaryLanguage":null,"pushedAt":"2024-01-02T00:00:00Z"}
         ]"#,
         )
@@ -595,6 +618,32 @@ mod tests {
         assert_eq!(items[1].color, None);
         // The value is still the slug, so selecting it is well-defined.
         assert_eq!(items[0].value(), "acme/billing-api");
+    }
+
+    #[test]
+    fn visibility_colours_a_row_that_is_not_on_disk_yet() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let items = repo_items(&repos(), tmp.path());
+        assert_eq!(items[0].color, gh::Visibility::Private.color());
+        assert_eq!(items[1].color, None, "a public repository is left bare");
+    }
+
+    #[test]
+    fn an_owner_with_nothing_to_show_names_the_archive_filter() {
+        assert!(empty_message("acme", false).contains("--archived"));
+        assert!(!empty_message("acme", true).contains("--archived"));
+    }
+
+    #[test]
+    fn preview_paints_the_visibility_tag() {
+        let Preview::Text(text) = repo_preview(&repos()[0], None) else {
+            panic!("expected text");
+        };
+        let color = gh::Visibility::Private.color().unwrap();
+        assert!(
+            text.contains(&term::paint("private", color, true)),
+            "{text}"
+        );
     }
 
     #[test]

--- a/src/gh.rs
+++ b/src/gh.rs
@@ -533,7 +533,7 @@ pub fn merge(
 /// JSON fields requested from `gh repo list`: only what a selector row and its
 /// preview can use.
 const REPO_FIELDS: &str =
-    "nameWithOwner,description,isPrivate,isArchived,isFork,primaryLanguage,pushedAt";
+    "nameWithOwner,description,visibility,isArchived,isFork,primaryLanguage,pushedAt";
 
 /// A repository on GitHub, as much of it as the clone selector needs.
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
@@ -543,8 +543,10 @@ pub struct Repo {
     pub name_with_owner: String,
     #[serde(default)]
     pub description: String,
+    /// GitHub's own word: `PUBLIC`, `PRIVATE` or `INTERNAL`. Read through
+    /// [`Repo::visibility`].
     #[serde(default)]
-    pub is_private: bool,
+    pub visibility: String,
     #[serde(default)]
     pub is_archived: bool,
     #[serde(default)]
@@ -560,6 +562,49 @@ pub struct Repo {
 pub struct Language {
     #[serde(default)]
     pub name: String,
+}
+
+/// Who can see a repository. `Internal` exists only under an enterprise, where
+/// it means every member of that enterprise rather than the wider internet.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Visibility {
+    Public,
+    Private,
+    Internal,
+}
+
+impl Visibility {
+    /// Anything GitHub did not say is public: the safe direction to be wrong in
+    /// is the one that leaves a private repository looking unremarkable rather
+    /// than announcing a private repository that is not one.
+    pub fn parse(raw: &str) -> Self {
+        if is(raw, &["PRIVATE"]) {
+            Self::Private
+        } else if is(raw, &["INTERNAL"]) {
+            Self::Internal
+        } else {
+            Self::Public
+        }
+    }
+
+    /// The tag for a list row, empty for the case that says nothing.
+    pub fn tag(self) -> &'static str {
+        match self {
+            Self::Public => "",
+            Self::Private => "private",
+            Self::Internal => "internal",
+        }
+    }
+
+    /// ANSI 256-colour index, or `None` for public — the ordinary case, which
+    /// keeps the terminal's own foreground so the restricted ones stand out.
+    pub fn color(self) -> Option<u8> {
+        match self {
+            Self::Public => None,
+            Self::Private => Some(3),  // yellow — yours alone
+            Self::Internal => Some(5), // magenta — your enterprise's
+        }
+    }
 }
 
 impl Repo {
@@ -587,6 +632,10 @@ impl Repo {
         self.pushed_at.split('T').next().unwrap_or_default()
     }
 
+    pub fn visibility(&self) -> Visibility {
+        Visibility::parse(&self.visibility)
+    }
+
     /// The one-word tags worth showing: what makes this repository unusual.
     /// A public, unarchived, non-fork repository is the default and says
     /// nothing.
@@ -595,8 +644,9 @@ impl Repo {
         if self.is_archived {
             tags.push("archived");
         }
-        if self.is_private {
-            tags.push("private");
+        let visibility = self.visibility().tag();
+        if !visibility.is_empty() {
+            tags.push(visibility);
         }
         if self.is_fork {
             tags.push("fork");
@@ -640,19 +690,31 @@ pub fn valid_slug(slug: &str) -> bool {
         })
 }
 
-/// Every repository belonging to `owner`. `--limit` drives `gh`'s pagination,
-/// and is exposed so an org larger than it is not silently truncated.
-pub fn list_repos(owner: &str, limit: usize) -> Result<Vec<Repo>> {
-    let limit = limit.to_string();
-    let out = capture(&[
+/// The `gh repo list` invocation for `owner`. Archived repositories are
+/// dropped by GitHub rather than by scriv, so an org whose history is mostly
+/// archived does not spend its `--limit` on rows nobody asked for.
+fn list_repos_args<'a>(owner: &'a str, limit: &'a str, archived: bool) -> Vec<&'a str> {
+    let mut args = vec![
         "repo",
         "list",
         owner,
         "--json",
         REPO_FIELDS,
         "--limit",
-        &limit,
-    ])?;
+        limit,
+    ];
+    if !archived {
+        args.push("--no-archived");
+    }
+    args
+}
+
+/// Every repository belonging to `owner`, archived ones only when `archived`.
+/// `--limit` drives `gh`'s pagination, and is exposed so an org larger than it
+/// is not silently truncated.
+pub fn list_repos(owner: &str, limit: usize, archived: bool) -> Result<Vec<Repo>> {
+    let limit = limit.to_string();
+    let out = capture(&list_repos_args(owner, &limit, archived))?;
     parse_repos(&out)
 }
 
@@ -1047,5 +1109,50 @@ mod tests {
         assert_eq!(MergeMethod::Merge.flag(), "--merge");
         assert_eq!(MergeMethod::Squash.flag(), "--squash");
         assert_eq!(MergeMethod::Rebase.flag(), "--rebase");
+    }
+
+    #[test]
+    fn visibility_parses_what_github_says() {
+        assert_eq!(Visibility::parse("PRIVATE"), Visibility::Private);
+        assert_eq!(Visibility::parse("internal"), Visibility::Internal);
+        assert_eq!(Visibility::parse("PUBLIC"), Visibility::Public);
+        // A field GitHub did not send must not read as restricted.
+        assert_eq!(Visibility::parse(""), Visibility::Public);
+    }
+
+    #[test]
+    fn each_visibility_reads_differently() {
+        let colors = [
+            Visibility::Public.color(),
+            Visibility::Private.color(),
+            Visibility::Internal.color(),
+        ];
+        let mut distinct = colors.to_vec();
+        distinct.sort_unstable();
+        distinct.dedup();
+        assert_eq!(distinct.len(), colors.len(), "two visibilities look alike");
+        assert_eq!(
+            Visibility::Public.color(),
+            None,
+            "the ordinary case is bare"
+        );
+    }
+
+    #[test]
+    fn archived_repositories_are_left_to_github_to_filter() {
+        assert!(list_repos_args("acme", "1000", false).contains(&"--no-archived"));
+        assert!(!list_repos_args("acme", "1000", true).contains(&"--no-archived"));
+        assert_eq!(
+            list_repos_args("acme", "50", true),
+            [
+                "repo",
+                "list",
+                "acme",
+                "--json",
+                REPO_FIELDS,
+                "--limit",
+                "50"
+            ]
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -240,7 +240,9 @@ enum RepoCmd {
     ///
     /// Everything lands at `<root>/<owner>/<repo>`, so a clone is in
     /// `scriv repo sel` immediately afterwards. Repositories you already have
-    /// are listed but greyed, and are skipped rather than re-cloned.
+    /// are listed but greyed, and are skipped rather than re-cloned; private
+    /// ones are yellow and internal ones magenta. Archived repositories are
+    /// left out unless you ask for them.
     Clone {
         /// `owner` to select from, or `owner/repo` to clone directly
         #[arg(value_name = "OWNER[/REPO]")]
@@ -248,6 +250,9 @@ enum RepoCmd {
         /// Maximum number of repositories to fetch for an owner
         #[arg(short = 'L', long, default_value_t = 1000)]
         limit: usize,
+        /// Also list an owner's archived repositories
+        #[arg(long)]
+        archived: bool,
     },
 }
 
@@ -571,7 +576,11 @@ fn run(cli: Cli) -> anyhow::Result<()> {
             RepoCmd::Ls { absolute_paths } => cmd::repo::ls(&ctx, absolute_paths),
             RepoCmd::Sel => cmd::repo::sel(&ctx),
             RepoCmd::Open { select } => cmd::repo::open(&ctx, select),
-            RepoCmd::Clone { target, limit } => cmd::repo::clone(&ctx, target.as_deref(), limit),
+            RepoCmd::Clone {
+                target,
+                limit,
+                archived,
+            } => cmd::repo::clone(&ctx, target.as_deref(), limit, archived),
         },
         Command::File { command } => match command {
             FileCmd::Ls {


### PR DESCRIPTION
Release: minor

- `repo clone` colours a row by who can see the repository: private yellow, internal magenta, public bare.
- Already-cloned rows stay grey, which still outranks visibility.
- Archived repositories are left out of the list; `--archived` puts them back.
- GitHub does that filtering, so a long archive no longer eats the `--limit`.
- Visibility comes from `visibility` rather than `isPrivate`, which cannot see `INTERNAL`.
- CHANGELOG has both under Unreleased; README needs no row and the demo never shows this selector.