### PR TITLE
Exempt Markdown-only commits from the branch requirement

### DIFF
--- a/.claude/hooks/no-commit-on-main.sh
+++ b/.claude/hooks/no-commit-on-main.sh
@@ -26,14 +26,35 @@ cwd=$(printf '%s' "$input" | jq -r '.cwd // empty' 2>/dev/null)
 branch=$(git -C "$cwd" rev-parse --abbrev-ref HEAD 2>/dev/null) || exit 0
 [ "$branch" = "main" ] || exit 0
 
+# CLAUDE.md's exception: a commit of nothing but Markdown may land on `main`.
+#
+# What the commit would contain is the staged set, plus every modified tracked
+# file when the command stages them itself. That flag is matched loosely — a
+# `-a` inside the message text matches too — because widening the set can only
+# ever refuse a commit this hook would otherwise have allowed. An amend is
+# never markdown-only: it carries whatever the commit it rewrites carried.
+paths=$(git -C "$cwd" diff --cached --name-only 2>/dev/null)
+if printf '%s' "$command" | grep -Eq '(^|[[:space:]])(-[A-Za-z]*a[A-Za-z]*|--all)([[:space:]]|$)'; then
+	paths=$(printf '%s\n%s' "$paths" "$(git -C "$cwd" diff --name-only 2>/dev/null)")
+fi
+amends=$(printf '%s' "$command" | grep -Eq '(^|[[:space:]])--amend([[:space:]]|$)' && echo yes)
+
+# An empty set means nothing is staged and the paths are on the command line,
+# which this cannot see. Unprovable is refused, not waved through.
+if [ -z "${amends:-}" ] && [ -n "$(printf '%s' "$paths" | tr -d '[:space:]')" ] &&
+	! printf '%s\n' "$paths" | grep -v '^[[:space:]]*$' | grep -qv '\.md$'; then
+	exit 0
+fi
+
 cat >&2 <<'EOF'
 Refusing: HEAD is `main`, and this commit would land on it directly.
 
 CLAUDE.md: "Never commit straight to `main`. The pull request is what leaves a
 reviewable record of work nobody watched happen."
 
-Put the work on a branch first. Anything larger than a one-line fix gets its
-own worktree:
+Only a commit whose every staged path ends in `.md` is exempt, and this one
+does not qualify — stage the Markdown on its own, or put the work on a branch.
+Anything larger than a one-line fix gets its own worktree:
 
     git worktree add .claude/worktrees/<name> -b <name>
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,7 @@ Three checked-in guards, none a substitute for `make`: `hooks/rustfmt.sh`
 formats each Rust file as written, `hooks/no-commit-on-main.sh` refuses the
 agent a commit on `main`, and `prek.toml` refuses git the same, plus hygiene and
 `make fmt-check` on commit and `make check` on push (`make hooks`, per clone).
+Both `main` guards let a Markdown-only commit through — see below.
 
 ## Shipping without being asked
 
@@ -58,10 +59,17 @@ that command, silently. `dist init` also rewrites `dist-workspace.toml`,
 replacing every comment with a canned one of its own, so the prose explaining
 why each key is set has to be put back by hand afterwards.
 
-Never commit straight to `main`. Stop and say so rather than merging when the
-change could not actually be verified, a test was deleted rather than replaced,
-a real cost is unnamed in the PR body, or the work rewrites pushed history,
-touches CI secrets, or publishes the crate.
+Never commit straight to `main`, with one exception: a commit whose every path
+ends in `.md` may be committed and pushed to `main` directly. Nothing CI builds
+reads those files, so a pull request over them buys a review nobody gives and a
+wait on two jobs that cannot fail differently. Both guards below know the
+exception; a commit that touches one Rust file alongside ten Markdown ones is
+not one and is still refused.
+
+Stop and say so rather than merging when the change could not actually be
+verified, a test was deleted rather than replaced, a real cost is unnamed in
+the PR body, or the work rewrites pushed history, touches CI secrets, or
+publishes the crate.
 
 ## Four docs nothing checks
 

