### PR TITLE
Find a process by the port it is holding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ raised, never by hand.
   whether git can see its commits have landed. Answering the question is what
   lets an unmerged branch go — a repository that squashes its merges has no
   other kind. Remote branches are never offered: deleting one is a push.
+- `scriv proc --port 3000` narrows `ls`, `sel` and `kill` to what is listening
+  on a TCP port, so "what is holding 3000" no longer means reading a pid out of
+  `lsof`. `kill --port` opens no selector — a port names its processes as
+  precisely as a pid does — and prints what it found as it signals them.
 
 ### Changed
 

--- a/src/cmd/config.rs
+++ b/src/cmd/config.rs
@@ -472,7 +472,8 @@ fn collect(ctx: &Ctx) -> Vec<Check> {
         "`branch` and `repo` cannot work without it",
     ));
     checks.push(gh_check());
-    // `kill` gets no row: it ships in the same base system `ps` does.
+    // `kill` and `lsof` get no row: both ship in the same base system `ps`
+    // does, and a report of three lines saying the same thing is one line.
     checks.push(tool_check(
         "ps",
         "ps",

--- a/src/cmd/proc.rs
+++ b/src/cmd/proc.rs
@@ -38,9 +38,39 @@ fn self_pid() -> i32 {
 }
 
 /// The process table, minus what must never be offered: scriv itself and
-/// everything above it in the parent chain.
-fn processes() -> Result<Vec<Process>> {
-    Ok(proc::selectable(&table()?, self_pid()))
+/// everything above it in the parent chain. With a `port`, narrowed to what is
+/// listening on it.
+fn processes(port: Option<u16>) -> Result<Vec<Process>> {
+    let procs = proc::selectable(&table()?, self_pid());
+    let Some(port) = port else {
+        return Ok(procs);
+    };
+    let pids = listeners(port)?;
+    let procs = proc::with_pids(&procs, &pids);
+    if procs.is_empty() {
+        bail!("nothing scriv may signal is listening on port {port}");
+    }
+    Ok(procs)
+}
+
+/// The pids listening on `port`, via `lsof`.
+///
+/// `lsof` exits 1 when it matched nothing, which for a port nobody is using is
+/// an answer rather than a failure — hence reading the status only far enough
+/// to tell that apart from `lsof` being absent.
+fn listeners(port: u16) -> Result<Vec<i32>> {
+    let output = Command::new("lsof")
+        .args(proc::lsof_args(port))
+        .stdin(Stdio::null())
+        .stderr(Stdio::null())
+        .output()
+        .map_err(|err| match err.kind() {
+            ErrorKind::NotFound => {
+                anyhow!("`lsof` was not found on PATH — `--port` asks it which process holds one")
+            }
+            _ => anyhow!(err).context("running lsof"),
+        })?;
+    Ok(proc::parse_pids(&String::from_utf8_lossy(&output.stdout)))
 }
 
 fn spawn_error(err: std::io::Error) -> anyhow::Error {
@@ -51,8 +81,8 @@ fn spawn_error(err: std::io::Error) -> anyhow::Error {
 }
 
 /// `scriv proc ls` — print the running processes, busiest first.
-pub fn ls(ctx: &Ctx, status: bool) -> Result<()> {
-    let procs = processes()?;
+pub fn ls(ctx: &Ctx, status: bool, port: Option<u16>) -> Result<()> {
+    let procs = processes(port)?;
     let width = proc::user_width(&procs);
     let mut out = term::Listing::stdout();
     for p in &procs {
@@ -70,8 +100,8 @@ pub fn ls(ctx: &Ctx, status: bool) -> Result<()> {
 }
 
 /// `scriv proc sel` — fuzzy-select a process and print its pid.
-pub fn sel(ctx: &Ctx) -> Result<()> {
-    let procs = processes()?;
+pub fn sel(ctx: &Ctx, port: Option<u16>) -> Result<()> {
+    let procs = processes(port)?;
     if procs.is_empty() {
         bail!("no processes to select from");
     }
@@ -84,11 +114,19 @@ pub fn sel(ctx: &Ctx) -> Result<()> {
 ///
 /// Several pids are signalled one at a time, so a refusal is reported against
 /// the row it belongs to and does not hide the ones that worked.
-pub fn kill(ctx: &Ctx, pids: &[i32], signal: Signal) -> Result<()> {
+pub fn kill(ctx: &Ctx, pids: &[i32], signal: Signal, port: Option<u16>) -> Result<()> {
     let table = table()?;
     let procs = proc::selectable(&table, self_pid());
 
-    let targets = if pids.is_empty() {
+    let targets = if let Some(port) = port {
+        // No selector: a port names its processes as precisely as a pid does,
+        // and the whole point of asking by one is not to have to look.
+        let holding = processes(Some(port))?;
+        for p in &holding {
+            eprintln!("port {port}: {}", proc::plain_row(p));
+        }
+        holding.iter().map(|p| p.pid).collect()
+    } else if pids.is_empty() {
         match choose(ctx, &procs, signal)? {
             Some(targets) => targets,
             None => return Ok(()),

--- a/src/main.rs
+++ b/src/main.rs
@@ -145,6 +145,9 @@ enum Command {
     /// it was started with rather than by its name alone. scriv's own process
     /// and everything that spawned it are never listed: killing the shell or
     /// the terminal is not a thing to be one keystroke away from.
+    ///
+    /// `--port` narrows all three verbs to what is listening on a TCP port,
+    /// which is `lsof`'s answer rather than `ps`'s.
     #[command(visible_alias = "pc")]
     Proc {
         #[command(subcommand)]
@@ -513,6 +516,18 @@ enum PrCmd {
     },
 }
 
+/// Narrow a `proc` listing to what holds a TCP port, shared by all three.
+#[derive(clap::Args)]
+struct PortScope {
+    /// Only the process listening on this TCP port
+    ///
+    /// Answers "what is holding 3000" without a pid, through `lsof`. Listening
+    /// sockets only: the process that owns the port, not everything talking
+    /// to it.
+    #[arg(short, long, value_name = "PORT")]
+    port: Option<u16>,
+}
+
 #[derive(Subcommand)]
 enum ProcCmd {
     /// List running processes, busiest first
@@ -524,15 +539,23 @@ enum ProcCmd {
         /// the pid without a parser.
         #[arg(long)]
         status: bool,
+        #[command(flatten)]
+        scope: PortScope,
     },
     /// Fuzzy-select a process and print its pid
-    Sel,
+    Sel {
+        #[command(flatten)]
+        scope: PortScope,
+    },
     /// Signal processes; omit the pids to select them
     ///
     /// `tab` selects several in the selector and they are signalled together.
     /// The default signal is `TERM`, which a process can catch to flush its
     /// buffers and clean up after itself; `--force` sends `KILL`, which it
     /// cannot.
+    ///
+    /// `--port` opens no selector: a port names its processes as precisely as
+    /// a pid does, and what it named is printed as they are signalled.
     Kill {
         /// Processes to signal, by pid; omit to select interactively
         #[arg(value_name = "PID")]
@@ -543,6 +566,8 @@ enum ProcCmd {
         /// Send `KILL` instead, which cannot be caught or ignored
         #[arg(short = '9', long, conflicts_with = "signal")]
         force: bool,
+        #[command(flatten)]
+        scope: PortScope,
     },
 }
 
@@ -713,12 +738,13 @@ fn run(cli: Cli) -> anyhow::Result<()> {
             ),
         },
         Command::Proc { command } => match command {
-            ProcCmd::Ls { status } => cmd::proc::ls(&ctx, status),
-            ProcCmd::Sel => cmd::proc::sel(&ctx),
+            ProcCmd::Ls { status, scope } => cmd::proc::ls(&ctx, status, scope.port),
+            ProcCmd::Sel { scope } => cmd::proc::sel(&ctx, scope.port),
             ProcCmd::Kill {
                 pids,
                 signal,
                 force,
+                scope,
             } => {
                 // `--force` and `--signal` conflict, so this is a choice
                 // between the flag and the default.
@@ -727,7 +753,7 @@ fn run(cli: Cli) -> anyhow::Result<()> {
                 } else {
                     scriv::proc::Signal::parse(&signal)?
                 };
-                cmd::proc::kill(&ctx, &pids, signal)
+                cmd::proc::kill(&ctx, &pids, signal, scope.port)
             }
         },
         Command::History { command } => match command {

--- a/src/proc.rs
+++ b/src/proc.rs
@@ -150,6 +150,44 @@ pub fn selectable(processes: &[Process], self_pid: i32) -> Vec<Process> {
     visible
 }
 
+/// The `lsof` arguments that list what is listening on a TCP port: numeric
+/// addresses and ports (`-nP`, so nothing is looked up over the network), the
+/// port itself, listening sockets only, and terse output — one pid per line.
+///
+/// Listening rather than connected: "what is holding 3000" is a question about
+/// the process that owns the port, not about everything talking to it.
+pub fn lsof_args(port: u16) -> [String; 4] {
+    [
+        "-nP".to_string(),
+        format!("-iTCP:{port}"),
+        "-sTCP:LISTEN".to_string(),
+        "-t".to_string(),
+    ]
+}
+
+/// Parse `lsof -t` output: one pid per line, and nothing else.
+///
+/// The same pid appears once per socket it holds — a server bound to both
+/// address families is two lines — so they are deduplicated, in the order they
+/// were first seen.
+pub fn parse_pids(text: &str) -> Vec<i32> {
+    let mut seen = HashSet::new();
+    text.lines()
+        .filter_map(|line| line.trim().parse::<i32>().ok())
+        .filter(|pid| seen.insert(*pid))
+        .collect()
+}
+
+/// The processes among `procs` holding `pids`, in the order `procs` was in.
+pub fn with_pids(procs: &[Process], pids: &[i32]) -> Vec<Process> {
+    let wanted: HashSet<i32> = pids.iter().copied().collect();
+    procs
+        .iter()
+        .filter(|p| wanted.contains(&p.pid))
+        .cloned()
+        .collect()
+}
+
 /// A plain listing row: the pid and the command, one space apart, so
 /// `scriv proc ls | grep node | cut -d' ' -f1` reaches the pid.
 pub fn plain_row(p: &Process) -> String {
@@ -295,6 +333,33 @@ joakim            501     1   12.3  1.5    03:12:44 /usr/local/bin/node server.j
 root              1       0    0.0  0.1 12-04:11:02 /sbin/launchd
 joakim          70123 70100    0.0  0.4       01:20 -fish
 ";
+
+    #[test]
+    fn a_pid_holding_two_sockets_is_one_row() {
+        // What `lsof -t` writes for a server bound to both address families.
+        assert_eq!(parse_pids("501\n501\n733\n"), vec![501, 733]);
+        assert_eq!(parse_pids(""), Vec::<i32>::new());
+        assert_eq!(parse_pids("not a pid\n\n42\n"), vec![42]);
+    }
+
+    #[test]
+    fn the_port_lookup_never_waits_on_a_name_server() {
+        let args = lsof_args(3000);
+        assert!(args.contains(&"-nP".to_string()), "{args:?}");
+        assert_eq!(args[1], "-iTCP:3000");
+        assert!(args.contains(&"-sTCP:LISTEN".to_string()), "{args:?}");
+    }
+
+    #[test]
+    fn only_the_processes_named_by_the_port_survive() {
+        let procs = sample();
+        let kept: Vec<i32> = with_pids(&procs, &[70123, 999])
+            .iter()
+            .map(|p| p.pid)
+            .collect();
+        assert_eq!(kept, vec![70123]);
+        assert!(with_pids(&procs, &[]).is_empty());
+    }
 
     fn sample() -> Vec<Process> {
         parse(SAMPLE)

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1244,6 +1244,39 @@ fn proc_ls_offers_neither_scriv_nor_the_process_that_ran_it() {
     }
 }
 
+/// Port 0 is the one port nothing can be listening on, which is what makes
+/// this a test of the flag rather than of whatever the machine happens to be
+/// running.
+#[test]
+fn a_port_nothing_holds_says_so_rather_than_listing_everything() {
+    let sandbox = Sandbox::new();
+    for verb in [&["ls"][..], &["sel"][..], &["kill"][..]] {
+        let mut args = vec!["proc"];
+        args.extend_from_slice(verb);
+        args.extend_from_slice(&["--port", "0"]);
+        let run = sandbox.run(&args);
+        run.code(1);
+        assert!(
+            run.stderr.contains("port 0"),
+            "`proc {}`: {}",
+            verb.join(" "),
+            run.stderr
+        );
+        assert!(
+            run.stdout.is_empty(),
+            "listed processes the port did not name: {}",
+            run.stdout
+        );
+    }
+}
+
+#[test]
+fn a_port_has_to_be_one() {
+    let sandbox = Sandbox::new();
+    sandbox.run(&["proc", "ls", "--port", "not-a-port"]).code(2);
+    sandbox.run(&["proc", "ls", "--port", "70000"]).code(2);
+}
+
 #[test]
 fn proc_ls_status_adds_columns_ahead_of_the_command() {
     let sandbox = Sandbox::new();


### PR DESCRIPTION
`--port` narrows `proc ls`, `proc sel` and `proc kill` to what is listening on a TCP port, so "what is holding 3000" stops being a pid read out of `lsof` by eye.

- Listening sockets only — the process that owns the port, not everything talking to it.
- `kill --port` opens no selector; it prints what the port named as it signals each one. The ancestry refusals still apply.
- `lsof` gets no `config check` row, for the reason `kill` has none: it ships in the same base system `ps` does.

Cost: one `lsof` spawn per run that passes `--port`, and a new external tool on that path — a missing `lsof` is reported by name.

Tests use port 0, which nothing can listen on, rather than binding a real port and being flaky about it; the parsing has unit tests.

CLI help: `--port` documented on the group and on `kill`, where it changes what the verb does. README: unchanged, no new group and `lsof` is base-system like `ps`. `docs/demo.gif`: nothing a selector draws changed. CHANGELOG: one line under Added. `Release: minor` is on the commit.