### PR TITLE
Open the branch's pull request, or the list, on f2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ raised, never by hand.
 
 ## Unreleased
 
+### Added
+
+- `scriv pr open --current` opens the pull request for the branch you have
+  checked out, and the repository's pull request list when it has none. In
+  fish, f2 does it.
+
 ### Changed
 
 - `scriv repo clone` shows the date each repository was last pushed to, as a

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ for `proc`.
 | `ctrl-r` | search shell history onto the command line |
 | `up` | the same, on the first line of a prompt |
 | `f1` | open a repository on GitHub |
+| `f2` | open this branch's pull request, or the list if it has none |
 | `f3` | open a tracked file in `$EDITOR` |
 | `f7` | check out a pull request |
 

--- a/src/cmd/pr.rs
+++ b/src/cmd/pr.rs
@@ -10,6 +10,7 @@ use anyhow::{Result, bail};
 
 use crate::Ctx;
 use crate::gh::{self, MergeMethod, PullRequest};
+use crate::git;
 use crate::select::{self, Preview, SelectItem};
 use crate::term;
 
@@ -328,7 +329,16 @@ pub fn checkout(ctx: &Ctx, number: Option<u64>, state: &str, limit: usize) -> Re
 
 /// `scriv pr open [number]` — open a pull request in the browser, selecting one
 /// when no number is given.
