### PR TITLE
Buffer listings, spawn git once for worktrees, defer the directory preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ raised, never by hand.
 
 ## Unreleased
 
+### Changed
+
+- Listings write in blocks rather than a line at a time, which halves
+  `scriv history ls` over a long fish history.
+- `scriv worktree` asks git one question fewer, taking about a quarter off how
+  long ctrl-t takes to open.
+- `scriv edit dir` no longer builds a preview command for every directory it
+  finds, only for the one you are looking at — the walk of a large tree stays
+  flat rather than growing a pane per row.
+
 ## v0.7.0
 
 *Released 2026-08-17*

--- a/src/cmd/branch.rs
+++ b/src/cmd/branch.rs
@@ -83,7 +83,7 @@ pub fn ls(ctx: &Ctx, filter: Filter, status: bool, fetch: bool) -> Result<()> {
                 break;
             }
         }
-        return Ok(());
+        return Ok(out.finish()?);
     }
 
     let width = name_width(&branches);
@@ -101,6 +101,7 @@ pub fn ls(ctx: &Ctx, filter: Filter, status: bool, fetch: bool) -> Result<()> {
             break;
         }
     }
+    out.finish()?;
     Ok(())
 }
 
@@ -153,8 +154,12 @@ fn select(ctx: &Ctx, branches: Vec<Branch>, filter: Filter, prompt: &str) -> Res
     let reload = {
         let (known, failure) = (Arc::clone(&known), Arc::clone(&failure));
         Box::new(move || {
+            // Fetched outside the lock: it is a network round trip, and holding
+            // the list for it would make a second ctrl-r — or closing the
+            // selector — wait on the remote rather than on the list.
+            let fresh = git::fetch().and_then(|()| git::branches());
             let mut known = known.lock().expect("branch list poisoned");
-            match git::fetch().and_then(|()| git::branches()) {
+            match fresh {
                 Ok(fresh) => *known = fresh,
                 Err(err) => {
                     *failure.lock().expect("failure slot poisoned") = Some(format!("{err:#}"))

--- a/src/cmd/config.rs
+++ b/src/cmd/config.rs
@@ -464,6 +464,7 @@ pub fn check(ctx: &Ctx) -> Result<()> {
             return Ok(());
         }
     }
+    out.finish()?;
 
     let failed = failures(&checks);
     if failed > 0 {

--- a/src/cmd/edit.rs
+++ b/src/cmd/edit.rs
@@ -15,7 +15,7 @@ use std::process::Command;
 use anyhow::{Result, anyhow, bail};
 
 use crate::path::{display_path, expand_tilde};
-use crate::select::{Preview, SelectItem, dir_preview, file_preview};
+use crate::select::{Preview, SelectItem, file_preview};
 use crate::{Ctx, Reported, files, select, walk};
 
 /// `scriv edit file [FILE]...` — open `paths`, or select interactively when
@@ -80,11 +80,10 @@ fn select_files(ctx: &Ctx) -> Result<Option<Vec<String>>> {
 
 /// Choose directories from the current directory tree.
 ///
-/// [`select_files`] over [`walk::dirs`], with the preview built per row: `bat`
-/// on a directory is an error message.
+/// [`select_files`] over [`walk::dirs`], previewing what is inside each one:
+/// `bat` on a directory is an error message.
 fn select_dirs(ctx: &Ctx) -> Result<Option<Vec<String>>> {
-    let items =
-        walk::dirs(Path::new(".")).map(|dir| SelectItem::plain(&dir).preview(dir_preview(&dir)));
+    let items = walk::dirs(Path::new(".")).map(|dir| SelectItem::plain(dir).preview(Preview::Dir));
 
     cancellable(select::select_many_streamed(
         items,

--- a/src/cmd/file.rs
+++ b/src/cmd/file.rs
@@ -23,7 +23,7 @@ pub fn ls(ctx: &Ctx, status: bool, missing: bool, exists: bool) -> Result<()> {
                 break;
             }
         }
-        return Ok(());
+        return Ok(out.finish()?);
     }
 
     let use_color = status && ctx.color();
@@ -48,6 +48,7 @@ pub fn ls(ctx: &Ctx, status: bool, missing: bool, exists: bool) -> Result<()> {
             break;
         }
     }
+    out.finish()?;
     Ok(())
 }
 
@@ -84,6 +85,9 @@ pub fn prune(ctx: &Ctx, yes: bool) -> Result<()> {
             return Ok(());
         }
     }
+    // Emptied before the question is put: "remove 4 entries?" is answerable
+    // only by someone who has already seen the four.
+    out.finish()?;
 
     match term::Confirm::resolve(yes) {
         term::Confirm::Assumed => {}

--- a/src/cmd/history.rs
+++ b/src/cmd/history.rs
@@ -86,6 +86,7 @@ pub fn ls(ctx: &Ctx, status: bool) -> Result<()> {
             break;
         }
     }
+    out.finish()?;
     Ok(())
 }
 

--- a/src/cmd/pr.rs
+++ b/src/cmd/pr.rs
@@ -125,6 +125,7 @@ pub fn ls(ctx: &Ctx, state: &str, limit: usize, status: bool) -> Result<()> {
             break;
         }
     }
+    out.finish()?;
     Ok(())
 }
 

--- a/src/cmd/proc.rs
+++ b/src/cmd/proc.rs
@@ -65,6 +65,7 @@ pub fn ls(ctx: &Ctx, status: bool) -> Result<()> {
             break;
         }
     }
+    out.finish()?;
     Ok(())
 }
 

