### PR TITLE
Drop key presses from history, say what `pr` needs, check gh's login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,23 @@ raised, never by hand.
 
 ## Unreleased
 
+### Changed
+
+- `scriv history` no longer offers scriv's own key bindings back. Pressing
+  ctrl-o records `scriv-repo-cd` in fish's history, so the rows at the top of
+  ctrl-r were the keys you had just pressed rather than anything you typed.
+- `scriv pr` says it is not in a git repository itself, rather than passing on
+  `gh`'s report of git's `fatal: not a git repository`. `GH_REPO` still names a
+  repository to work on without one.
+- `scriv pr` says when a listing stopped at `--limit`, as `repo clone` already
+  did, so a missing pull request is not mistaken for one that is not there.
+- A missing `root` now points at the config file to edit when there is one, and
+  only sends you to `scriv config init` when there is not — that command refuses
+  to overwrite a config, so the old advice was a dead end.
+- `scriv config check` reports whether `gh` is still logged in. An expired token
+  breaks `pr` as completely as a missing `gh` does, and looked like nothing at
+  all. It is the one check that waits on the network.
+
 ## v0.7.1
 
 *Released 2026-08-17*

--- a/src/cmd/config.rs
+++ b/src/cmd/config.rs
@@ -7,7 +7,7 @@ use std::process::{Command, Stdio};
 use anyhow::{Context, Result, bail};
 
 use crate::path::expand_home_dir;
-use crate::{Ctx, files, history, repo, term};
+use crate::{Ctx, files, gh, history, repo, term};
 
 /// A commented starter config. Settings are grouped by the command that reads
 /// them; users edit it to taste.
@@ -266,6 +266,35 @@ fn tool_check(name: &'static str, program: &str, required: bool, note: &str) -> 
     }
 }
 
+/// What the `gh` row says when `gh` is not installed at all.
+const GH_NOTE: &str = "only `pr` and `repo clone`/`open` need it (https://cli.github.com)";
+
+/// What the `gh` row says once it is installed: which version, and whether it
+/// can act as anyone. An expired token fails `pr` exactly as completely as a
+/// missing binary does, which is why one row covers both — but neither stops
+/// the rest of scriv, so it is a warning.
+fn gh_state(version: &str, authenticated: bool) -> (Status, String) {
+    if authenticated {
+        (Status::Ok, format!("{version}, authenticated"))
+    } else {
+        (
+            Status::Warn,
+            format!("{version}, not authenticated — run `gh auth login`"),
+        )
+    }
+}
+
+/// `gh`: installed, and logged in. The login is asked of GitHub, which is the
+/// slowest thing in the report and the reason this is not a [`tool_check`].
+fn gh_check() -> Check {
+    if on_path("gh").is_none() {
+        return Check::warn("gh", format!("not on PATH — {GH_NOTE}"));
+    }
+    let version = version_of("gh").unwrap_or_else(|| "found".into());
+    let (status, detail) = gh_state(&version, gh::authenticated());
+    Check::new("gh", status, detail)
+}
+
 /// The config file itself: whether there is one, and where. Reaching this point
 /// means it parsed, so the only question left is whether one exists — and
 /// absent is a warning, since the known-files commands work without one.
