### PR TITLE
Correct the README and give it the shape of a front page

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,9 +33,9 @@ install:
 hooks:
 	prek install --hook-type pre-commit --hook-type pre-push
 
-# Releasing has no target here. It is two cargo-release commands around an
-# ordinary pull request, spelled out in README.md, and a target wrapping them
-# would only hide which of the two a half-finished release stopped after.
+# Releasing has no target here, and cannot have one: release-plz tags the merge
+# of the pull request it keeps open, and dist builds and publishes what that tag
+# starts. Both run in CI — see README.md under Releasing.
 
 # Re-record docs/demo.gif. Local only — the render depends on installed fonts.
 # Requires vhs (brew install vhs).

--- a/README.md
+++ b/README.md
@@ -2,11 +2,17 @@
 
 [![ci](https://github.com/joakimen/scriv/actions/workflows/ci.yml/badge.svg)](https://github.com/joakimen/scriv/actions/workflows/ci.yml)
 [![release](https://img.shields.io/github/v/release/joakimen/scriv?logo=github&color=blue)](https://github.com/joakimen/scriv/releases/latest)
+[![platform](https://img.shields.io/badge/platform-macOS%20%28Apple%20Silicon%29-blue?logo=apple&logoColor=white)](#install)
 [![license](https://img.shields.io/github/license/joakimen/scriv?color=blue)](LICENSE)
 
 ![A candle burning above an open book, flanked by engraved rules](docs/art/banner.svg)
 
 Provides fuzzy-completion for various local and remote resources.
+
+One selector over the things you reach for all day: repositories, tracked
+files, branches, worktrees, GitHub pull requests, running processes and shell
+history. The finder is compiled in, so a selection is one process rather than a
+pipeline, and `scriv init fish` puts the common ones on a key.
 
 ![scriv: check out a remote branch, find and open a file, list pull requests](docs/demo.gif)
 
@@ -14,14 +20,20 @@ Provides fuzzy-completion for various local and remote resources.
 
 ```sh
 curl --proto '=https' --tlsv1.2 -LsSf https://github.com/joakimen/scriv/releases/latest/download/scriv-installer.sh | sh
-mise use -g github:joakimen/scriv    # or: cargo install --path .
 ```
 
-The script puts the binary in `~/.local/bin` and adds it to your `PATH`; both
-it and mise resolve the same release archive.
+The script puts the binary in `~/.local/bin` and adds that to your `PATH`. Two
+other ways in, resolving the same release archive or building it yourself:
 
-macOS on Apple Silicon. Needs `git`; `gh` for pull requests and
-`repo clone`/`open`.
+```sh
+mise use -g github:joakimen/scriv
+cargo install --git https://github.com/joakimen/scriv
+```
+
+macOS on Apple Silicon, and nothing else — the signal table `scriv proc` uses
+is Darwin's. `git` is required. `gh` is needed by `pr` and by `repo
+clone`/`open`, fish's history file by `history`, and `$VISUAL` or `$EDITOR` by
+`edit`; `scriv config check` reports on each.
 
 ## Setup
 
@@ -31,9 +43,30 @@ scriv init fish | source   # helpers, key bindings, completions
 scriv config check         # confirm it all resolves
 ```
 
+Put the middle line in `~/.config/fish/config.fish` to keep it. The bindings
+arrive as a function rather than bound at source time, so they compose with
+fish's own lifecycle — call it yourself to switch them on:
+
+```fish
+function fish_user_key_bindings
+    scriv_key_bindings
+end
+```
+
+Every setting is a commented line in the file `config init` writes. The one
+that matters is the root your repositories live under, laid out `<owner>/<repo>`
+as GitHub itself is:
+
+```toml
+[repo]
+root = "~/dev/github.com"
+ignore = ["node_modules", "target"]
+# labels = { personal = ["your-github-user"], work = ["acme", "acme-labs"] }
+```
+
 ## Commands
 
-| | |
+| Group | Verbs |
 | --- | --- |
 | `scriv repo` | `ls` `sel` `open` `clone` |
 | `scriv file` | `ls` `sel` `add` `rm` `prune` |
@@ -50,9 +83,23 @@ scriv config check         # confirm it all resolves
 act. Every `sel` composes: `cd (scriv repo sel)`. Each group takes a one-letter
 abbreviation — `r`, `f`, `b`, `w`, `e`, `h`, `c`, and `pc` for `proc`.
 
-In fish, `ctrl-r` searches history, `ctrl-o` jumps to a repository, `ctrl-t` to
-a worktree of the one you are in, and `ctrl-g` checks out a branch; `f1`, `f3`
-and `f7` open a repository, a tracked file and a pull request.
+## Key bindings
+
+`scriv_key_bindings` binds these in fish:
+
+| Key | Action |
+| --- | --- |
+| `ctrl-o` | `cd` to a repository |
+| `ctrl-t` | `cd` to a worktree of the one you are in |
+| `ctrl-g` | check out a branch |
+| `ctrl-r` | search shell history onto the command line |
+| `up` | the same, on the first line of a prompt |
+| `f1` | open a repository on GitHub |
+| `f3` | open a tracked file in `$EDITOR` |
+| `f7` | check out a pull request |
+
+Two functions come with them: `fe` for `scriv edit`, arguments passed through,
+and `kl` for `scriv proc kill --force`.
 
 `scriv --help` covers the flags, the generated `config.toml` the settings.
 
@@ -74,9 +121,9 @@ Every push to `main` runs [release-plz](https://release-plz.dev), which keeps a
 pull request open proposing the next version: the bump in `Cargo.toml` and
 `Cargo.lock`, and the version heading and release date that `## Unreleased`
 work in `CHANGELOG.md` is filed under.
-Merging that pull request tags the merge commit `v0.5.1` and pushes the tag.
-Leaving it open holds the version, which is the answer to a run of pull requests
-that only touched docs, `demo/` or CI.
+Merging that pull request tags the merge commit with that version and pushes
+the tag. Leaving it open holds the version, which is the answer to a run of
+pull requests that only touched docs, `demo/` or CI.
 
 The proposal is a patch. A change that earns a minor — a new command or flag —
 says so with a `Release: minor` line in the body it is squashed with, which
@@ -100,3 +147,7 @@ a fine-grained token with `Contents` and `Pull requests` write on this
 repository. The workflow's own `GITHUB_TOKEN` cannot stand in — a tag it pushes
 starts no workflow, so dist would never build, and a pull request it opens runs
 no checks, so `build` and `demo` would never report to the ruleset on `main`.
+
+## License
+
+[MIT](LICENSE)


### PR DESCRIPTION
- `f7` checks out a pull request; the key-binding sentence listed it as opening one, and omitted `up` entirely — both now match `scriv_key_bindings`.
- *Releasing* named the tag `v0.5.1`, a release ago.
- The `Install` line named `git` and `gh` but not `$EDITOR` or fish's history file, which `config check` has rows for.
- Setup now says to call `scriv_key_bindings` from `fish_user_key_bindings`, without which no binding a README reader follows is ever bound.
- Setup shows the `[repo] root` it tells you to set.
- `cargo install --git` replaces a `cargo install --path .` that assumed a clone.
- Command and key tables get real headers; the page gains an opening paragraph, a platform badge and a License section.
- The Makefile's note on releasing still described two cargo-release commands.

No CHANGELOG entry and no `make demo`: docs only, and nothing changed on screen.