--- a/README.md
+++ b/README.md
@@ -9,10 +9,13 @@
 
 Provides fuzzy-completion for various local and remote resources.
 
-One selector over the things you reach for all day: repositories, tracked
-files, branches, worktrees, GitHub pull requests, running processes and shell
-history. The finder is compiled in, so a selection is one process rather than a
-pipeline, and `scriv init fish` puts the common ones on a key.
+A single fuzzy selector over resources that would otherwise each need their own
+command and output parser: Git repositories, tracked files, branches,
+worktrees, GitHub pull requests, system processes and fish history. Each group
+lists its set, selects from it, and acts on the selection.
+
+The finder is linked into the binary — no `fzf` dependency and no subprocess.
+`scriv init fish` emits shell functions, key bindings and completions.
 
 ![scriv: check out a remote branch, find and open a file, list pull requests](docs/demo.gif)
 
@@ -22,18 +25,20 @@ pipeline, and `scriv init fish` puts the common ones on a key.
 curl --proto '=https' --tlsv1.2 -LsSf https://github.com/joakimen/scriv/releases/latest/download/scriv-installer.sh | sh
 ```
 
-The script puts the binary in `~/.local/bin` and adds that to your `PATH`. Two
-other ways in, resolving the same release archive or building it yourself:
+The script installs into `~/.local/bin` and adds it to `PATH`. Alternatively,
+through a version manager or from source:
 
 ```sh
 mise use -g github:joakimen/scriv
 cargo install --git https://github.com/joakimen/scriv
 ```
 
-macOS on Apple Silicon, and nothing else — the signal table `scriv proc` uses
-is Darwin's. `git` is required. `gh` is needed by `pr` and by `repo
-clone`/`open`, fish's history file by `history`, and `$VISUAL` or `$EDITOR` by
-`edit`; `scriv config check` reports on each.
+Supported platform: macOS on Apple Silicon. `scriv proc` depends on Darwin's
+signal numbers, and the crate refuses to compile for any other target.
+
+External requirements: `git`, plus `gh` for `pr` and `repo clone`/`open`, a
+fish history file for `history`, and `$VISUAL` or `$EDITOR` for `edit`.
+`scriv config check` reports on each.
 
 ## Setup
 
@@ -43,9 +48,9 @@ scriv init fish | source   # helpers, key bindings, completions
 scriv config check         # confirm it all resolves
 ```
 
-Put the middle line in `~/.config/fish/config.fish` to keep it. The bindings
-arrive as a function rather than bound at source time, so they compose with
-fish's own lifecycle — call it yourself to switch them on:
+Add the second line to `~/.config/fish/config.fish` to make it permanent. Key
+bindings are emitted as a function rather than bound at source time, so they
+compose with fish's binding lifecycle; call it from `fish_user_key_bindings`:
 
 ```fish
 function fish_user_key_bindings
@@ -53,9 +58,8 @@ function fish_user_key_bindings
 end
 ```
 
