### PR TITLE
Add and remove worktrees, and delete the branches they leave behind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,21 @@ raised, never by hand.
 
 ## Unreleased
 
+### Added
+
+- `scriv worktree add` creates a working tree and picks where it goes:
+  `.worktrees/<branch>` inside the repository, or wherever `[worktree] root`
+  says. A branch that does not exist yet is created, a remote-only one arrives
+  tracking its remote, and the path is printed — `cd (scriv worktree add
+  feat/x)` lands in the new tree. A root inside the repository is added to that
+  clone's `.git/info/exclude`, so nothing else offers the tree twice.
+- `scriv worktree rm` removes trees, several at a time. Neither the main tree
+  nor the one you are standing in is offered.
+- `scriv branch rm` deletes local branches, several at a time, each listed with
+  whether git can see its commits have landed. Answering the question is what
+  lets an unmerged branch go — a repository that squashes its merges has no
+  other kind. Remote branches are never offered: deleting one is a push.
+
 ### Changed
 
 - `scriv history` no longer offers scriv's own key bindings back. Pressing

--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ ignore = ["node_modules", "target"]
 | --- | --- |
 | `scriv repo` | `ls` `sel` `open` `clone` |
 | `scriv file` | `ls` `sel` `add` `rm` `prune` |
-| `scriv branch` | `ls` `sel` `checkout` |
-| `scriv worktree` | `ls` `sel` |
+| `scriv branch` | `ls` `sel` `checkout` `rm` |
+| `scriv worktree` | `ls` `sel` `add` `rm` |
 | `scriv pr` | `ls` `sel` `checkout` `open` `merge` |
 | `scriv proc` | `ls` `sel` `kill` |
 | `scriv history` | `ls` `sel` |

--- a/src/cmd/branch.rs
+++ b/src/cmd/branch.rs
@@ -7,11 +7,12 @@
 //! Every listing arrives ordered by [`git::by_relevance`]: current branch, then
 //! local, then remote-only, newest first within each.
 
+use std::collections::HashSet;
 use std::sync::{Arc, Mutex};
 
 use anyhow::{Result, bail};
 
-use crate::git::{self, Branch, Filter};
+use crate::git::{self, Branch, BranchKind, Filter};
 use crate::select::{Preview, SelectItem};
 use crate::term;
 use crate::{Ctx, select};
@@ -213,10 +214,161 @@ pub fn checkout(ctx: &Ctx, name: Option<&str>, filter: Filter, fetch: bool) -> R
     git::checkout(&action)
 }
 