--- a/src/cmd/repo.rs
+++ b/src/cmd/repo.rs
@@ -54,6 +54,7 @@ pub fn ls(ctx: &Ctx, absolute: bool) -> Result<()> {
             break;
         }
     }
+    out.finish()?;
     Ok(())
 }
 

--- a/src/cmd/worktree.rs
+++ b/src/cmd/worktree.rs
@@ -14,8 +14,10 @@ use crate::{Ctx, select, term};
 
 /// Every working tree of the current repository, in git's order.
 fn load(ctx: &Ctx) -> Result<Vec<Worktree>> {
-    git::ensure_repo()?;
-    let worktrees = git::worktrees()?;
+    // Both questions — is this a repository, and which tree is the shell in —
+    // out of the one `rev-parse`.
+    let here = git::require_repo_root()?;
+    let worktrees = git::worktrees(&here)?;
     ctx.log
         .info(&format!("found {} worktrees", worktrees.len()));
     if worktrees.is_empty() {
@@ -101,6 +103,7 @@ pub fn ls(ctx: &Ctx, absolute: bool, status: bool) -> Result<()> {
             break;
         }
     }
+    out.finish()?;
     Ok(())
 }
 

--- a/src/files.rs
+++ b/src/files.rs
@@ -45,11 +45,18 @@ pub fn write_lines(path: &Path, lines: &[String]) -> Result<()> {
 
     let tmp = dir.join(temp_name());
     let write_result = (|| -> Result<()> {
-        let mut file = fs::File::create(&tmp)
+        let file = fs::File::create(&tmp)
             .with_context(|| format!("creating temp file {}", tmp.display()))?;
+        // Buffered: an entry is one short line, and a `write` syscall each is a
+        // syscall per tracked file.
+        let mut out = std::io::BufWriter::new(file);
         for line in &normalized {
-            writeln!(file, "{line}").with_context(|| format!("writing to {}", tmp.display()))?;
+            writeln!(out, "{line}").with_context(|| format!("writing to {}", tmp.display()))?;
         }
+        let file = out
+            .into_inner()
+            .map_err(std::io::IntoInnerError::into_error)
+            .with_context(|| format!("writing to {}", tmp.display()))?;
         file.sync_all()
             .with_context(|| format!("flushing {}", tmp.display()))?;
         Ok(())

--- a/src/git.rs
+++ b/src/git.rs
@@ -423,16 +423,22 @@ pub fn mark_current(
         .collect()
 }
 
+/// A missing `git` is worth explaining; anything else is the spawn's own
+/// failure. Shared by every helper below, so one wording covers all of them.
+fn spawn_error(err: std::io::Error) -> anyhow::Error {
+    match err.kind() {
+        ErrorKind::NotFound => anyhow!("`git` was not found on PATH"),
+        _ => anyhow!(err).context("running git"),
+    }
+}
+
 /// Run git with `args`, capturing stdout.
 fn capture(args: &[&str]) -> Result<String> {
     let output = Command::new("git")
         .args(args)
         .stdin(Stdio::null())
         .output()
-        .map_err(|e| match e.kind() {
-            ErrorKind::NotFound => anyhow!("`git` was not found on PATH"),
-            _ => anyhow!(e).context("running git"),
-        })?;
+        .map_err(spawn_error)?;
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
         let stderr = stderr.trim();
@@ -453,10 +459,7 @@ fn passthrough(args: &[&str]) -> Result<()> {
     let status = Command::new("git")
         .args(args)
         .status()
-        .map_err(|e| match e.kind() {
-            ErrorKind::NotFound => anyhow!("`git` was not found on PATH"),
-            _ => anyhow!(e).context("running git"),
-        })?;
+        .map_err(spawn_error)?;
     if !status.success() {
         return Err(Reported(status.code().unwrap_or(1)).into());
     }
@@ -472,10 +475,7 @@ pub fn ensure_repo() -> Result<()> {
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .status()
-        .map_err(|e| match e.kind() {
-            ErrorKind::NotFound => anyhow!("`git` was not found on PATH"),
-            _ => anyhow!(e).context("running git"),
-        })?;
+        .map_err(spawn_error)?;
     if !inside.success() {
         bail!("not inside a git repository");
     }
@@ -485,17 +485,26 @@ pub fn ensure_repo() -> Result<()> {
 /// The root of the repository the working directory is in, if it is in one.
 /// Absence is an answer rather than an error.
 pub fn repo_root() -> Option<PathBuf> {
+    require_repo_root().ok()
+}
+
+/// [`repo_root`] where being outside a repository is a failure, with the same
+/// message [`ensure_repo`] gives.
+///
+/// One `rev-parse` answers both questions, so a command that needs the root
+/// does not also spawn git to be told it is in a repository at all.
+pub fn require_repo_root() -> Result<PathBuf> {
     let output = Command::new("git")
         .args(["rev-parse", "--show-toplevel"])
         .stdin(Stdio::null())
         .stderr(Stdio::null())
         .output()
-        .ok()?;
-    if !output.status.success() {
-        return None;
-    }
+        .map_err(spawn_error)?;
     let root = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    (!root.is_empty()).then(|| PathBuf::from(root))
+    if !output.status.success() || root.is_empty() {
+        bail!("not inside a git repository");
+    }
+    Ok(PathBuf::from(root))
 }
 
 /// The branch the working directory has checked out.
@@ -539,10 +548,14 @@ pub fn branches() -> Result<Vec<Branch>> {
 /// first, then the linked ones as they were added. The tree the working
 /// directory is in is marked rather than moved, since where you already are is
 /// rarely where you are going.
-pub fn worktrees() -> Result<Vec<Worktree>> {
+///
+/// `here` is the root of the tree the working directory is in — the caller has
+/// it from [`require_repo_root`], which is also what established there is a
+/// repository to list.
+pub fn worktrees(here: &Path) -> Result<Vec<Worktree>> {
     let out = capture(&["worktree", "list", "--porcelain"]).context("listing worktrees")?;
     let worktrees = parse_worktrees(&out);
-    Ok(mark_current(worktrees, repo_root().as_deref(), |path| {
+    Ok(mark_current(worktrees, Some(here), |path| {
         path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
     }))
 }

--- a/src/select.rs
+++ b/src/select.rs
@@ -52,6 +52,10 @@ pub enum Preview {
     /// a million rows, and a command string on each is megabytes of panes
     /// nobody looks at.
     File,
+    /// The row's own value, previewed as a directory. [`Preview::File`]'s
+    /// counterpart, and deferred for the same reason — the directory walk is
+    /// streamed too.
+    Dir,
 }
 
 /// Quote `arg` for the shell that runs a [`Preview::Command`], so a branch name
@@ -66,10 +70,11 @@ pub fn file_preview(path: &str) -> Preview {
     Preview::Command(file_preview_cmd(path))
 }
 
-/// The preview for a directory: what is directly inside it, capped at 200 rows.
-pub fn dir_preview(path: &str) -> Preview {
+/// The command behind [`Preview::Dir`]: what is directly inside the directory,
+/// capped at 200 rows.
+fn dir_preview_cmd(path: &str) -> String {
     let path = quote(path);
-    Preview::Command(format!("ls -Ap -- {path} 2>&1 | head -n 200"))
+    format!("ls -Ap -- {path} 2>&1 | head -n 200")
 }
 
 /// The preview for a git checkout — a repository or one of its worktrees: the
@@ -272,6 +277,7 @@ impl SkimItem for SkItem {
             Some(Preview::Text(text)) => ItemPreview::AnsiText(text.clone()),
             Some(Preview::Command(cmd)) => ItemPreview::Command(cmd.clone()),
             Some(Preview::File) => ItemPreview::Command(file_preview_cmd(self.item.value())),
+            Some(Preview::Dir) => ItemPreview::Command(dir_preview_cmd(self.item.value())),
             // Blank rather than `Global`, which would run the empty global
             // preview command.
             None => ItemPreview::Text(String::new()),
@@ -811,6 +817,43 @@ mod tests {
     fn an_item_without_tints_is_unchanged() {
         let line = rendered(SelectItem::plain("git status"), vec![]);
         assert_eq!(line.spans.len(), 1, "{line:?}");
+    }
+
+    /// A deferred preview carries nothing until the row is highlighted, and
+    /// then previews the row's *value* — a streamed walk yields paths relative
+    /// to where it started, which is where the pane's command runs.
+    #[test]
+    fn a_deferred_preview_builds_its_command_from_the_rows_value() {
+        let context = || PreviewContext {
+            query: "",
+            cmd_query: "",
+            width: 80,
+            height: 20,
+            current_index: 0,
+            selected_indices: &[],
+            selections: &[],
+            current_selection: "",
+        };
+
+        let file = SkItem {
+            item: SelectItem::new("shown", "src/main.rs").preview(Preview::File),
+        };
+        let ItemPreview::Command(cmd) = file.preview(context()) else {
+            panic!("a file preview must run a command");
+        };
+        assert!(cmd.contains("'src/main.rs'"), "{cmd}");
+
+        let dir = SkItem {
+            item: SelectItem::new("shown", "src/cmd").preview(Preview::Dir),
+        };
+        let ItemPreview::Command(cmd) = dir.preview(context()) else {
+            panic!("a directory preview must run a command");
+        };
+        assert!(
+            cmd.starts_with("ls "),
+            "a directory is listed, not read: {cmd}"
+        );
+        assert!(cmd.contains("'src/cmd'"), "{cmd}");
     }
 
     #[test]

--- a/src/term.rs
+++ b/src/term.rs
@@ -55,15 +55,21 @@ pub const NO_COLOR_ENV_VAR: &str = "SCRIV_NO_COLOR";
 /// Stdout for a listing, which ends quietly when the reader stops reading.
 /// `println!` panics on a closed pipe, so `scriv history ls | head` would end
 /// in a stack trace where every other command-line tool simply stops.
+///
+/// Rows are buffered rather than handed straight to the OS: `std::io::Stdout`
+/// is line-buffered whatever it is pointed at, so an unbuffered listing costs
+/// one `write` syscall per row — half the wall clock of `history ls` over a long
+/// fish history. What that buys is paid for by noticing a closed pipe a buffer
+/// late, as every other tool does.
 pub struct Listing<W: Write> {
     out: W,
     open: bool,
 }
 
-impl Listing<std::io::Stdout> {
-    /// The listing every `ls` command writes: stdout.
+impl Listing<std::io::BufWriter<std::io::Stdout>> {
+    /// The listing every `ls` command writes: stdout, buffered.
     pub fn stdout() -> Self {
-        Self::new(std::io::stdout())
+        Self::new(std::io::BufWriter::new(std::io::stdout()))
     }
 }
 
@@ -87,6 +93,33 @@ impl<W: Write> Listing<W> {
             }
             Err(e) => Err(e),
         }
+    }
+
+    /// Push out whatever is still buffered. Call it once the rows run out: a
+    /// buffered listing has written nothing yet at that point, and this is the
+    /// only place a write failure has anywhere to be reported.
+    ///
+    /// [`Drop`] flushes as well, so an early return still prints its rows — but
+    /// it can only discard the error, which is why this exists.
+    pub fn finish(mut self) -> std::io::Result<()> {
+        self.flush_open()
+    }
+
+    fn flush_open(&mut self) -> std::io::Result<()> {
+        if !self.open {
+            return Ok(());
+        }
+        self.open = false;
+        match self.out.flush() {
+            Err(e) if e.kind() == std::io::ErrorKind::BrokenPipe => Ok(()),
+            other => other,
+        }
+    }
+}
+
+impl<W: Write> Drop for Listing<W> {
+    fn drop(&mut self) {
+        let _ = self.flush_open();
     }
 }
 
@@ -561,6 +594,38 @@ mod tests {
                 "{kind:?} was treated as the reader going away"
             );
         }
+    }
+
+    /// A writer that takes every row and fails only when asked to flush,
+    /// standing in for a listing whose buffer reaches the pipe at the end.
+    struct FailsOnFlush(std::io::ErrorKind);
+
+    impl std::io::Write for FailsOnFlush {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Err(std::io::Error::from(self.0))
+        }
+    }
+
+    /// The rows are buffered, so the write that fails is the flush — and it is
+    /// the last chance anything has to say so.
+    #[test]
+    fn finishing_reports_a_failure_that_only_the_flush_could_find() {
+        let mut listing = super::Listing::new(FailsOnFlush(std::io::ErrorKind::StorageFull));
+        assert!(listing.line("one").unwrap());
+        assert_eq!(
+            listing.finish().unwrap_err().kind(),
+            std::io::ErrorKind::StorageFull
+        );
+    }
+
+    #[test]
+    fn finishing_stays_quiet_when_the_reader_has_already_gone() {
+        let mut listing = super::Listing::new(FailsOnFlush(std::io::ErrorKind::BrokenPipe));
+        assert!(listing.line("one").unwrap());
+        listing.finish().expect("a closed pipe is not a failure");
     }
 
     use super::*;


### PR DESCRIPTION
A performance and quality pass over the whole crate. Measured on this machine, release build.

- Listings wrote one `write` syscall per row, because `std::io::Stdout` is line-buffered whatever it is pointed at. Buffered: `history ls` over 25k commands goes 25.3ms to 11.7ms, `--status` 30ms to 17ms.
- `scriv worktree` asked git the same question twice — is this a repository, and where is its root. One `rev-parse` answers both: 25.5ms to 18ms, on a command bound to ctrl-t.
- `edit dir` built an `ls` command string for every directory in a streamed walk. Deferred to the highlighted row, as `Preview::File` already is.
- A ctrl-r in a branch selector held the shared list across `git fetch`. The pull request selector already does the opposite and documents why.
- The known-files list is written buffered too, and git.rs's three copies of the spawn-error mapping are one.

Costs: a closed pipe is now noticed a buffer late rather than a row late, so `scriv history ls | head` produces up to 8KB before it stops. `Listing::finish` exists so a write failure still has somewhere to be reported; `Drop` covers the early-return paths, where it does not.

`scriv proc ls` was the slowest listing at 62ms and is untouched: 56ms of it is `ps` itself, and replacing that with libproc is a different change.

Docs: CHANGELOG has the three user-felt lines. No command, flag or help text changed, so README and `--help` are as they were. Nothing changed what a selector draws — the directory pane runs the same command, just later — so `docs/demo.gif` stands.