@@ -375,7 +404,11 @@ fn history_check(ctx: &Ctx) -> Check {
         ),
         Err(e) => Check::fail("fish history", format!("{shown}: {e}")),
         Ok(data) => {
-            let entries = history::recent_first(history::parse(&String::from_utf8_lossy(&data)));
+            // The same list `history sel` offers, so the count is the one the
+            // selector will show rather than one that counts key presses.
+            let entries = history::recent_first(history::typed_only(history::parse(
+                &String::from_utf8_lossy(&data),
+            )));
             Check::ok(
                 "fish history",
                 format!("{} unique command(s) in {shown}", entries.len()),
@@ -428,12 +461,7 @@ fn collect(ctx: &Ctx) -> Vec<Check> {
         true,
         "`branch` and `repo` cannot work without it",
     ));
-    checks.push(tool_check(
-        "gh",
-        "gh",
-        false,
-        "only `pr` and `repo clone`/`open` need it (https://cli.github.com)",
-    ));
+    checks.push(gh_check());
     // `kill` gets no row: it ships in the same base system `ps` does.
     checks.push(tool_check(
         "ps",
@@ -562,6 +590,21 @@ mod tests {
         ];
         let column = |row: &str| row.rfind("  ").map(|i| i + 2);
         assert_eq!(column(&rows[0]), column(&rows[1]), "{rows:?}");
+    }
+
+    #[test]
+    fn an_unauthenticated_gh_is_a_warning_that_names_the_way_out() {
+        let (status, detail) = gh_state("gh version 2.97.0", false);
+        assert_eq!(status, Status::Warn, "a login nobody has is not fatal");
+        assert!(detail.contains("gh auth login"), "{detail}");
+        assert!(
+            detail.contains("2.97.0"),
+            "the version went missing: {detail}"
+        );
+
+        let (status, detail) = gh_state("gh version 2.97.0", true);
+        assert_eq!(status, Status::Ok);
+        assert!(!detail.contains("gh auth login"), "{detail}");
     }
 
     #[test]

--- a/src/cmd/history.rs
+++ b/src/cmd/history.rs
@@ -1,8 +1,9 @@
 //! `scriv history` — search the commands you have already run.
 //!
-//! The list is fish's own history file, newest first with repeats dropped.
-//! Selecting a command prints it rather than running it; the fish integration
-//! puts it back on the command line to be read before enter.
+//! The list is fish's own history file, newest first with repeats dropped and
+//! scriv's own key bindings left out. Selecting a command prints it rather than
+//! running it; the fish integration puts it back on the command line to be read
+//! before enter.
 
 use std::io::Write;
 
@@ -27,7 +28,9 @@ fn load(ctx: &Ctx) -> Result<Vec<Entry>> {
 
     // A history file holds whatever was typed at the shell, which is not
     // always valid UTF-8.
-    let entries = history::recent_first(history::parse(&String::from_utf8_lossy(&data)));
+    let entries = history::recent_first(history::typed_only(history::parse(
+        &String::from_utf8_lossy(&data),
+    )));
     if entries.is_empty() {
         anyhow::bail!("no commands in {}", path.display());
     }

--- a/src/cmd/pr.rs
+++ b/src/cmd/pr.rs
@@ -14,6 +14,22 @@ use crate::git;
 use crate::select::{self, Preview, SelectItem};
 use crate::term;
 
+/// Fail before `gh` does when there is no repository for it to be about.
+///
+/// `gh` works this out from the directory it runs in, and outside one reports
+/// git's own `fatal: not a git repository` — a sentence about git, from a
+/// command the user asked about pull requests. `GH_REPO` names a repository
+/// without a checkout, and is `gh`'s to act on, so it is left alone.
+fn ensure_target(ctx: &Ctx) -> Result<()> {
+    if ctx.gh_repo().is_some() || git::repo_root().is_some() {
+        return Ok(());
+    }
+    bail!(
+        "not inside a git repository — `pr` acts on the repository you are \
+         standing in, or the one `GH_REPO` names"
+    )
+}
+
 /// Fetch pull requests, failing with a useful message when there are none.
 fn collect(ctx: &Ctx, state: &str, limit: usize) -> Result<Vec<PullRequest>> {
     let prs = {
@@ -21,6 +37,11 @@ fn collect(ctx: &Ctx, state: &str, limit: usize) -> Result<Vec<PullRequest>> {
         gh::list(state, limit)?
     };
     ctx.log.info(&format!("found {} pull requests", prs.len()));
+    if prs.len() == limit {
+        // A full page is indistinguishable from a repository with exactly that
+        // many, so the filter names itself rather than quietly hiding the rest.
+        eprintln!("note: showing the first {limit} pull requests; pass --limit to raise it");
+    }
     if prs.is_empty() {
         // `--state all` would otherwise read "no all pull requests found".
         let scope = if state == "all" {
@@ -95,6 +116,7 @@ impl StatusColumns {
 /// The glyphs are shapes rather than colours, so a piped listing still says
 /// everything a coloured one does.
 pub fn ls(ctx: &Ctx, state: &str, limit: usize, status: bool) -> Result<()> {
+    ensure_target(ctx)?;
     let prs = collect(ctx, state, limit)?;
     let color = ctx.color();
     let width = number_width(&prs);
@@ -293,6 +315,7 @@ fn select(ctx: &Ctx, state: &str, limit: usize, prompt: &str, tint: Tint) -> Res
 /// `scriv pr sel` — fuzzy-select a pull request and print its number, so it
 /// composes with `gh`: `gh pr view (scriv pr sel)`.
 pub fn sel(ctx: &Ctx, state: &str, limit: usize) -> Result<()> {
+    ensure_target(ctx)?;
     let number = select(ctx, state, limit, "Select a pull request", Tint::State)?;
     println!("{number}");
     Ok(())
@@ -317,6 +340,7 @@ fn resolve(
 /// one when no number is given. The checkout itself is `gh pr checkout`, which
 /// handles fork PRs and sets the upstream.
 pub fn checkout(ctx: &Ctx, number: Option<u64>, state: &str, limit: usize) -> Result<()> {
+    ensure_target(ctx)?;
     let number = resolve(
         ctx,
         number,
@@ -337,6 +361,7 @@ pub fn open(
     state: &str,
     limit: usize,
 ) -> Result<()> {
+    ensure_target(ctx)?;
     if current {
         return open_current(ctx);
     }
@@ -406,6 +431,7 @@ pub fn merge(
     delete_branch: bool,
     auto: bool,
 ) -> Result<()> {
+    ensure_target(ctx)?;
     let number = resolve(
         ctx,
         number,

--- a/src/cmd/repo.rs
+++ b/src/cmd/repo.rs
@@ -15,13 +15,29 @@ use crate::repo::FoundRepo;
 use crate::select::{Choice, SelectItem, Tint};
 use crate::{Ctx, git, repo, select, term};
 
+/// What to say when there is nowhere to look for repositories. The two ways to
+/// arrive here need opposite advice, and telling someone who has just written a
+/// config to write one is how a first run stalls: `config init` refuses to
+/// overwrite the file it is being recommended for.
+fn no_root_message(config_path: &Path, config_exists: bool) -> String {
+    if config_exists {
+        format!(
+            "no `root` configured in {} — set `[repo] root` to the directory \
+             holding your <owner>/<repo> checkouts",
+            config_path.display()
+        )
+    } else {
+        format!(
+            "no configuration at {} — run `scriv config init` to write a starter one",
+            config_path.display()
+        )
+    }
+}
+
 /// Discover repositories, label-tagged and sorted by path.
 fn discover(ctx: &Ctx) -> Result<Vec<FoundRepo>> {
     if ctx.config.repo.root.is_none() && ctx.config.repo.extra.is_empty() {
-        anyhow::bail!(
-            "no `root` configured in {}; run `scriv config init` to create a starter config",
-            ctx.config_path.display()
-        );
+        anyhow::bail!(no_root_message(&ctx.config_path, ctx.config_path.exists()));
     }
     ctx.log.info(&format!(
         "settings: ignore = {}",
@@ -201,8 +217,8 @@ const PRESENT_COLOR: u8 = 2;
 fn clone_root(ctx: &Ctx) -> Result<PathBuf> {
     let root = ctx.config.repo.root.as_deref().ok_or_else(|| {
         anyhow::anyhow!(
-            "no `root` configured in {}; `repo clone` writes to <root>/<owner>/<repo>",
-            ctx.config_path.display()
+            "{} — `repo clone` writes to <root>/<owner>/<repo>",
+            no_root_message(&ctx.config_path, ctx.config_path.exists())
         )
     })?;
     Ok(expand_home_dir(root, ctx.home()))
@@ -742,6 +758,21 @@ mod tests {
         for item in repo_items(&repos(), tmp.path()) {
             assert!(item.preview.is_none(), "{} opens a pane", item.label);
         }
+    }
+
+    #[test]
+    fn the_advice_for_a_missing_root_depends_on_there_being_a_config() {
+        let path = Path::new("/home/u/.config/scriv/config.toml");
+
+        let written = no_root_message(path, true);
+        assert!(written.contains("[repo] root"), "{written}");
+        assert!(
+            !written.contains("config init"),
+            "advises a command that refuses to run: {written}"
+        );
+
+        let absent = no_root_message(path, false);
+        assert!(absent.contains("scriv config init"), "{absent}");
     }
 
     #[test]

--- a/src/gh.rs
+++ b/src/gh.rs
@@ -803,6 +803,22 @@ pub fn owners() -> Result<Vec<String>> {
     Ok(out)
 }
 
+/// Whether `gh` can act as someone on GitHub: `gh auth status` tests the stored
+/// token against the host, so this catches an expired or revoked one as well as
+/// no login at all.
+///
+/// A network round trip, and therefore for `config check` alone — nothing on a
+/// keystroke path may ask this.
+pub fn authenticated() -> bool {
+    Command::new("gh")
+        .args(["auth", "status", "--active"])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .is_ok_and(|status| status.success())
+}
+
 /// Run `gh` with the terminal attached, in the working directory scriv was
 /// invoked from. `gh` writes its own diagnostics, so a failure is [`Reported`].
 fn run(args: &[&str]) -> Result<()> {

--- a/src/history.rs
+++ b/src/history.rs
@@ -93,6 +93,25 @@ fn unescape(text: &str) -> String {
     out
 }
 
+/// Whether `cmd` is a call to one of the `scriv-` functions `scriv init fish`
+/// emits.
+///
+/// Pressing ctrl-o hands `scriv-repo-cd` to fish to run, so fish records it —
+/// see [`shell`](crate::shell). A key press is not something that was typed,
+/// and offering it back puts a row nobody can use at the top of the very
+/// selector the key opened. `fe` and `kl` are deliberately not among them:
+/// those are typed, and worth recalling.
+fn is_key_binding(cmd: &str) -> bool {
+    let cmd = cmd.trim();
+    cmd.starts_with("scriv-") && !cmd.contains(char::is_whitespace)
+}
+
+/// Drop the entries that are [`is_key_binding`] calls.
+pub fn typed_only(mut entries: Vec<Entry>) -> Vec<Entry> {
+    entries.retain(|entry| !is_key_binding(&entry.cmd));
+    entries
+}
+
 /// Newest first, with earlier runs of the same command dropped. The set holds
 /// borrowed commands: this runs on every ctrl-r over tens of thousands of
 /// entries, and cloning each one built a second copy of the whole history.
@@ -295,6 +314,31 @@ mod tests {
     #[test]
     fn an_empty_history_dedups_to_nothing() {
         assert!(recent_first(Vec::new()).is_empty());
+    }
+
+    #[test]
+    fn the_key_bindings_scriv_emits_are_not_offered_back() {
+        let entries = parse(
+            "- cmd: scriv-repo-cd\n  when: 3\n\
+             - cmd: scriv-history-select\n  when: 2\n\
+             - cmd: git status\n  when: 1\n",
+        );
+        let kept = typed_only(entries);
+        assert_eq!(
+            kept.iter().map(|e| e.cmd.as_str()).collect::<Vec<_>>(),
+            vec!["git status"]
+        );
+    }
+
+    /// The rule is "a bare call to a `scriv-` function", not "mentions scriv":
+    /// what the user typed at the prompt is theirs, however it starts.
+    #[test]
+    fn a_typed_command_survives_however_it_begins() {
+        let entries = parse(
+            "- cmd: scriv repo sel\n- cmd: fe -t\n- cmd: kl\n\
+             - cmd: scriv-repo-cd --help\n- cmd: scriv_key_bindings\n",
+        );
+        assert_eq!(typed_only(entries).len(), 5);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,6 +69,9 @@ pub struct Ctx {
     utc_offset: time::UtcOffset,
     /// The editor `scriv edit` launches, from the environment.
     editor: Option<String>,
+    /// `GH_REPO`, which names the repository `gh` acts on when the working
+    /// directory is not one.
+    gh_repo: Option<String>,
     /// Whether printed output carries colour, resolved once from `--color`,
     /// `SCRIV_NO_COLOR` and whether stdout is a terminal.
     color: bool,
@@ -132,6 +135,10 @@ impl Ctx {
             std::env::var("EDITOR").ok().as_deref(),
         );
 
+        let gh_repo = std::env::var("GH_REPO")
+            .ok()
+            .filter(|repo| !repo.trim().is_empty());
+
         Ok(Self {
             home_s: home.to_string_lossy().into_owned(),
             pwd_s: pwd.to_string_lossy().into_owned(),
@@ -142,6 +149,7 @@ impl Ctx {
             history_path,
             utc_offset,
             editor,
+            gh_repo,
             color: color.for_stdout(),
             config,
             log: Logger::new(verbose),
@@ -171,6 +179,13 @@ impl Ctx {
             anyhow::bail!("the configured editor is empty");
         }
         Ok(parts)
+    }
+
+    /// The repository `GH_REPO` names, if it names one. `gh` reads the variable
+    /// itself; scriv reads it only to know whether a command that needs a
+    /// repository already has one.
+    pub fn gh_repo(&self) -> Option<&str> {
+        self.gh_repo.as_deref()
     }
 
     /// This machine's offset from UTC, resolved once at startup.

--- a/src/main.rs
+++ b/src/main.rs
@@ -160,6 +160,9 @@ enum Command {
     ///
     /// The date is shown but never searched: it is digits at the front of every
     /// row, and matching it would rank timestamps above commands.
+    ///
+    /// scriv's own `scriv-` shell functions are left out — pressing ctrl-o
+    /// records one, and a key press is not a command anyone typed.
     #[command(visible_alias = "h")]
     History {
         #[command(subcommand)]
@@ -544,10 +547,14 @@ enum ConfigCmd {
     /// Check everything scriv depends on and report what is wrong
     ///
     /// Looks at the config file, the paths it names, the repositories
-    /// discovery actually finds, your editor, `git`, `gh`, fish's history file
-    /// and the tracked-file list — all in one pass, each with what to do about
-    /// it. Exits non-zero only when something is genuinely broken, so it is
-    /// worth putting in a setup script; a warning still leaves scriv working.
+    /// discovery actually finds, your editor, `git`, `gh` and whether it is
+    /// still logged in, fish's history file and the tracked-file list — all in
+    /// one pass, each with what to do about it. Exits non-zero only when
+    /// something is genuinely broken, so it is worth putting in a setup script;
+    /// a warning still leaves scriv working.
+    ///
+    /// The login is asked of GitHub, so this is the one command here that waits
+    /// on the network.
     Check,
 }
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -321,6 +321,36 @@ fn pr_open_current_outside_a_repository_says_so() {
     );
 }
 
+/// Every `pr` verb needs a repository to be about, and left to `gh` the answer
+/// is git's `fatal: not a git repository` — a sentence about git, from a
+/// command that was asked about pull requests.
+#[test]
+fn pr_outside_a_repository_says_so_before_gh_does() {
+    let sandbox = Sandbox::new();
+    for verb in [&["ls"][..], &["sel"][..], &["checkout", "1"][..]] {
+        let mut args = vec!["pr"];
+        args.extend_from_slice(verb);
+        let run = sandbox.run(&args);
+        run.code(1);
+        assert!(
+            run.stderr.contains("not inside a git repository"),
+            "`pr {}`: {}",
+            verb.join(" "),
+            run.stderr
+        );
+        assert!(
+            run.stderr.contains("GH_REPO"),
+            "the way to run this anyway went unmentioned: {}",
+            run.stderr
+        );
+        assert!(
+            !run.stderr.contains("fatal:"),
+            "gh was reached after all: {}",
+            run.stderr
+        );
+    }
+}
+
 #[test]
 fn every_registry_exposes_sel() {
     let sandbox = Sandbox::new();
@@ -533,6 +563,37 @@ fn config_check_does_not_report_one_problem_twice() {
 
 // --- repo discovery ---------------------------------------------------------
 
+/// The two ways to have nowhere to look need opposite advice. Someone who has
+/// just run `config init` and not yet filled in the root must not be sent back
+/// to `config init`, which refuses to overwrite the file it just wrote.
+#[test]
+fn a_missing_root_is_answered_by_where_the_user_actually_is() {
+    let sandbox = Sandbox::new();
+
+    let fresh = sandbox.run(&["repo", "ls"]);
+    fresh.code(1);
+    assert!(
+        fresh.stderr.contains("scriv config init"),
+        "{}",
+        fresh.stderr
+    );
+
+    let path = sandbox.write_config("[repo]\nignore = [\"target\"]\n");
+    let written = sandbox.run(&["repo", "ls"]);
+    written.code(1);
+    assert!(
+        written.stderr.contains(path.to_str().unwrap()),
+        "the error did not say which file to edit: {}",
+        written.stderr
+    );
+    assert!(written.stderr.contains("[repo] root"), "{}", written.stderr);
+    assert!(
+        !written.stderr.contains("config init"),
+        "sent back to a command that will refuse: {}",
+        written.stderr
+    );
+}
+
 #[test]
 fn repo_ls_finds_repositories_under_the_root() {
     let sandbox = Sandbox::new();
@@ -589,17 +650,6 @@ fn repo_ls_skips_ignored_directories() {
     let run = sandbox.run(&["repo", "ls"]);
     run.ok();
     assert_eq!(run.lines(), vec!["~/dev/github.com/acme/billing"]);
-}
-
-#[test]
-fn repo_ls_without_a_root_says_what_to_do() {
-    let sandbox = Sandbox::new();
-    sandbox.write_config("[selector]\nheight = \"40%\"\n");
-
-    let run = sandbox.run(&["repo", "ls"]);
-    run.code(1);
-    assert!(run.stderr.contains("root"), "{}", run.stderr);
-    assert!(run.stderr.contains("config init"), "{}", run.stderr);
 }
 
 #[test]
@@ -1188,6 +1238,31 @@ fn history_ls_status_dates_every_row_in_one_column() {
         "an undated row did not hold the column open: {undated:?}"
     );
     assert!(undated.trim_end().ends_with("undated"), "{undated:?}");
+}
+
+/// ctrl-o reaches the selector by handing `scriv-repo-cd` to fish, which
+/// records it. Offered back, those rows sit at the top of ctrl-r — the newest
+/// commands in the file — and none of them is a command anyone can use.
+#[test]
+fn the_key_bindings_scriv_emits_are_not_listed_as_history() {
+    let sandbox = Sandbox::new();
+    write_history(
+        &sandbox,
+        "- cmd: git status\n  when: 100\n\
+         - cmd: scriv-repo-cd\n  when: 200\n\
+         - cmd: scriv-history-select\n  when: 300\n\
+         - cmd: scriv repo sel\n  when: 400\n\
+         - cmd: fe -t\n  when: 500\n",
+    );
+
+    let run = sandbox.run(&["history", "ls"]);
+    run.ok();
+    assert_eq!(
+        run.lines(),
+        vec!["fe -t", "scriv repo sel", "git status"],
+        "stderr: {}",
+        run.stderr
+    );
 }
 
 #[test]


### PR DESCRIPTION
Five places where scriv knew more than it said.

- ctrl-o records `scriv-repo-cd` in fish's history, so the top of ctrl-r was the keys you had just pressed; those rows are now left out.
- `pr` outside a repository said `fatal: not a git repository` in git's words, through gh. It now says so itself and names `GH_REPO`.
- `pr` says when a listing stopped at `--limit`, as `repo clone` already did.
- A missing `root` sent you to `scriv config init` even when the config existed, which that command refuses to overwrite. It now names the file to edit.
- `config check` reports whether gh is still logged in — a warning, and the one check that waits on the network, costing it about 0.4s.

`repo_ls_without_a_root_says_what_to_do` asserted the advice that was wrong; `a_missing_root_is_answered_by_where_the_user_actually_is` replaces it and covers both directions.

CLI help: the `history` and `config check` doc comments say what changed. README: unchanged, no flag or group moved. `docs/demo.gif`: nothing a selector draws changed. CHANGELOG: five lines under Unreleased. Patch, not minor — no new command or flag.