-Every setting is a commented line in the file `config init` writes. The one
-that matters is the root your repositories live under, laid out `<owner>/<repo>`
-as GitHub itself is:
+`config init` writes every setting as a commented line. `repo.root` is the one
+that must be set: repositories are located at `<root>/<owner>/<repo>`.
 
 ```toml
 [repo]
@@ -79,9 +83,10 @@ ignore = ["node_modules", "target"]
 | `scriv config` | `init` `print` `path` `check` |
 | `scriv init` | `fish` and every other shell — see Setup |
 
-`ls` prints the set, `sel` fuzzy-selects one line of it, and the other verbs
-act. Every `sel` composes: `cd (scriv repo sel)`. Each group takes a one-letter
-abbreviation — `r`, `f`, `b`, `w`, `e`, `h`, `c`, and `pc` for `proc`.
+`ls` prints the set, `sel` fuzzy-selects one entry, and the remaining verbs act
+on the selection. `sel` prints to stdout and composes: `cd (scriv repo sel)`.
+Groups abbreviate to one letter — `r`, `f`, `b`, `w`, `e`, `h`, `c`, and `pc`
+for `proc`.
 
 ## Key bindings
 
@@ -90,7 +95,7 @@ abbreviation — `r`, `f`, `b`, `w`, `e`, `h`, `c`, and `pc` for `proc`.
 | Key | Action |
 | --- | --- |
 | `ctrl-o` | `cd` to a repository |
-| `ctrl-t` | `cd` to a worktree of the one you are in |
+| `ctrl-t` | `cd` to a worktree of the current repository |
 | `ctrl-g` | check out a branch |
 | `ctrl-r` | search shell history onto the command line |
 | `up` | the same, on the first line of a prompt |
@@ -98,10 +103,11 @@ abbreviation — `r`, `f`, `b`, `w`, `e`, `h`, `c`, and `pc` for `proc`.
 | `f3` | open a tracked file in `$EDITOR` |
 | `f7` | check out a pull request |
 
-Two functions come with them: `fe` for `scriv edit`, arguments passed through,
-and `kl` for `scriv proc kill --force`.
+`scriv init fish` also defines `fe` (`scriv edit`, arguments passed through) and
+`kl` (`scriv proc kill --force`).
 
-`scriv --help` covers the flags, the generated `config.toml` the settings.
+Flags are documented in `scriv --help`, settings in the generated
+`config.toml`.
 
 ## Development
 

--- a/prek.toml
+++ b/prek.toml
@@ -22,13 +22,17 @@ repo = "local"
 
 # CLAUDE.md forbids committing to main, and `.claude/hooks/no-commit-on-main.sh`
 # only refuses the agent. This refuses git.
+#
+# `exclude` is what implements CLAUDE.md's exception for Markdown: with no
+# `always_run`, a hook runs only when a staged file matches its filter, so a
+# commit of nothing but `.md` files leaves this one with nothing to run on.
 [[repos.hooks]]
 id = "no-commit-on-main"
 name = "commits go on a branch, not main"
-entry = "sh -c 'test \"$(git branch --show-current)\" != main || { echo \"On main. Branch first: git switch -c <name>\" >&2; exit 1; }'"
+entry = "sh -c 'test \"$(git branch --show-current)\" != main || { echo \"On main with a non-Markdown change. Branch first: git switch -c <name>\" >&2; exit 1; }'"
 language = "system"
 stages = ["pre-commit"]
-always_run = true
+exclude = "\\.md$"
 pass_filenames = false
 
 # The first thing `make` runs, and the cheapest: a fraction of a second against


### PR DESCRIPTION
A commit whose every path ends in `.md` may now be committed and pushed to `main` directly. Nothing CI builds reads those files.

- `prek.toml` drops `always_run` and excludes `\.md$`, so the hook is skipped when no other file is staged.
- The agent's PreToolUse hook allows the commit only when every staged path is Markdown. An amend is refused outright; nothing staged is refused too, since the paths are then on the command line where the hook cannot see them.
- CLAUDE.md states the exception and that a mixed commit is not one.

Both guards were exercised against throwaway repositories: markdown-only allowed, markdown plus a Rust file blocked, `--amend` blocked, `-a` picking up a non-Markdown file blocked, a branch unaffected. No test harness is checked in for that — the repo has nowhere for shell tests to live, and one target for a twenty-line hook is not worth the machinery.

The README prose is rewritten in the same pass: the opening paragraph stated what a reader's day was like rather than what the tool does, and Install, Setup and the table captions had the same register. The *Releasing* section is untouched.

No CHANGELOG entry and no `make demo`: docs, `prek.toml` and a hook only.