+// --- rm ---------------------------------------------------------------------
+
+/// The branches `rm` may offer: the ones that exist in this clone, minus the
+/// one that is checked out.
+///
+/// Remote branches are deliberately absent. Deleting one is a push, which is
+/// not something to be one keystroke and no network round trip away from, and
+/// nothing on this list would say it had happened.
+fn deletable(branches: &[Branch]) -> Vec<&Branch> {
+    branches
+        .iter()
+        .filter(|branch| branch.kind != BranchKind::Remote && !branch.head)
+        .collect()
+}
+
+/// The mark a branch carries in the list of what is about to be deleted, and in
+/// the selector: whether git considers its commits to have landed.
+///
+/// A squash merge leaves no trace git can follow — the branch's commits never
+/// become ancestors of the commit that merged them — so `not merged` is
+/// routinely true of work that is finished. It is a fact, not a warning, which
+/// is why it is shown rather than obeyed.
+fn merge_mark(merged: bool) -> &'static str {
+    if merged { "merged" } else { "not merged" }
+}
+
+/// Selector rows for deletion: the branch, when it was last committed to, and
+/// whether it has landed. Tinted green where git can see it has.
+fn rm_items(branches: &[Branch], merged: &HashSet<String>) -> Vec<SelectItem> {
+    let width = name_width(branches);
+    let mark_width = "not merged".len();
+    branches
+        .iter()
+        .map(|branch| {
+            let landed = merged.contains(&branch.name);
+            let label = format!(
+                "{name:<width$}  {mark:<mark_width$}  {date}  {subject}",
+                name = branch.name,
+                mark = merge_mark(landed),
+                date = branch.date,
+                subject = branch.subject,
+            );
+            SelectItem::new(label.trim_end(), branch.name.clone())
+                .color(if landed { 2 } else { 3 })
+                .preview(preview(branch))
+        })
+        .collect()
+}
+
+/// `scriv branch rm [NAME]...` — delete local branches, selecting them when
+/// none are named.
+///
+/// What will go is printed with its merge state before the question is put, as
+/// `file prune` does, and answering it is the consent that lets an unmerged
+/// branch go: a repository that squashes its merges has no other kind, so a
+/// flag guarding them would be a flag typed every time and read never.
+pub fn rm(ctx: &Ctx, names: &[String], yes: bool) -> Result<()> {
+    let branches = collect(ctx, Filter::Local, false)?;
+    let merged = git::merged_branches()?;
+
+    let targets: Vec<String> = if names.is_empty() {
+        let offered: Vec<Branch> = deletable(&branches).into_iter().cloned().collect();
+        if offered.is_empty() {
+            bail!("no other local branches — only the one you have checked out");
+        }
+        match select::select_many(
+            rm_items(&offered, &merged),
+            "Delete branches",
+            &ctx.config.selector,
+        ) {
+            Ok(selected) => selected,
+            Err(e) if e.is::<select::Cancelled>() => return Ok(()),
+            Err(e) => return Err(e),
+        }
+    } else {
+        names.to_vec()
+    };
+    if targets.is_empty() {
+        return Ok(());
+    }
+
+    if !confirm_deletion(ctx, &targets, &merged, yes)? {
+        return Ok(());
+    }
+
+    let mut failed = 0;
+    for name in &targets {
+        // Forced for a branch git cannot see has landed: the confirmation
+        // above showed that state and was answered anyway.
+        let force = !merged.contains(name);
+        match git::delete_branch(name, force) {
+            Ok(()) => println!("Deleted {name}"),
+            Err(err) => {
+                failed += 1;
+                eprintln!("error: {name}: {err:#}");
+            }
+        }
+    }
+    if failed > 0 {
+        bail!(
+            "{failed} of {} branches could not be deleted",
+            targets.len()
+        );
+    }
+    Ok(())
+}
+
+/// Show what is about to go, and what git knows about each, then ask.
+fn confirm_deletion(
+    ctx: &Ctx,
+    targets: &[String],
+    merged: &HashSet<String>,
+    yes: bool,
+) -> Result<bool> {
+    let width = targets.iter().map(|n| n.chars().count()).max().unwrap_or(0);
+    let color = ctx.color();
+
+    let mut out = term::Listing::stdout();
+    for name in targets {
+        let landed = merged.contains(name);
+        let row = format!("{name:<width$}  {}", merge_mark(landed));
+        if !out.line(&term::paint(&row, if landed { 2 } else { 3 }, color))? {
+            return Ok(false);
+        }
+    }
+    out.finish()?;
+
+    match term::Confirm::resolve(yes) {
+        term::Confirm::Assumed => Ok(true),
+        term::Confirm::Ask => {
+            let question = format!(
+                "Delete {} {}?",
+                targets.len(),
+                if targets.len() == 1 {
+                    "branch"
+                } else {
+                    "branches"
+                }
+            );
+            let answer = term::confirm(&question)?;
+            if !answer {
+                println!("Nothing deleted");
+            }
+            Ok(answer)
+        }
+        term::Confirm::Impossible => bail!(
+            "no terminal to ask for confirmation on — pass `--yes` to delete without being asked"
+        ),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::git::{BranchKind, RefLine, classify};
+    use crate::git::{RefLine, classify};
 
     fn branches() -> Vec<Branch> {
         classify(&[
@@ -280,6 +432,39 @@ mod tests {
             label.starts_with("  café  now"),
             "column padded past the longest name: {label:?}"
         );
+    }
+
+    /// Deleting a remote branch is a push. Nothing on this list would say it
+    /// had happened, and no confirmation here is consent to change a remote.
+    #[test]
+    fn only_local_branches_that_are_not_checked_out_are_offered_for_deletion() {
+        let here = branches();
+        let offered: Vec<&str> = deletable(&here).iter().map(|b| b.name.as_str()).collect();
+        assert_eq!(offered, Vec::<&str>::new(), "main is checked out here");
+
+        let mut branches = branches();
+        branches[0].head = false;
+        let offered: Vec<&str> = deletable(&branches)
+            .iter()
+            .map(|b| b.name.as_str())
+            .collect();
+        assert_eq!(offered, vec!["main"], "a remote branch was offered");
+    }
+
+    #[test]
+    fn the_deletion_rows_say_what_git_can_see_has_landed() {
+        let mut branches = branches();
+        branches[0].head = false;
+        let merged: HashSet<String> = ["main".to_string()].into_iter().collect();
+
+        let rows = rm_items(&branches, &merged);
+        assert!(rows[0].label.contains("merged"), "{}", rows[0].label);
+        assert_eq!(rows[0].color, Some(2), "a landed branch is not green");
+        assert_eq!(rows[0].value(), "main");
+
+        let rows = rm_items(&branches, &HashSet::new());
+        assert!(rows[0].label.contains("not merged"), "{}", rows[0].label);
+        assert_eq!(rows[0].color, Some(3));
     }
 
     #[test]

--- a/src/cmd/config.rs
+++ b/src/cmd/config.rs
@@ -40,6 +40,16 @@ ignore = ["node_modules", "target"]
 # `[repo.labels]` header would swallow every `[repo]` key written after it.
 # labels = { personal = ["your-github-user"], work = ["acme", "acme-labs"] }
 
+# `scriv worktree`: where `worktree add` creates a tree.
+[worktree]
+
+# One directory per branch, with `/` written as `-`. A relative path is inside
+# the repository the tree belongs to, and is added to that clone's
+# .git/info/exclude the first time, so nothing else offers the tree twice. An
+# absolute path holds the trees of every repository, under the repository's own
+# name.
+# root = ".worktrees"
+
 # `scriv history`: which shell history to search.
 [history]
 

--- a/src/cmd/worktree.rs
+++ b/src/cmd/worktree.rs
@@ -3,13 +3,15 @@
 //!
 //! Switching to one is a `cd`, which a child process cannot do to its parent,
 //! so `sel` prints the path and the fish integration's ctrl-t moves there —
-//! the same split as `repo sel`.
+//! the same split as `repo sel`. `add` prints its path for the same reason.
+
+use std::path::{Path, PathBuf};
 
 use anyhow::{Result, bail};
 
 use crate::git::{self, Worktree};
-use crate::path::display_path;
-use crate::select::SelectItem;
+use crate::path::{display_path, expand_home_dir};
+use crate::select::{Choice, SelectItem};
 use crate::{Ctx, select, term};
 
 /// Every working tree of the current repository, in git's order.
@@ -138,6 +140,208 @@ pub fn sel(ctx: &Ctx) -> Result<()> {
     Ok(())
 }
 
+// --- add --------------------------------------------------------------------
+
+/// A branch name as one directory name: `feat/x` becomes `feat-x` rather than
+/// an `x` inside a `feat`, so however branches are named the trees stay one
+/// flat list to look at.
+fn slug(branch: &str) -> String {
+    branch.replace('/', "-")
+}
+
+/// Where a new tree for `branch` goes.
+///
+/// A relative root is inside the repository, so a tree sits beside the checkout
+/// it came from and goes when that does. An absolute one holds the trees of
+/// every repository, and would collide on the first two branches named `main`,
+/// so the repository's own directory name is a level of it.
+fn tree_path(repo_root: &Path, root: &Path, branch: &str) -> PathBuf {
+    let slug = slug(branch);
+    if !root.is_absolute() {
+        return repo_root.join(root).join(slug);
+    }
+    match repo_root.file_name() {
+        Some(name) => root.join(name).join(slug),
+        None => root.join(slug),
+    }
+}
+
+/// Fuzzy-select the branch a new tree checks out, accepting a name that matches
+/// nothing — which is how a tree for work that has not started yet is made.
+fn choose_branch(ctx: &Ctx, branches: &[git::Branch]) -> Result<String> {
+    let items = items_for_branches(branches);
+    match select::select_one_or_query(items, "Branch (type a new name)", &ctx.config.selector)? {
+        Choice::Item(name) => Ok(name),
+        Choice::Query(typed) => Ok(typed),
+    }
+}
+
+/// Selector rows for the branch list: the name, and what it last carried.
+fn items_for_branches(branches: &[git::Branch]) -> Vec<SelectItem> {
+    let width = branches
+        .iter()
+        .map(|b| b.name.chars().count())
+        .max()
+        .unwrap_or(0);
+    branches
+        .iter()
+        .map(|branch| {
+            let label = format!(
+                "{name:<width$}  {date}  {subject}",
+                name = branch.name,
+                date = branch.date,
+                subject = branch.subject,
+            );
+            SelectItem::new(label.trim_end(), branch.name.clone()).color(branch.kind.color())
+        })
+        .collect()
+}
+
+/// `scriv worktree add [BRANCH]` — create a working tree, selecting or naming
+/// the branch it checks out.
+///
+/// The path is scriv's to decide (see [`tree_path`]) and is printed on stdout,
+/// so the tree can be entered with `cd (scriv worktree add feat/x)`. git's own
+/// narration goes to stderr, where it does not get in the way of that.
+pub fn add(ctx: &Ctx, branch: Option<&str>) -> Result<()> {
+    let repo_root = git::require_repo_root()?;
+    let branches = git::branches()?;
+
+    let input = match branch {
+        Some(branch) => branch.to_string(),
+        None => choose_branch(ctx, &branches)?,
+    };
+    let source = git::tree_source(&branches, &input);
+    ctx.log.info(&format!("tree source: {source:?}"));
+
+    let root = expand_home_dir(&ctx.config.worktree.root, ctx.home());
+    let path = tree_path(&repo_root, &root, source.branch());
+    if path.exists() {
+        bail!(
+            "{} already exists — `scriv worktree sel` will take you there",
+            path.display()
+        );
+    }
+
+    git::add_worktree(&path, &source)?;
+
+    // Only for a root inside the repository: an absolute one is nobody's
+    // working copy and there is nothing to hide from `git status`.
+    if !root.is_absolute() {
+        match git::ignore_locally(&repo_root, &ctx.config.worktree.root) {
+            Ok(true) => eprintln!(
+                "note: added `{}/` to this clone's .git/info/exclude",
+                ctx.config.worktree.root
+            ),
+            Ok(false) => {}
+            Err(err) => ctx
+                .log
+                .warn(&format!("could not write info/exclude: {err:#}")),
+        }
+    }
+
+    println!("{}", path.display());
+    Ok(())
+}
+
+// --- rm ---------------------------------------------------------------------
+
+/// The trees `rm` may offer: neither the main tree, which git will not remove,
+/// nor the one the shell is standing in, which it will not remove either.
+fn removable(worktrees: &[Worktree]) -> Vec<&Worktree> {
+    worktrees
+        .iter()
+        .skip(1) // git lists the main tree first, and it cannot be removed
+        .filter(|worktree| !worktree.current)
+        .collect()
+}
+
+/// `scriv worktree rm [PATH]...` — remove working trees, selecting them when
+/// none are named.
+///
+/// What will go is printed before the question is put, as `file prune` does:
+/// "remove 2 trees?" is answerable only by someone who has seen the two. The
+/// branches they had checked out are left alone — that is `scriv branch rm`.
+pub fn remove(ctx: &Ctx, paths: &[String], force: bool, yes: bool) -> Result<()> {
+    let worktrees = load(ctx)?;
+
+    let targets: Vec<String> = if paths.is_empty() {
+        let offered = removable(&worktrees);
+        if offered.is_empty() {
+            bail!("no worktrees to remove — only the main tree and the one you are in");
+        }
+        let rows: Vec<SelectItem> = {
+            let owned: Vec<Worktree> = offered.into_iter().cloned().collect();
+            items(&owned, ctx.home_str())
+        };
+        match select::select_many(rows, "Remove worktrees", &ctx.config.selector) {
+            Ok(selected) => selected,
+            Err(e) if e.is::<select::Cancelled>() => return Ok(()),
+            Err(e) => return Err(e),
+        }
+    } else {
+        paths.to_vec()
+    };
+    if targets.is_empty() {
+        return Ok(());
+    }
+
+    if !confirm_removal(ctx, &targets, yes)? {
+        return Ok(());
+    }
+
+    let mut failed = 0;
+    for path in &targets {
+        match git::remove_worktree(Path::new(path), force) {
+            Ok(()) => println!("Removed {}", display_path(path, ctx.home_str(), false)),
+            // git says why on the terminal it was handed; a second sentence
+            // from scriv over the top of it would only be vaguer.
+            Err(_) => failed += 1,
+        }
+    }
+    if failed > 0 {
+        bail!(
+            "{failed} of {} worktrees could not be removed",
+            targets.len()
+        );
+    }
+    Ok(())
+}
+
+/// Show what is about to go and ask, unless `yes`.
+fn confirm_removal(ctx: &Ctx, targets: &[String], yes: bool) -> Result<bool> {
+    let mut out = term::Listing::stdout();
+    for path in targets {
+        if !out.line(&display_path(path, ctx.home_str(), false))? {
+            return Ok(false);
+        }
+    }
+    out.finish()?;
+
+    match term::Confirm::resolve(yes) {
+        term::Confirm::Assumed => Ok(true),
+        term::Confirm::Ask => {
+            let question = format!(
+                "Remove {} {}?",
+                targets.len(),
+                if targets.len() == 1 {
+                    "worktree"
+                } else {
+                    "worktrees"
+                }
+            );
+            let answer = term::confirm(&question)?;
+            if !answer {
+                println!("Nothing removed");
+            }
+            Ok(answer)
+        }
+        term::Confirm::Impossible => bail!(
+            "no terminal to ask for confirmation on — pass `--yes` to remove without being asked"
+        ),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -221,6 +425,55 @@ mod tests {
             label.starts_with("  café  ~/café"),
             "column padded past the longest name: {label:?}",
         );
+    }
+
+    #[test]
+    fn a_branch_becomes_one_directory_rather_than_a_nest() {
+        assert_eq!(slug("feat/x"), "feat-x");
+        assert_eq!(slug("release/1.2/rc"), "release-1.2-rc");
+        assert_eq!(slug("main"), "main");
+    }
+
+    #[test]
+    fn a_relative_root_puts_the_tree_beside_the_checkout() {
+        let path = tree_path(
+            Path::new("/home/u/dev/github.com/me/scriv"),
+            Path::new(".worktrees"),
+            "feat/x",
+        );
+        assert_eq!(
+            path,
+            PathBuf::from("/home/u/dev/github.com/me/scriv/.worktrees/feat-x")
+        );
+    }
+
+    /// One directory of trees for every repository would have two `main`s the
+    /// moment a second repository used it.
+    #[test]
+    fn an_absolute_root_keeps_each_repository_apart() {
+        let path = tree_path(
+            Path::new("/home/u/dev/github.com/me/scriv"),
+            Path::new("/home/u/dev/worktrees"),
+            "main",
+        );
+        assert_eq!(path, PathBuf::from("/home/u/dev/worktrees/scriv/main"));
+    }
+
+    #[test]
+    fn neither_the_main_tree_nor_the_one_you_are_in_is_offered_for_removal() {
+        let mut trees = worktrees();
+        trees[1].current = true;
+        assert!(
+            removable(&trees).is_empty(),
+            "offered a tree git would refuse to remove"
+        );
+
+        let trees = worktrees();
+        let offered: Vec<&str> = removable(&trees)
+            .iter()
+            .map(|w| w.branch.as_str())
+            .collect();
+        assert_eq!(offered, vec!["feat/x"], "the main tree was offered");
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -44,6 +44,7 @@ pub type Labels = IndexMap<String, Vec<String>>;
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct Config {
     pub repo: RepoConfig,
+    pub worktree: WorktreeConfig,
     pub history: HistoryConfig,
     pub selector: SelectorConfig,
 }
@@ -107,6 +108,31 @@ impl RepoConfig {
         self.labels.values().flatten().map(String::as_str).collect()
     }
 }
+
+/// `[worktree]` — where `scriv worktree add` puts a new working tree.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(default)]
+pub struct WorktreeConfig {
+    /// The directory new trees are created in, one per branch.
+    ///
+    /// A relative path is inside the repository the tree belongs to, so its
+    /// trees sit beside the checkout they came from. An absolute path — or one
+    /// beginning with `~` — is one directory of trees for every repository, and
+    /// the repository's own name becomes a level of it.
+    pub root: String,
+}
+
+impl Default for WorktreeConfig {
+    fn default() -> Self {
+        Self {
+            root: DEFAULT_WORKTREE_ROOT.to_string(),
+        }
+    }
+}
+
+/// Where trees go when nothing says otherwise: beside the checkout, in a
+/// directory git itself will not confuse for part of it.
+const DEFAULT_WORKTREE_ROOT: &str = ".worktrees";
 
 /// `[history]` — which shell history `scriv history` searches.
 #[derive(Debug, Clone, PartialEq, Eq, Default, Deserialize)]
@@ -199,6 +225,8 @@ impl Default for SelectorConfig {
 struct RawToml {
     #[serde(default)]
     repo: RepoConfig,
+    #[serde(default)]
+    worktree: WorktreeConfig,
     #[serde(default)]
     history: HistoryConfig,
     #[serde(default)]
@@ -478,6 +506,7 @@ fn parse_toml(data: &str) -> Result<Config> {
     }
     Ok(Config {
         repo: raw.repo,
+        worktree: raw.worktree,
         history: raw.history,
         selector: raw.selector.into(),
     })
@@ -899,6 +928,18 @@ preview = false
         assert_eq!(cfg.repo.display, RepoDisplay::Tilde);
         assert_eq!(cfg.selector.height, "30%");
         assert!(!cfg.selector.preview);
+    }
+
+    #[test]
+    fn worktree_root_defaults_to_a_directory_beside_the_checkout() {
+        assert_eq!(parse_toml("").unwrap().worktree.root, ".worktrees");
+        assert_eq!(
+            parse_toml("[worktree]\nroot = \"~/dev/worktrees\"\n")
+                .unwrap()
+                .worktree
+                .root,
+            "~/dev/worktrees"
+        );
     }
 
     #[test]

--- a/src/git.rs
+++ b/src/git.rs
@@ -288,6 +288,68 @@ pub fn resolve(branches: &[Branch], input: &str) -> Checkout {
     Checkout::Switch(input.to_string())
 }
 
+/// What a name given to `worktree add` means: the three ways a new tree can
+/// come by the branch it checks out.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TreeSource {
+    /// Check out a local branch that already exists.
+    Branch(String),
+    /// Create `branch` from `remote_ref` and track it, as [`Checkout::Track`]
+    /// does for the current tree.
+    Track { remote_ref: String, branch: String },
+    /// Create a branch here, from what is checked out now.
+    New(String),
+}
+
+impl TreeSource {
+    /// The local branch the new tree will be on, whichever way it got there.
+    pub fn branch(&self) -> &str {
+        match self {
+            Self::Branch(name) | Self::New(name) => name,
+            Self::Track { branch, .. } => branch,
+        }
+    }
+}
+
+/// Decide where a new tree's branch comes from, given the known branches.
+///
+/// [`resolve`]'s rules, and then two of its own, because `git worktree add`
+/// does not guess the way `git switch` does:
+///
+/// - A bare name only a remote has creates the local branch tracking it. This
+///   is git's own DWIM, which `switch` performs and `worktree add` does not —
+///   left to git, `worktree add -b feat/x` would build a *new* branch from
+///   HEAD that shares a name with the remote one and nothing else. Ambiguous
+///   across remotes, it is left alone, as a branch to create.
+/// - A name matching nothing at all is a branch to create rather than an error.
+///   Adding a tree is how a piece of work starts, and its branch usually does
+///   not exist yet.
+pub fn tree_source(branches: &[Branch], input: &str) -> TreeSource {
+    let tracking = |remote_ref: &str| TreeSource::Track {
+        branch: split_remote(remote_ref)
+            .map(|(_, branch)| branch.to_string())
+            .unwrap_or_else(|| remote_ref.to_string()),
+        remote_ref: remote_ref.to_string(),
+    };
+
+    match resolve(branches, input) {
+        Checkout::Track { remote_ref } => tracking(&remote_ref),
+        Checkout::Switch(name) if branches.iter().any(|b| b.name == name) => {
+            TreeSource::Branch(name)
+        }
+        Checkout::Switch(name) => {
+            let mut remotes = branches
+                .iter()
+                .filter(|b| b.kind == BranchKind::Remote)
+                .filter(|b| split_remote(&b.name).is_some_and(|(_, tail)| tail == name));
+            match (remotes.next(), remotes.next()) {
+                (Some(only), None) => tracking(&only.name),
+                _ => TreeSource::New(name),
+            }
+        }
+    }
+}
+
 /// A working tree of the repository: the main one, or one added with
 /// `git worktree add`.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -466,6 +528,30 @@ fn passthrough(args: &[&str]) -> Result<()> {
     Ok(())
 }
 
+/// [`passthrough`], with the child's stdout sent to scriv's stderr.
+///
+/// `git worktree add` narrates its checkout on stdout — `HEAD is now at …`, and
+/// the line saying an upstream was set — while stdout is also where scriv puts
+/// the path a shell reads to `cd` into the new tree. Both are worth keeping, so
+/// git keeps its voice and gives up the channel.
+fn passthrough_onto_stderr(args: &[&str]) -> Result<()> {
+    use std::os::fd::AsFd;
+
+    let stderr = std::io::stderr()
+        .as_fd()
+        .try_clone_to_owned()
+        .context("duplicating stderr")?;
+    let status = Command::new("git")
+        .args(args)
+        .stdout(Stdio::from(stderr))
+        .status()
+        .map_err(spawn_error)?;
+    if !status.success() {
+        return Err(Reported(status.code().unwrap_or(1)).into());
+    }
+    Ok(())
+}
+
 /// Fail early, and with a better message than git's, when the working
 /// directory is not inside a repository.
 pub fn ensure_repo() -> Result<()> {
@@ -579,6 +665,121 @@ pub fn checkout(action: &Checkout) -> Result<()> {
         Checkout::Switch(name) => passthrough(&["switch", "--", name]),
         Checkout::Track { remote_ref } => passthrough(&["switch", "--track", remote_ref]),
     }
+}
+
+/// Create a working tree at `path` from `source`.
+///
+/// git creates the parent directories itself, so there is nothing to prepare,
+/// and everything it says lands on stderr — see [`passthrough_onto_stderr`].
+pub fn add_worktree(path: &Path, source: &TreeSource) -> Result<()> {
+    let path = path.to_string_lossy();
+    match source {
+        TreeSource::Branch(name) => passthrough_onto_stderr(&["worktree", "add", &path, name]),
+        TreeSource::New(name) => passthrough_onto_stderr(&["worktree", "add", "-b", name, &path]),
+        TreeSource::Track { remote_ref, branch } => passthrough_onto_stderr(&[
+            "worktree", "add", "--track", "-b", branch, &path, remote_ref,
+        ]),
+    }
+}
+
+/// Whether git already ignores `path`, by any of the rules it consults.
+fn is_ignored(path: &Path) -> bool {
+    Command::new("git")
+        .args(["check-ignore", "--quiet", "--"])
+        .arg(path)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .is_ok_and(|status| status.success())
+}
+
+/// Have this clone ignore `pattern`, if nothing already does.
+///
+/// A directory of working trees inside the repository is untracked files as far
+/// as everything else is concerned: `git status` lists them, and every walker
+/// that honours `.gitignore` — `scriv edit`'s included — offers the whole tree a
+/// second time under it. The rule belongs to this clone rather than to the
+/// project, so it goes in `info/exclude` and is never committed.
+///
+/// Returns whether a line was written. A failure is not one: the tree is
+/// already there and usable, and being untidy about it is not worth undoing it.
+pub fn ignore_locally(root: &Path, pattern: &str) -> Result<bool> {
+    if is_ignored(&root.join(pattern)) {
+        return Ok(false);
+    }
+
+    // The *common* directory: a linked worktree's own `.git` is a file
+    // pointing into the main one, and that is where `info/exclude` lives.
+    let common = capture(&["rev-parse", "--path-format=absolute", "--git-common-dir"])
+        .context("locating the git directory")?;
+    let exclude = Path::new(common.trim()).join("info").join("exclude");
+
+    let mut existing = std::fs::read_to_string(&exclude).unwrap_or_default();
+    if !existing.is_empty() && !existing.ends_with('\n') {
+        existing.push('\n');
+    }
+    existing.push_str(&format!("{pattern}/\n"));
+
+    if let Some(dir) = exclude.parent() {
+        std::fs::create_dir_all(dir).with_context(|| format!("creating {}", dir.display()))?;
+    }
+    std::fs::write(&exclude, existing).with_context(|| format!("writing {}", exclude.display()))?;
+    Ok(true)
+}
+
+/// Remove the working tree at `path`. `force` is git's own, and is what a tree
+/// with uncommitted changes in it needs.
+pub fn remove_worktree(path: &Path, force: bool) -> Result<()> {
+    let path = path.to_string_lossy();
+    let mut args = vec!["worktree", "remove"];
+    if force {
+        args.push("--force");
+    }
+    args.push(&path);
+    passthrough(&args)
+}
+
+/// The local branches already contained in the current HEAD, which are the ones
+/// git will delete without being forced.
+///
+/// A squash merge produces no such containment — the branch's commits never
+/// become ancestors of what merged them — so an empty answer means "git cannot
+/// tell", not "nothing has landed".
+pub fn merged_branches() -> Result<HashSet<String>> {
+    // `HEAD` spelled out: `--merged` takes an optional commit, so the format
+    // argument after a bare one is read as the commit to compare against.
+    let out = capture(&["branch", "--merged", "HEAD", "--format=%(refname:short)"])
+        .context("listing merged branches")?;
+    Ok(out
+        .lines()
+        .map(str::trim)
+        .filter(|name| !name.is_empty())
+        .map(str::to_string)
+        .collect())
+}
+
+/// Delete a local branch. `force` is git's `-D`: it deletes a branch whose
+/// commits are in no other, which `-d` refuses.
+///
+/// Captured rather than passed through, so a refusal is one line the caller can
+/// report against the branch it belongs to — several branches are deleted in
+/// one run, and git's own wording says which only by quoting the name.
+pub fn delete_branch(name: &str, force: bool) -> Result<()> {
+    let flag = if force { "-D" } else { "-d" };
+    capture(&["branch", flag, "--", name])
+        .map(|_| ())
+        .map_err(|err| anyhow!("{}", unprefixed(&format!("{err:#}"))))
+}
+
+/// git's own `error:` or `fatal:` opener, removed. The caller is reporting the
+/// line inside one of its own, and two of the word in a row says nothing twice.
+fn unprefixed(message: &str) -> &str {
+    let message = message.trim();
+    ["error: ", "fatal: "]
+        .iter()
+        .find_map(|prefix| message.strip_prefix(prefix))
+        .unwrap_or(message)
 }
 
 #[cfg(test)]
@@ -818,6 +1019,79 @@ mod tests {
         assert_eq!(
             resolve(&sample(), "nope"),
             Checkout::Switch("nope".to_string())
+        );
+    }
+
+    #[test]
+    fn gits_own_error_opener_is_not_repeated_inside_the_callers() {
+        assert_eq!(
+            unprefixed("error: cannot delete branch 'x' used by worktree at '/y'"),
+            "cannot delete branch 'x' used by worktree at '/y'"
+        );
+        assert_eq!(unprefixed("fatal: not a valid ref"), "not a valid ref");
+        assert_eq!(unprefixed("  plain trouble  "), "plain trouble");
+    }
+
+    /// A tree is where work starts, and its branch usually does not exist yet —
+    /// the one place an unknown name means "create it" rather than "ask git".
+    #[test]
+    fn an_unknown_name_is_a_branch_to_create() {
+        assert_eq!(
+            tree_source(&sample(), "feat/new"),
+            TreeSource::New("feat/new".to_string())
+        );
+    }
+
+    #[test]
+    fn an_existing_branch_is_checked_out_rather_than_recreated() {
+        assert_eq!(
+            tree_source(&sample(), "scratch"),
+            TreeSource::Branch("scratch".to_string())
+        );
+    }
+
+    #[test]
+    fn a_remote_only_branch_arrives_tracking_it() {
+        assert_eq!(
+            tree_source(&sample(), "origin/feature"),
+            TreeSource::Track {
+                remote_ref: "origin/feature".to_string(),
+                branch: "feature".to_string(),
+            }
+        );
+        // The remote name is not part of the local branch, whichever form the
+        // tree was asked for by.
+        assert_eq!(tree_source(&sample(), "origin/feature").branch(), "feature");
+    }
+
+    /// `git switch feature` would create the tracking branch by itself.
+    /// `git worktree add -b feature` would not: it would build a new branch
+    /// from HEAD sharing a name with the remote one and nothing else.
+    #[test]
+    fn a_bare_name_only_a_remote_has_still_tracks_it() {
+        assert_eq!(
+            tree_source(&sample(), "feature"),
+            TreeSource::Track {
+                remote_ref: "origin/feature".to_string(),
+                branch: "feature".to_string(),
+            }
+        );
+    }
+
+    /// git refuses to guess between two remotes, and neither does this.
+    #[test]
+    fn a_name_two_remotes_share_is_left_as_a_branch_to_create() {
+        let mut branches = sample();
+        branches.push(Branch {
+            name: "fork/feature".to_string(),
+            kind: BranchKind::Remote,
+            head: false,
+            date: "1 day ago".to_string(),
+            subject: "theirs".to_string(),
+        });
+        assert_eq!(
+            tree_source(&branches, "feature"),
+            TreeSource::New("feature".to_string())
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -347,6 +347,22 @@ enum BranchCmd {
         #[command(flatten)]
         scope: BranchScope,
     },
+    /// Delete local branches; omit the names to select them
+    ///
+    /// `tab` selects several. Each is listed with whether git can see its
+    /// commits have landed, and answering the question that follows is what
+    /// lets an unmerged one go — a repository that squashes its merges has no
+    /// other kind, so there is no flag to type every time and read never.
+    ///
+    /// Remote branches are never offered: deleting one is a push.
+    Rm {
+        /// Branches to delete; omit to select interactively
+        #[arg(value_name = "BRANCH")]
+        branches: Vec<String>,
+        /// Delete without asking
+        #[arg(short, long)]
+        yes: bool,
+    },
 }
 
 #[derive(Subcommand)]
@@ -364,6 +380,36 @@ enum WorktreeCmd {
     },
     /// Fuzzy-select a worktree and print its absolute path
     Sel,
+    /// Add a worktree; omit the branch to select or name one
+    ///
+    /// A branch that does not exist is created, since a tree is usually where
+    /// a piece of work starts. A remote-only one arrives tracking it.
+    ///
+    /// Where the tree goes is `[worktree] root` — `.worktrees` inside the
+    /// repository by default, one directory per branch with `/` written as `-`.
+    /// An absolute root holds the trees of every repository, under the
+    /// repository's own name. The path is printed, so `cd (scriv worktree add
+    /// feat/x)` lands in it.
+    Add {
+        /// Branch the tree checks out; omit to select or type one
+        branch: Option<String>,
+    },
+    /// Remove worktrees; omit the paths to select them
+    ///
+    /// `tab` selects several. Neither the main tree nor the one you are
+    /// standing in is offered — git will not remove either. The branches they
+    /// had checked out are left alone; that is `scriv branch rm`.
+    Rm {
+        /// Worktrees to remove, by path; omit to select interactively
+        #[arg(value_name = "PATH")]
+        paths: Vec<String>,
+        /// Remove a tree with uncommitted changes in it
+        #[arg(short, long)]
+        force: bool,
+        /// Remove without asking
+        #[arg(short, long)]
+        yes: bool,
+    },
 }
 
 /// Which pull requests a `pr` subcommand fetches, shared by all three.
@@ -626,6 +672,7 @@ fn run(cli: Cli) -> anyhow::Result<()> {
             BranchCmd::Checkout { branch, scope } => {
                 cmd::branch::checkout(&ctx, branch.as_deref(), scope.filter(), scope.fetch)
             }
+            BranchCmd::Rm { branches, yes } => cmd::branch::rm(&ctx, &branches, yes),
         },
         Command::Worktree { command } => match command {
             WorktreeCmd::Ls {
@@ -633,6 +680,10 @@ fn run(cli: Cli) -> anyhow::Result<()> {
                 status,
             } => cmd::worktree::ls(&ctx, absolute_paths, status),
             WorktreeCmd::Sel => cmd::worktree::sel(&ctx),
+            WorktreeCmd::Add { branch } => cmd::worktree::add(&ctx, branch.as_deref()),
+            WorktreeCmd::Rm { paths, force, yes } => {
+                cmd::worktree::remove(&ctx, &paths, force, yes)
+            }
         },
         Command::Pr { command } => match command {
             PrCmd::Ls { status, scope } => cmd::pr::ls(&ctx, &scope.state, scope.limit, status),

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -680,28 +680,38 @@ fn mk_worktree_repo(root: &Path) -> (PathBuf, PathBuf) {
         &["commit", "--allow-empty", "-m", "init"][..],
         &["worktree", "add", "-b", "feat", "../feat"][..],
     ] {
-        let out = Command::new("git")
-            .args(args)
-            .current_dir(&main)
-            .env_clear()
-            .env("PATH", std::env::var("PATH").unwrap_or_default())
-            .env("HOME", root)
-            .env("GIT_CONFIG_GLOBAL", "/dev/null")
-            .env("GIT_CONFIG_SYSTEM", "/dev/null")
-            .env("GIT_AUTHOR_NAME", "scriv tests")
-            .env("GIT_AUTHOR_EMAIL", "tests@example.invalid")
-            .env("GIT_COMMITTER_NAME", "scriv tests")
-            .env("GIT_COMMITTER_EMAIL", "tests@example.invalid")
-            .output()
-            .expect("running git");
-        assert!(
-            out.status.success(),
-            "git {args:?} failed: {}",
-            String::from_utf8_lossy(&out.stderr),
-        );
+        git_in(&main, root, args);
     }
 
     (main, root.join("feat"))
+}
+
+/// Run git in `dir`, sealed off the way [`Sandbox`] seals scriv off.
+///
+/// The sandbox has no git identity to commit with — hence the author and
+/// committer in the environment, and the two `GIT_CONFIG_*` variables that keep
+/// the machine running the test out of the result.
+fn git_in(dir: &Path, home: &Path, args: &[&str]) -> String {
+    let out = Command::new("git")
+        .args(args)
+        .current_dir(dir)
+        .env_clear()
+        .env("PATH", std::env::var("PATH").unwrap_or_default())
+        .env("HOME", home)
+        .env("GIT_CONFIG_GLOBAL", "/dev/null")
+        .env("GIT_CONFIG_SYSTEM", "/dev/null")
+        .env("GIT_AUTHOR_NAME", "scriv tests")
+        .env("GIT_AUTHOR_EMAIL", "tests@example.invalid")
+        .env("GIT_COMMITTER_NAME", "scriv tests")
+        .env("GIT_COMMITTER_EMAIL", "tests@example.invalid")
+        .output()
+        .expect("running git");
+    assert!(
+        out.status.success(),
+        "git {args:?} failed: {}",
+        String::from_utf8_lossy(&out.stderr),
+    );
+    String::from_utf8_lossy(&out.stdout).into_owned()
 }
 
 /// git reports the real path of a worktree, and a temporary directory on macOS
@@ -772,6 +782,189 @@ fn worktree_ls_outside_a_repository_says_so() {
         "{}",
         run.stderr
     );
+}
+
+#[test]
+fn worktree_add_creates_the_tree_beside_the_checkout_and_prints_its_path() {
+    let sandbox = Sandbox::new();
+    let (main, _) = mk_worktree_repo(sandbox.home());
+
+    let run = sandbox.run_in(&main, &["worktree", "add", "work/x"]);
+    run.ok();
+
+    let path = main.join(".worktrees/work-x");
+    assert!(
+        path.is_dir(),
+        "no tree at {}: {}",
+        path.display(),
+        run.stderr
+    );
+    // The path is stdout and git's narration is not, so `cd (scriv worktree
+    // add …)` lands in the tree rather than in a sentence about it.
+    assert_eq!(run.lines(), vec![real(&path)]);
+    assert_eq!(
+        git_in(
+            &path,
+            sandbox.home(),
+            &["rev-parse", "--abbrev-ref", "HEAD"]
+        )
+        .trim(),
+        "work/x",
+        "the tree is not on the branch it was asked for",
+    );
+}
+
+/// Untracked trees inside the repository are files `git status` reports and
+/// every `.gitignore`-honouring walker offers a second time.
+#[test]
+fn a_tree_inside_the_repository_is_excluded_from_it() {
+    let sandbox = Sandbox::new();
+    let (main, _) = mk_worktree_repo(sandbox.home());
+
+    let run = sandbox.run_in(&main, &["worktree", "add", "work/x"]);
+    run.ok();
+    assert!(run.stderr.contains("info/exclude"), "{}", run.stderr);
+
+    let status = git_in(&main, sandbox.home(), &["status", "--short"]);
+    assert!(
+        status.trim().is_empty(),
+        "the tree shows as untracked: {status}"
+    );
+
+    // Written once: a second tree finds the rule already there.
+    let again = sandbox.run_in(&main, &["worktree", "add", "work/y"]);
+    again.ok();
+    let exclude = std::fs::read_to_string(main.join(".git/info/exclude")).unwrap();
+    assert_eq!(exclude.matches(".worktrees/").count(), 1, "{exclude}");
+}
+
+#[test]
+fn an_absolute_worktree_root_keeps_each_repository_apart() {
+    let sandbox = Sandbox::new();
+    let (main, _) = mk_worktree_repo(sandbox.home());
+    sandbox.write_config("[worktree]\nroot = \"~/trees\"\n");
+
+    let run = sandbox.run_in(&main, &["worktree", "add", "work/x"]);
+    run.ok();
+
+    let path = sandbox.home().join("trees/scriv/work-x");
+    assert!(
+        path.is_dir(),
+        "no tree at {}: {}",
+        path.display(),
+        run.stderr
+    );
+    assert!(
+        !run.stderr.contains("info/exclude"),
+        "a tree outside the repository has nothing to hide from it: {}",
+        run.stderr
+    );
+}
+
+#[test]
+fn worktree_add_refuses_a_path_that_is_already_a_tree() {
+    let sandbox = Sandbox::new();
+    let (main, _) = mk_worktree_repo(sandbox.home());
+    sandbox.run_in(&main, &["worktree", "add", "work/x"]).ok();
+
+    let again = sandbox.run_in(&main, &["worktree", "add", "work/x"]);
+    again.code(1);
+    assert!(again.stderr.contains("already exists"), "{}", again.stderr);
+}
+
+#[test]
+fn worktree_rm_removes_the_tree_it_is_given() {
+    let sandbox = Sandbox::new();
+    let (main, _) = mk_worktree_repo(sandbox.home());
+    sandbox.run_in(&main, &["worktree", "add", "work/x"]).ok();
+    let path = main.join(".worktrees/work-x");
+
+    let run = sandbox.run_in(&main, &["worktree", "rm", path.to_str().unwrap(), "--yes"]);
+    run.ok();
+    assert!(
+        !path.exists(),
+        "{} survived: {}",
+        path.display(),
+        run.stderr
+    );
+}
+
+/// The question cannot be asked without a terminal, and a removal is not the
+/// kind of thing to answer on the user's behalf.
+#[test]
+fn worktree_rm_without_a_terminal_names_the_flag_that_skips_the_question() {
+    let sandbox = Sandbox::new();
+    let (main, _) = mk_worktree_repo(sandbox.home());
+    sandbox.run_in(&main, &["worktree", "add", "work/x"]).ok();
+    let path = main.join(".worktrees/work-x");
+
+    let run = sandbox.run_in(&main, &["worktree", "rm", path.to_str().unwrap()]);
+    run.code(1);
+    assert!(run.stderr.contains("--yes"), "{}", run.stderr);
+    assert!(path.exists(), "the tree went without being confirmed");
+}
+
+// --- branch deletion --------------------------------------------------------
+
+#[test]
+fn branch_rm_deletes_the_branches_it_is_given_and_says_what_had_landed() {
+    let sandbox = Sandbox::new();
+    let (main, _) = mk_worktree_repo(sandbox.home());
+    git_in(&main, sandbox.home(), &["branch", "landed"]);
+    git_in(&main, sandbox.home(), &["branch", "other"]);
+
+    let run = sandbox.run_in(&main, &["branch", "rm", "landed", "other", "--yes"]);
+    run.ok();
+
+    // Both point at HEAD, so git can see both have landed.
+    assert!(run.stdout.contains("landed  merged"), "{}", run.stdout);
+    assert!(run.stdout.contains("Deleted landed"), "{}", run.stdout);
+
+    let left = git_in(
+        &main,
+        sandbox.home(),
+        &["branch", "--format=%(refname:short)"],
+    );
+    let left: Vec<&str> = left.lines().collect();
+    assert_eq!(left, vec!["feat", "main"], "{left:?}");
+}
+
+/// A branch git cannot see has landed is still deletable — a repository that
+/// squashes its merges has no other kind — but the list says so first.
+#[test]
+fn an_unmerged_branch_is_marked_rather_than_refused() {
+    let sandbox = Sandbox::new();
+    let (main, _) = mk_worktree_repo(sandbox.home());
+    git_in(&main, sandbox.home(), &["checkout", "-b", "work"]);
+    git_in(
+        &main,
+        sandbox.home(),
+        &["commit", "--allow-empty", "-m", "wip"],
+    );
+    git_in(&main, sandbox.home(), &["checkout", "main"]);
+
+    let run = sandbox.run_in(&main, &["branch", "rm", "work", "--yes"]);
+    run.ok();
+    assert!(run.stdout.contains("work  not merged"), "{}", run.stdout);
+    assert!(run.stdout.contains("Deleted work"), "{}", run.stdout);
+}
+
+#[test]
+fn branch_rm_without_a_terminal_names_the_flag_that_skips_the_question() {
+    let sandbox = Sandbox::new();
+    let (main, _) = mk_worktree_repo(sandbox.home());
+    git_in(&main, sandbox.home(), &["branch", "keep"]);
+
+    let run = sandbox.run_in(&main, &["branch", "rm", "keep"]);
+    run.code(1);
+    assert!(run.stderr.contains("--yes"), "{}", run.stderr);
+
+    let left = git_in(
+        &main,
+        sandbox.home(),
+        &["branch", "--format=%(refname:short)"],
+    );
+    assert!(left.contains("keep"), "the branch went unconfirmed: {left}");
 }
 
 // --- the known-files list ---------------------------------------------------


### PR DESCRIPTION
The three verbs at the end of a piece of work. `worktree` and `branch` were the two registries missing them.

- `scriv worktree add [BRANCH]` — picks the path from `[worktree] root`, defaulting to `.worktrees/<branch>` inside the repository. Prints it, so `cd (scriv worktree add feat/x)` works.
- A bare name only a remote has arrives tracking it. `git switch` guesses that; `git worktree add -b` does not, and would build a new branch from HEAD sharing a name with the remote one and nothing else.
- A root inside the repository goes into that clone's `.git/info/exclude` on the first tree, or `git status` and every walker sees the tree twice.
- `scriv worktree rm [PATH]...` — several at a time, neither the main tree nor the one you are in.
- `scriv branch rm [BRANCH]...` — several at a time, each marked with whether git can see it has landed. Answering the question releases an unmerged one; a squash-merging repository has no other kind. Remote branches are never offered.

Cost: `branch rm` spends one extra `git branch --merged` per run, and `worktree add` writes to `.git/info/exclude` without being asked — a local, uncommitted file, reported on stderr when it happens.

CLI help: four new doc comments; `EXAMPLES` is unchanged, since nothing there earned displacing. README: the two command-table rows. `docs/demo.gif`: nothing a selector draws changed. CHANGELOG: three lines under Added. `Release: minor` is on the commit.