### PR TITLE
Colour the visibility word, not the row it sits in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ raised, never by hand.
 
 ## Unreleased
 
+### Changed
+
+- `scriv repo clone` shows the date each repository was last pushed to, as a
+  column before the description.
+- Its rows are no longer coloured end to end. Only the visibility word is
+  tinted — yellow private, magenta internal — and a repository you already have
+  is marked with a green tick rather than being greyed out.
+- The preview pane is gone from that selector: everything it held is a column
+  now.
+
 ## v0.6.0
 
 *Released 2026-08-17*

--- a/src/cmd/repo.rs
+++ b/src/cmd/repo.rs
@@ -12,7 +12,7 @@ use crate::config::{Labels, RepoDisplay};
 use crate::gh::{self, Repo};
 use crate::path::{display_path, expand_home_dir, relative_label};
 use crate::repo::FoundRepo;
-use crate::select::{Choice, Preview, SelectItem};
+use crate::select::{Choice, SelectItem, Tint};
 use crate::{Ctx, git, repo, select, term};
 
 /// Discover repositories, label-tagged and sorted by path.
@@ -189,9 +189,12 @@ pub fn open(ctx: &Ctx, force_select: bool) -> Result<()> {
 /// the ceiling is what a remote accepts from one user.
 const CLONE_CONCURRENCY: usize = 8;
 
-/// Colour for a row that is already on disk. Grey reads as "not actionable",
-/// which is exactly what an already-cloned repository is.
-const PRESENT_COLOR: u8 = 8;
+/// The mark on a repository already on disk, and its colour: green, the one
+/// hue that reads as "done" without being read as a warning. It is the whole
+/// signal — the row beneath it is drawn like any other, since a dimmed row says
+/// "not worth looking at" of a repository that is merely already here.
+const PRESENT_MARK: &str = "✓";
+const PRESENT_COLOR: u8 = 2;
 
 /// The configured root, expanded — the one directory clones are written to.
 fn clone_root(ctx: &Ctx) -> Result<PathBuf> {
@@ -282,86 +285,107 @@ fn select_owner(ctx: &Ctx, root: &Path) -> Result<String> {
     }
 }
 
-/// The preview for a repository: description and the facts that tell two
-/// similar repositories apart, from data `gh repo list` already returned.
-fn repo_preview(repo: &Repo, present: Option<&Path>) -> Preview {
-    let mut out = term::paint(&repo.name_with_owner, 6, true);
-    out.push('\n');
+/// How wide each column of the clone selector is, measured over the whole list
+/// so the columns line up.
+struct Widths {
+    name: usize,
+    tags: usize,
+    pushed: usize,
+}
 
-    let mut facts = Vec::new();
-    if !repo.language().is_empty() {
-        facts.push(repo.language().to_string());
+impl Widths {
+    fn of(repos: &[Repo]) -> Self {
+        // Character counts, not bytes: a column is padded by characters.
+        let widest = |f: fn(&Repo) -> usize| repos.iter().map(f).max().unwrap_or(0);
+        Self {
+            name: widest(|r| r.name().chars().count()),
+            tags: widest(|r| tag_column(r).chars().count()),
+            pushed: widest(|r| r.pushed_date().chars().count()),
+        }
     }
-    if !repo.pushed_date().is_empty() {
-        facts.push(format!("pushed {}", repo.pushed_date()));
+}
+
+/// The tags column: what makes this repository unusual, in one string.
+fn tag_column(repo: &Repo) -> String {
+    repo.tags().join(" ")
+}
+
+/// Append `text` and pad it out to `width` characters.
+fn push_column(row: &mut String, text: &str, width: usize) {
+    row.push_str(text);
+    for _ in text.chars().count()..width {
+        row.push(' ');
     }
-    let visibility = repo.visibility();
-    for tag in repo.tags() {
-        facts.push(match visibility.color() {
-            Some(color) if tag == visibility.tag() => term::paint(tag, color, true),
-            _ => tag.to_string(),
+}
+
+/// One row of the clone selector, and the columns of it that carry a colour.
+///
+/// The two are built together because a tint is a character range into the row,
+/// and counting those ranges out a second time is how they drift.
+///
+/// Nothing tints the row as a whole. A line drawn in one colour reads as a
+/// statement about the repository, and neither "already on disk" nor "private"
+/// is one — the first is about this machine and the second about one column, so
+/// each colours only the thing it is true of.
+fn clone_row(repo: &Repo, present: bool, widths: &Widths) -> (String, Vec<Tint>) {
+    let mut row = String::new();
+    let mut tints = Vec::new();
+
+    row.push_str(if present { PRESENT_MARK } else { " " });
+    if present {
+        tints.push(Tint {
+            range: 0..row.chars().count(),
+            color: PRESENT_COLOR,
         });
     }
-    if !facts.is_empty() {
-        out.push_str(&facts.join("  ·  "));
-        out.push('\n');
-    }
+    row.push(' ');
 
-    if let Some(path) = present {
-        out.push_str(&term::paint(
-            &format!("already cloned at {}\n", path.display()),
-            PRESENT_COLOR,
-            true,
-        ));
-    }
-    out.push('\n');
+    push_column(&mut row, repo.name(), widths.name);
+    row.push_str("  ");
 
-    let description = repo.description.trim();
-    out.push_str(if description.is_empty() {
-        "(no description)"
-    } else {
-        description
-    });
-    Preview::Text(out)
+    let visibility = repo.visibility();
+    let tags_at = row.chars().count();
+    for (index, tag) in repo.tags().iter().enumerate() {
+        if index > 0 {
+            row.push(' ');
+        }
+        let at = row.chars().count();
+        row.push_str(tag);
+        if let Some(color) = visibility.color()
+            && *tag == visibility.tag()
+        {
+            tints.push(Tint {
+                range: at..row.chars().count(),
+                color,
+            });
+        }
+    }
+    for _ in (row.chars().count() - tags_at)..widths.tags {
+        row.push(' ');
+    }
+    row.push_str("  ");
+
+    push_column(&mut row, repo.pushed_date(), widths.pushed);
+    row.push_str("  ");
+    row.push_str(repo.description.trim());
+
+    (row.trim_end().to_string(), tints)
 }
 
 /// Build the repository rows, marking the ones already on disk. They stay
 /// listed rather than filtered out, since their absence would read as "this org
 /// does not have that repo".
+///
+/// No preview pane: everything `gh repo list` returned that is worth seeing is
+/// now a column, and a pane that repeats the row is a pane nobody reads.
 fn repo_items(repos: &[Repo], root: &Path) -> Vec<SelectItem> {
-    let width = repos
-        .iter()
-        .map(|r| r.name().chars().count())
-        .max()
-        .unwrap_or(0);
-    // Rendered once and reused for both the column width and the rows.
-    let tags: Vec<String> = repos.iter().map(|r| r.tags().join(" ")).collect();
-    let tag_width = tags.iter().map(|t| t.chars().count()).max().unwrap_or(0);
-
+    let widths = Widths::of(repos);
     repos
         .iter()
-        .zip(&tags)
-        .map(|(repo, tags)| {
-            let dest = destination(root, repo.owner(), repo.name());
-            let present = dest.exists();
-            let marker = if present { "✓" } else { " " };
-            let label = format!(
-                "{marker} {name:<width$}  {tags:<tag_width$}  {description}",
-                name = repo.name(),
-                description = repo.description.trim(),
-            );
-            let item = SelectItem::new(label.trim_end(), repo.name_with_owner.clone())
-                .preview(repo_preview(repo, present.then_some(dest.as_path())));
-            // Being on disk outranks visibility: it is the one thing that
-            // changes what selecting the row does.
-            match if present {
-                Some(PRESENT_COLOR)
-            } else {
-                repo.visibility().color()
-            } {
-                Some(color) => item.color(color),
-                None => item,
-            }
+        .map(|repo| {
+            let present = destination(root, repo.owner(), repo.name()).exists();
+            let (row, tints) = clone_row(repo, present, &widths);
+            SelectItem::new(row, repo.name_with_owner.clone()).tints(tints)
         })
         .collect()
 }
@@ -604,6 +628,21 @@ mod tests {
         assert_eq!(repos[1].tags(), vec!["archived", "fork"]);
     }
 
+    /// The characters `range` covers, which is what the selector will paint.
+    fn tinted(row: &str, tint: &Tint) -> String {
+        row.chars()
+            .skip(tint.range.start)
+            .take(tint.range.end - tint.range.start)
+            .collect::<String>()
+    }
+
+    fn tint_of(row: &str, tints: &[Tint], color: u8) -> Option<String> {
+        tints
+            .iter()
+            .find(|t| t.color == color)
+            .map(|t| tinted(row, t))
+    }
+
     #[test]
     fn present_repositories_are_marked_not_hidden() {
         let tmp = tempfile::TempDir::new().unwrap();
@@ -612,57 +651,101 @@ mod tests {
 
         let items = repo_items(&repos(), root);
         assert_eq!(items.len(), 2, "a present repo was dropped from the list");
-        assert!(items[0].label.starts_with('✓'), "{}", items[0].label);
-        assert_eq!(items[0].color, Some(PRESENT_COLOR));
-        assert!(!items[1].label.starts_with('✓'), "{}", items[1].label);
-        assert_eq!(items[1].color, None);
+        assert!(
+            items[0].label.starts_with(PRESENT_MARK),
+            "{}",
+            items[0].label
+        );
+        assert!(
+            !items[1].label.starts_with(PRESENT_MARK),
+            "{}",
+            items[1].label
+        );
         // The value is still the slug, so selecting it is well-defined.
         assert_eq!(items[0].value(), "acme/billing-api");
     }
 
     #[test]
-    fn visibility_colours_a_row_that_is_not_on_disk_yet() {
+    fn nothing_colours_a_whole_row() {
         let tmp = tempfile::TempDir::new().unwrap();
-        let items = repo_items(&repos(), tmp.path());
-        assert_eq!(items[0].color, gh::Visibility::Private.color());
-        assert_eq!(items[1].color, None, "a public repository is left bare");
+        let root = tmp.path();
+        std::fs::create_dir_all(root.join("acme/billing-api")).unwrap();
+        for item in repo_items(&repos(), root) {
+            assert_eq!(item.color, None, "{} is drawn in one colour", item.label);
+        }
+    }
+
+    #[test]
+    fn the_mark_on_an_existing_clone_is_green_and_only_the_mark() {
+        let widths = Widths::of(&repos());
+        let (row, tints) = clone_row(&repos()[0], true, &widths);
+        assert_eq!(tint_of(&row, &tints, PRESENT_COLOR).as_deref(), Some("✓"));
+        assert_eq!(PRESENT_COLOR, 2, "the mark is not green");
+    }
+
+    #[test]
+    fn an_uncloned_repository_carries_no_mark() {
+        let widths = Widths::of(&repos());
+        let (row, tints) = clone_row(&repos()[0], false, &widths);
+        assert!(!row.starts_with(PRESENT_MARK), "{row}");
+        assert_eq!(tint_of(&row, &tints, PRESENT_COLOR), None);
+    }
+
+    #[test]
+    fn only_the_visibility_word_takes_the_visibility_colour() {
+        let widths = Widths::of(&repos());
+        let (row, tints) = clone_row(&repos()[0], false, &widths);
+        let color = gh::Visibility::Private.color().unwrap();
+        assert_eq!(tint_of(&row, &tints, color).as_deref(), Some("private"));
+    }
+
+    /// `archived` and `fork` share the tags column with the visibility word and
+    /// say nothing about who can see the repository.
+    #[test]
+    fn the_other_tags_are_left_uncoloured() {
+        let widths = Widths::of(&repos());
+        let (row, tints) = clone_row(&repos()[1], false, &widths);
+        assert!(row.contains("archived fork"), "{row}");
+        assert!(tints.is_empty(), "a public repository is left bare: {row}");
+    }
+
+    #[test]
+    fn the_row_carries_the_last_push_date_before_the_description() {
+        let widths = Widths::of(&repos());
+        let (row, _) = clone_row(&repos()[0], false, &widths);
+        let pushed = row.find("2026-07-27").expect(&row);
+        let description = row.find("Meters usage").expect(&row);
+        assert!(pushed < description, "{row}");
+    }
+
+    /// Every column is padded to the width of the whole list, so a row reads
+    /// down the screen rather than only across.
+    #[test]
+    fn the_columns_line_up() {
+        let widths = Widths::of(&repos());
+        let rows: Vec<String> = repos()
+            .iter()
+            .map(|repo| clone_row(repo, false, &widths).0)
+            .collect();
+        let at = |row: &str, needle: &str| row.find(needle).map(|i| row[..i].chars().count());
+        assert_eq!(
+            at(&rows[0], "2026-07-27"),
+            at(&rows[1], "2024-01-02"),
+            "{rows:?}",
+        );
+    }
+
+    #[test]
+    fn nothing_previews_a_repository() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        for item in repo_items(&repos(), tmp.path()) {
+            assert!(item.preview.is_none(), "{} opens a pane", item.label);
+        }
     }
 
     #[test]
     fn an_owner_with_nothing_to_show_names_the_archive_filter() {
         assert!(empty_message("acme", false).contains("--archived"));
         assert!(!empty_message("acme", true).contains("--archived"));
-    }
-
-    #[test]
-    fn preview_paints_the_visibility_tag() {
-        let Preview::Text(text) = repo_preview(&repos()[0], None) else {
-            panic!("expected text");
-        };
-        let color = gh::Visibility::Private.color().unwrap();
-        assert!(
-            text.contains(&term::paint("private", color, true)),
-            "{text}"
-        );
-    }
-
-    #[test]
-    fn preview_names_the_existing_checkout() {
-        let path = PathBuf::from("/home/u/dev/github.com/acme/billing-api");
-        let Preview::Text(text) = repo_preview(&repos()[0], Some(&path)) else {
-            panic!("a repo preview must not spawn a command");
-        };
-        assert!(text.contains("already cloned at"), "{text}");
-        assert!(text.contains("Rust"), "{text}");
-        assert!(text.contains("Meters usage"), "{text}");
-    }
-
-    #[test]
-    fn preview_handles_a_missing_description() {
-        let Preview::Text(text) = repo_preview(&repos()[1], None) else {
-            panic!("expected text");
-        };
-        assert!(text.contains("(no description)"), "{text}");
-        assert!(!text.contains("already cloned"), "{text}");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -239,10 +239,11 @@ enum RepoCmd {
     /// several and they clone concurrently. `owner/repo` skips both selectors.
     ///
     /// Everything lands at `<root>/<owner>/<repo>`, so a clone is in
-    /// `scriv repo sel` immediately afterwards. Repositories you already have
-    /// are listed but greyed, and are skipped rather than re-cloned; private
-    /// ones are yellow and internal ones magenta. Archived repositories are
-    /// left out unless you ask for them.
+    /// `scriv repo sel` immediately afterwards. Each row carries the tags that
+    /// make a repository unusual — `private` in yellow, `internal` in magenta —
+    /// and the date it was last pushed to. Repositories you already have are
+    /// marked with a green tick and skipped rather than re-cloned. Archived
+    /// repositories are left out unless you ask for them.
     Clone {
         /// `owner` to select from, or `owner/repo` to clone directly
         #[arg(value_name = "OWNER[/REPO]")]

--- a/src/select.rs
+++ b/src/select.rs
@@ -10,6 +10,7 @@
 //! Rows arrive either all at once ([`select_one`], [`select_many`]) or as they
 //! are discovered ([`select_one_streamed`], [`select_many_streamed`]).
 
+use std::ops::Range;
 use std::sync::Mutex;
 use std::time::{Duration, Instant};
 
@@ -96,6 +97,16 @@ fn file_preview_cmd(path: &str) -> String {
     )
 }
 
+/// A stretch of a label drawn in its own colour, as a character range.
+///
+/// Where [`SelectItem::color`] says something about the whole row, a tint says
+/// something about one column of it — so a row can carry two facts that are
+/// true of different parts of it without either claiming the line.
+pub struct Tint {
+    pub range: Range<usize>,
+    pub color: u8,
+}
+
 /// One choice in the selector: `label` is displayed and matched against,
 /// [`SelectItem::value`] is returned when it is selected, `color` optionally
 /// tints the row (an ANSI 256-colour index, so it respects the terminal
@@ -110,6 +121,7 @@ pub struct SelectItem {
     /// [`SelectItem::value`].
     value: Option<String>,
     pub color: Option<u8>,
+    pub tints: Vec<Tint>,
     pub preview: Option<Preview>,
 }
 
@@ -121,6 +133,7 @@ impl SelectItem {
             prefix: None,
             value: None,
             color: None,
+            tints: Vec::new(),
             preview: None,
         }
     }
@@ -132,6 +145,7 @@ impl SelectItem {
             prefix: None,
             value: Some(value.into()),
             color: None,
+            tints: Vec::new(),
             preview: None,
         }
     }
@@ -153,6 +167,12 @@ impl SelectItem {
         self
     }
 
+    /// Colour individual columns of the label. See [`Tint`].
+    pub fn tints(mut self, tints: Vec<Tint>) -> Self {
+        self.tints = tints;
+        self
+    }
+
     /// Show `preview` in the preview pane while this row is highlighted.
     pub fn preview(mut self, preview: Preview) -> Self {
         self.preview = Some(preview);
@@ -162,6 +182,50 @@ impl SelectItem {
 
 /// Colour of a [`SelectItem::prefix`]: ANSI 8, the terminal's own grey.
 const PREFIX_COLOR: u8 = 8;
+
+/// Recolour the character ranges in `tints`, leaving skim's match highlighting
+/// alone: a span drawn in anything but `base` is a character the query matched,
+/// and why the row is on screen at all outranks which column it sits in.
+fn tinted<'a>(line: Line<'a>, tints: &[Tint], base: Style) -> Line<'a> {
+    let color_at = |index: usize| {
+        tints
+            .iter()
+            .find(|tint| tint.range.contains(&index))
+            .map(|tint| tint.color)
+    };
+    let style = |color: Option<u8>| match color {
+        Some(color) => base.fg(Color::Indexed(color)),
+        None => base,
+    };
+
+    let mut out = Line::default();
+    let mut at = 0;
+    for span in line.spans {
+        let width = span.content.chars().count();
+        if span.style != base {
+            out.push_span(span);
+            at += width;
+            continue;
+        }
+        // One span per run of characters sharing a colour, rather than per
+        // character: a row is redrawn on every keystroke.
+        let mut run = String::new();
+        let mut color = None;
+        for (offset, ch) in span.content.chars().enumerate() {
+            let next = color_at(at + offset);
+            if next != color && !run.is_empty() {
+                out.push_span(Span::styled(std::mem::take(&mut run), style(color)));
+            }
+            color = next;
+            run.push(ch);
+        }
+        if !run.is_empty() {
+            out.push_span(Span::styled(run, style(color)));
+        }
+        at += width;
+    }
+    out
+}
 
 /// Bridges a [`SelectItem`] to skim.
 struct SkItem {
@@ -182,19 +246,25 @@ impl SkimItem for SkItem {
             context.base_style = context.base_style.fg(Color::Indexed(idx));
         }
 
+        let base = context.base_style;
+        let mut line = context.to_line(self.text());
+        if !self.item.tints.is_empty() {
+            line = tinted(line, &self.item.tints, base);
+        }
+
         let Some(prefix) = &self.item.prefix else {
-            return context.to_line(self.text());
+            return line;
         };
 
         // Prepended as a span rather than folded into the label, so
         // `to_line`'s highlight positions still index the matched text.
-        let mut line = Line::default();
-        line.push_span(Span::styled(
+        let mut out = Line::default();
+        out.push_span(Span::styled(
             prefix.clone(),
             Style::default().fg(Color::Indexed(PREFIX_COLOR)),
         ));
-        line.spans.extend(context.to_line(self.text()).spans);
-        line
+        out.spans.extend(line.spans);
+        out
     }
 
     fn preview(&self, _context: PreviewContext) -> ItemPreview {
@@ -693,6 +763,54 @@ mod tests {
     fn an_item_without_a_prefix_is_unchanged() {
         let line = rendered(SelectItem::plain("git status"), vec![]);
         assert_eq!(text_of(&line), "git status");
+    }
+
+    /// The characters drawn in `color`, wherever the renderer put them.
+    fn painted(line: &Line, color: u8) -> String {
+        line.spans
+            .iter()
+            .filter(|s| s.style.fg == Some(Color::Indexed(color)))
+            .map(|s| s.content.as_ref())
+            .collect()
+    }
+
+    #[test]
+    fn a_tint_colours_its_range_and_nothing_else() {
+        let item = SelectItem::plain("✓ billing-api  private").tints(vec![
+            Tint {
+                range: 0..1,
+                color: 2,
+            },
+            Tint {
+                range: 15..22,
+                color: 3,
+            },
+        ]);
+        let line = rendered(item, vec![]);
+        assert_eq!(text_of(&line), "✓ billing-api  private");
+        assert_eq!(painted(&line, 2), "✓");
+        assert_eq!(painted(&line, 3), "private");
+    }
+
+    /// A tinted column that the query hit is still shown as matched: the
+    /// highlight says why the row survived the search, which the colour of the
+    /// column it happens to sit in must not paint over.
+    #[test]
+    fn match_highlighting_survives_a_tint() {
+        let item = SelectItem::plain("✓ billing-api  private").tints(vec![Tint {
+            range: 15..22,
+            color: 3,
+        }]);
+        // Character 15: the `p` of `private`.
+        let line = rendered(item, vec![15]);
+        assert_eq!(painted(&line, 1), "p", "{line:?}");
+        assert_eq!(painted(&line, 3), "rivate", "{line:?}");
+    }
+
+    #[test]
+    fn an_item_without_tints_is_unchanged() {
+        let line = rendered(SelectItem::plain("git status"), vec![]);
+        assert_eq!(line.spans.len(), 1, "{line:?}");
     }
 
     #[test]


### PR DESCRIPTION
- Only the visibility word is tinted now — yellow private, magenta internal. The row keeps the terminal's foreground.
- An already-cloned repository is marked with a green tick and is no longer greyed out.
- The last-push date is a column before the description.
- The preview pane is gone from that selector; everything it held is a column.

`SelectItem::color` sets skim's base style for the whole line, so `select::Tint` names a character range of the label instead. A span skim drew in the matched style is left alone, so match highlighting still wins inside a tinted column.

CHANGELOG under `## Unreleased`, and the `repo clone` help in `src/main.rs` no longer describes greyed rows. No `make demo`: the tape does not record `repo clone`.