-pub fn open(ctx: &Ctx, number: Option<u64>, state: &str, limit: usize) -> Result<()> {
+pub fn open(
+    ctx: &Ctx,
+    number: Option<u64>,
+    current: bool,
+    state: &str,
+    limit: usize,
+) -> Result<()> {
+    if current {
+        return open_current(ctx);
+    }
     let number = resolve(
         ctx,
         number,
@@ -338,6 +348,45 @@ pub fn open(ctx: &Ctx, number: Option<u64>, state: &str, limit: usize) -> Result
         Tint::State,
     )?;
     gh::view_web(number)
+}
+
+/// `scriv pr open --current` — open the pull request for the checked-out
+/// branch, falling back to the repository's pull request list when it has none.
+///
+/// The fallback is the point of the flag: a branch either has a pull request or
+/// is a branch you are about to open one from, and both answers are a page in
+/// the browser rather than a question to answer. A detached HEAD has no branch
+/// at all, and takes the same fallback.
+fn open_current(ctx: &Ctx) -> Result<()> {
+    git::ensure_repo()?;
+
+    let branch = git::current_branch();
+    let number = match &branch {
+        Some(branch) => {
+            let _spinner = term::spinner("looking for this branch's pull request", ctx.color());
+            gh::pr_for_branch(branch)?
+        }
+        None => None,
+    };
+
+    match number {
+        Some(number) => {
+            ctx.log
+                .info(&format!("pull request #{number} for this branch"));
+            gh::view_web(number)
+        }
+        None => {
+            // Said out loud: the browser opens either way, and without this the
+            // list page looks like the pull request the binding was asked for.
+            match &branch {
+                Some(branch) => {
+                    eprintln!("note: no pull request from `{branch}`; opening the list")
+                }
+                None => eprintln!("note: HEAD is detached; opening the pull request list"),
+            }
+            gh::list_web()
+        }
+    }
 }
 
 /// `scriv pr merge [number]` — merge a pull request, selecting one when no

--- a/src/gh.rs
+++ b/src/gh.rs
@@ -489,6 +489,44 @@ pub fn view_web(number: u64) -> Result<()> {
     run(&["pr", "view", "--web", &number.to_string()])
 }
 
+/// Open the repository's pull request list in the browser.
+pub fn list_web() -> Result<()> {
+    run(&["pr", "list", "--web"])
+}
+
+/// The most recent pull request opened from `branch`, in any state, or `None`
+/// when GitHub has none.
+///
+/// State is deliberately unfiltered: a branch whose pull request has merged
+/// still has one, and it is the page a reader asking about that branch wants.
+///
+/// The number is asked for rather than derived from `gh pr view`'s own notion
+/// of the current branch, so one query decides both whether a pull request
+/// exists and which it is — two answers that must not be able to disagree.
+pub fn pr_for_branch(branch: &str) -> Result<Option<u64>> {
+    let out = capture(&[
+        "pr",
+        "list",
+        "--head",
+        branch,
+        "--state",
+        "all",
+        "--limit",
+        "1",
+        "--json",
+        "number",
+        "--jq",
+        ".[0].number",
+    ])?;
+    let out = out.trim();
+    if out.is_empty() {
+        return Ok(None);
+    }
+    out.parse()
+        .map(Some)
+        .with_context(|| format!("gh returned `{out}` as the pull request number for {branch}"))
+}
+
 /// How to merge a pull request. `None` at the call site leaves the choice to
 /// `gh`, which asks.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/git.rs
+++ b/src/git.rs
@@ -498,6 +498,25 @@ pub fn repo_root() -> Option<PathBuf> {
     (!root.is_empty()).then(|| PathBuf::from(root))
 }
 
+/// The branch the working directory has checked out.
+///
+/// `None` on a detached HEAD, where `rev-parse` answers with the literal
+/// `HEAD`: there is no branch, and so nothing a pull request could be opened
+/// from. Absence is an answer rather than an error, as in [`repo_root`].
+pub fn current_branch() -> Option<String> {
+    let output = Command::new("git")
+        .args(["rev-parse", "--abbrev-ref", "HEAD"])
+        .stdin(Stdio::null())
+        .stderr(Stdio::null())
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let branch = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    (!branch.is_empty() && branch != "HEAD").then_some(branch)
+}
+
 /// Every branch in the repository, ordered by [`by_relevance`]: the current
 /// branch, then local branches, then remote-only ones, newest first within
 /// each.

--- a/src/main.rs
+++ b/src/main.rs
@@ -432,6 +432,13 @@ enum PrCmd {
     Open {
         /// Pull request number
         number: Option<u64>,
+        /// Open the pull request for the checked-out branch, without asking
+        ///
+        /// A branch with none opens the repository's pull request list
+        /// instead, which is also what a detached HEAD gets. The fish
+        /// integration binds this to f2.
+        #[arg(long, conflicts_with_all = ["number", "state", "limit"])]
+        current: bool,
         #[command(flatten)]
         scope: PrScope,
     },
@@ -626,7 +633,11 @@ fn run(cli: Cli) -> anyhow::Result<()> {
             PrCmd::Checkout { number, scope } => {
                 cmd::pr::checkout(&ctx, number, &scope.state, scope.limit)
             }
-            PrCmd::Open { number, scope } => cmd::pr::open(&ctx, number, &scope.state, scope.limit),
+            PrCmd::Open {
+                number,
+                current,
+                scope,
+            } => cmd::pr::open(&ctx, number, current, &scope.state, scope.limit),
             PrCmd::Merge {
                 number,
                 method,

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -112,6 +112,12 @@ function scriv-pr-checkout --description "Select a GitHub pull request and check
     command scriv pr checkout
 end
 
+# The one pull request binding that asks nothing: whatever this branch is, it
+# either has a pull request or it does not, and both are a page.
+function scriv-pr-open --description "Open this branch's pull request, or the list"
+    command scriv pr open --current
+end
+
 # History is the one selector whose result belongs on the command line, which
 # only the shell can write to.
 #
@@ -143,10 +149,10 @@ end
 # `history-pager`, ctrl-t over `transpose-chars` — swapping the two characters
 # around the cursor, which is worth less than a jump between worktrees — and up
 # over `up-line`, which scriv-history-up hands back wherever the selector would
-# be wrong. ctrl-p/ctrl-n are deliberately left as `up-line`/`down-line`. f1, f3
-# and f7 displace nothing; f4 and f5 are skipped because users' own tools cluster
-# there. alt-<letter> is not free: fish presets alt-b, alt-e, alt-o and alt-p
-# among others.
+# be wrong. ctrl-p/ctrl-n are deliberately left as `up-line`/`down-line`. f1, f2,
+# f3 and f7 displace nothing; f4 and f5 are skipped because users' own tools
+# cluster there. alt-<letter> is not free: fish presets alt-b, alt-e, alt-o and
+# alt-p among others.
 #
 # Rebind by calling `bind` yourself after `scriv_key_bindings`; the last binding
 # for a key wins.
@@ -158,6 +164,7 @@ function scriv_key_bindings --description "Bind scriv selectors to keys"
     bind ctrl-o "scriv-run-as-command scriv-repo-cd"
     bind ctrl-t "scriv-run-as-command scriv-worktree-cd"
     bind f1     "scriv-run-as-command scriv-repo-open"
+    bind f2     "scriv-run-as-command scriv-pr-open"
     bind f3     "scriv-run-as-command scriv-file-edit"
     bind ctrl-g "scriv-run-as-command scriv-branch-checkout"
     bind f7     "scriv-run-as-command scriv-pr-checkout"
@@ -188,6 +195,7 @@ mod tests {
         assert!(out.contains("function kl"));
         assert!(out.contains("function scriv-branch-checkout"));
         assert!(out.contains("function scriv-pr-checkout"));
+        assert!(out.contains("function scriv-pr-open"));
         assert!(out.contains("function scriv-history-select"));
         assert!(out.contains("function scriv-history-up"));
         assert!(out.contains("function scriv_key_bindings"));
@@ -200,6 +208,7 @@ mod tests {
         assert!(out.contains("bind ctrl-o"));
         assert!(out.contains("bind ctrl-t"));
         assert!(out.contains("bind f1"));
+        assert!(out.contains("bind f2"));
         assert!(out.contains("bind f3"));
         assert!(out.contains("bind f7"));
         assert!(out.contains("bind ctrl-g"));
@@ -301,7 +310,7 @@ mod tests {
     #[test]
     fn bindings_that_produce_output_run_through_the_command_line() {
         let out = integration(Shell::Fish, &mut dummy());
-        for key in ["ctrl-o", "ctrl-t", "f1", "f3", "ctrl-g", "f7"] {
+        for key in ["ctrl-o", "ctrl-t", "f1", "f2", "f3", "ctrl-g", "f7"] {
             let bind = binding_for(&out, key);
             assert!(
                 bind.contains("scriv-run-as-command"),

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -288,6 +288,39 @@ fn edit_dir_opens_the_directories_it_is_given() {
     assert_eq!(run.stdout.trim(), "-- src tests");
 }
 
+/// The branch's pull request is a different question from "which pull
+/// request?", so the two spellings must not both be answerable at once.
+#[test]
+fn pr_open_current_and_a_number_are_different_questions() {
+    let sandbox = Sandbox::new();
+    let run = sandbox.run(&["pr", "open", "--current", "42"]);
+    run.code(2);
+    assert!(run.stderr.contains("cannot be used with"), "{}", run.stderr);
+}
+
+/// `--state` and `--limit` narrow a list this flag never asks for.
+#[test]
+fn pr_open_current_refuses_the_flags_it_would_ignore() {
+    let sandbox = Sandbox::new();
+    for scope in [&["--state", "all"][..], &["--limit", "5"][..]] {
+        let mut args = vec!["pr", "open", "--current"];
+        args.extend_from_slice(scope);
+        sandbox.run(&args).code(2);
+    }
+}
+
+#[test]
+fn pr_open_current_outside_a_repository_says_so() {
+    let sandbox = Sandbox::new();
+    let run = sandbox.run(&["pr", "open", "--current"]);
+    run.code(1);
+    assert!(
+        run.stderr.contains("not inside a git repository"),
+        "{}",
+        run.stderr
+    );
+}
+
 #[test]
 fn every_registry_exposes_sel() {
     let sandbox = Sandbox::new();


### PR DESCRIPTION
Release: minor

- `scriv pr open --current` opens the pull request for the checked-out branch, or the repository's pull request list when it has none.
- f2 in fish runs it. It displaces nothing.
- The number comes from `gh pr list --head`, so one query decides both whether a pull request exists and which it is.
- State is unfiltered: a branch whose pull request has merged still has one.
- The fallback prints a note on stderr, since a list page arriving silently reads as the pull request that was asked for.
- `--current` refuses `--state` and `--limit` rather than accepting flags it would ignore.

Verified against this repository: a branch with a merged pull request opened `/pull/106`, a branch with none and a detached HEAD both opened `/pulls`, and outside a repository it exits 1.

CHANGELOG under `## Unreleased`, README key table, and the `--current` doc comment in `src/main.rs`. No `make demo`: no selector draws differently.