### PR TITLE
Offer the repositories and files you actually work in first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ raised, never by hand.
 
 ### Added
 
+- The repositories and files you actually work in are offered first.
+  `repo sel`, `repo open`, `file sel` and `edit --tracked` now lead with what
+  you have chosen before — frequently and recently both count — instead of
+  making you type your way past a hundred and ninety-five repositories to reach
+  the five you are living in. Everything unchosen keeps its old order below.
+  `[selector] recent = false` turns it off and stops the choices being
+  recorded; `ls` is unaffected, so anything piping it sees no change. The
+  record lives in `recent`, beside your config.
 - `scriv worktree add` creates a working tree and picks where it goes:
   `.worktrees/<branch>` inside the repository, or wherever `[worktree] root`
   says. A branch that does not exist yet is created, a remote-only one arrives

--- a/src/cmd/config.rs
+++ b/src/cmd/config.rs
@@ -62,6 +62,7 @@ ignore = ["node_modules", "target"]
 # The built-in fuzzy selector, shared by every command that opens one.
 [selector]
 height = "50%"        # finder height, e.g. "50%" or "20"
+# recent = true        # offer repositories and files you have chosen before first
 # preview = true       # show a preview pane for the highlighted row
 # preview_window = "right:50%" # preview layout: [up|down|left|right][:SIZE][:hidden]
 "#;

--- a/src/cmd/edit.rs
+++ b/src/cmd/edit.rs
@@ -111,7 +111,14 @@ fn select_tracked(ctx: &Ctx) -> Result<Option<Vec<String>>> {
         })
         .collect();
 
-    cancellable(select::select_many(items, "Edit", &ctx.config.selector))
+    let (items, now) = ctx.by_recency(items, |row| row.value());
+    let chosen = cancellable(select::select_many(items, "Edit", &ctx.config.selector))?;
+    // Every file opened together counts: the next selector is being asked
+    // which of them you reach for, not which you happened to list first.
+    for file in chosen.iter().flatten() {
+        ctx.remember(file, now);
+    }
+    Ok(chosen)
 }
 
 /// Map a cancelled selector to `None`, leaving real errors alone.

--- a/src/cmd/file.rs
+++ b/src/cmd/file.rs
@@ -243,7 +243,9 @@ pub fn sel(ctx: &Ctx) -> Result<()> {
         })
         .collect();
 
+    let (items, now) = ctx.by_recency(items, |row| row.value());
     let choice = select::select_one(items, "Select a file", &ctx.config.selector)?;
+    ctx.remember(&choice, now);
     println!("{choice}");
     Ok(())
 }

--- a/src/cmd/repo.rs
+++ b/src/cmd/repo.rs
@@ -160,8 +160,9 @@ fn repo_rows(ctx: &Ctx, repos: &[FoundRepo]) -> Vec<SelectItem> {
 /// The path is printed absolute so a shell shim can `cd` to it directly.
 pub fn sel(ctx: &Ctx) -> Result<()> {
     let repos = discover(ctx)?;
-    let rows = repo_rows(ctx, &repos);
+    let (rows, now) = ctx.by_recency(repo_rows(ctx, &repos), |row| row.value());
     let choice = select::select_one(rows, "Select a repository", &ctx.config.selector)?;
+    ctx.remember(&choice, now);
     println!("{choice}");
     Ok(())
 }
@@ -195,8 +196,9 @@ pub fn open(ctx: &Ctx, force_select: bool) -> Result<()> {
     }
 
     let repos = discover(ctx)?;
-    let rows = repo_rows(ctx, &repos);
+    let (rows, now) = ctx.by_recency(repo_rows(ctx, &repos), |row| row.value());
     let choice = select::select_one(rows, "Open a repository on GitHub", &ctx.config.selector)?;
+    ctx.remember(&choice, now);
     gh::view_repo_web(Path::new(&choice))
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,15 +2,18 @@
 //! they take environment and home values as arguments — so the only I/O is the
 //! file read in [`load_config`].
 //!
-//! Two files live side by side under the config directory:
+//! Three files live side by side under the config directory:
 //!
 //! - `config.toml` — hand-edited settings, grouped by the command that reads
-//!   them: `[repo]` for discovery and labelling, `[history]` for the shell
-//!   history to search, `[selector]` for the finder every command shares. A
-//!   legacy `config.json` is still read when no TOML file is present.
+//!   them: `[repo]` for discovery and labelling, `[worktree]` for where a new
+//!   tree goes, `[history]` for the shell history to search, `[selector]` for
+//!   the finder every command shares. A legacy `config.json` is still read when
+//!   no TOML file is present.
 //! - `files` — the known-files list, rewritten programmatically by
 //!   `scriv file add`/`rm`/`prune`. Kept separate so machine writes never
 //!   clobber hand-written settings or comments.
+//! - `recent` — what has been selected before, rewritten on every selection.
+//!   See [`crate::recent`]; kept separate for the same reason.
 //!
 //! A key belongs in a command's table when exactly one command reads it;
 //! anything genuinely shared stays at the top level.
@@ -181,6 +184,10 @@ pub struct SelectorConfig {
     /// Preview pane layout in skim's syntax, e.g. `"right:50%"`, `"down:40%"`,
     /// or `"right:50%:hidden"` to start collapsed.
     pub preview_window: String,
+    /// Whether repositories and files you have chosen before are offered first.
+    /// Off, every such list keeps the order the command built it in, and
+    /// nothing is recorded.
+    pub recent: bool,
 }
 
 /// How `repo ls`/`sel` renders each repository's path.
@@ -214,6 +221,7 @@ impl Default for SelectorConfig {
             height: "50%".to_string(),
             preview: true,
             preview_window: "right:50%".to_string(),
+            recent: true,
         }
     }
 }
@@ -252,6 +260,7 @@ struct RawSelector {
     height: Option<String>,
     preview: Option<bool>,
     preview_window: Option<String>,
+    recent: Option<bool>,
     /// Superseded by `[repo] display`, present for detection only.
     display: Option<RepoDisplay>,
 }
@@ -263,6 +272,7 @@ impl From<RawSelector> for SelectorConfig {
             height: raw.height.unwrap_or(default.height),
             preview: raw.preview.unwrap_or(default.preview),
             preview_window: raw.preview_window.unwrap_or(default.preview_window),
+            recent: raw.recent.unwrap_or(default.recent),
         }
     }
 }
@@ -969,6 +979,18 @@ preview = false
             parse_toml("[selector]\npreview = false\npreview_window = \"down:40%\"\n").unwrap();
         assert!(!cfg.selector.preview);
         assert_eq!(cfg.selector.preview_window, "down:40%");
+    }
+
+    #[test]
+    fn recent_ordering_is_on_unless_turned_off() {
+        assert!(parse_toml("").unwrap().selector.recent);
+        assert!(parse_toml("[selector]\n").unwrap().selector.recent);
+        assert!(
+            !parse_toml("[selector]\nrecent = false\n")
+                .unwrap()
+                .selector
+                .recent
+        );
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ pub mod history;
 pub mod logger;
 pub mod path;
 pub mod proc;
+pub mod recent;
 pub mod repo;
 pub mod select;
 pub mod shell;
@@ -34,6 +35,24 @@ pub const VERSION: &str = env!("SCRIV_VERSION");
 
 use config::Config;
 use logger::Logger;
+
+/// The wall clock, in Unix seconds, as [`recent`] counts it. Before 1970 is not
+/// a time anything here has to represent.
+fn unix_now() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|since| since.as_secs() as i64)
+        .unwrap_or(0)
+}
+
+/// Write the store, creating its directory — the config directory exists on
+/// every machine that has a config, and not on one that has never had one.
+fn write_recent(path: &Path, contents: &str) -> Result<()> {
+    if let Some(dir) = path.parent() {
+        std::fs::create_dir_all(dir).with_context(|| format!("creating {}", dir.display()))?;
+    }
+    std::fs::write(path, contents).with_context(|| format!("writing {}", path.display()))
+}
 
 /// A subprocess that already explained its own failure on stderr. Propagated
 /// instead of a message so the command exits with the child's status without
@@ -61,6 +80,8 @@ pub struct Ctx {
     pub config_path: PathBuf,
     /// The known-files list, beside the config file.
     pub files_path: PathBuf,
+    /// What has been selected before, beside the config file.
+    pub recent_path: PathBuf,
     /// The standalone `kf` tool's config, read once to migrate its list.
     pub legacy_kf_path: PathBuf,
     /// fish's history file, which `scriv history` reads.
@@ -114,6 +135,7 @@ impl Ctx {
             |p| p.exists(),
         );
         let files_path = config::files_path(&config_path);
+        let recent_path = recent::path(&config_path);
         let legacy_kf_path = config::legacy_kf_path(xdg_env.as_deref(), &home);
         let config = config::load_config(&config_path)?;
 
@@ -145,6 +167,7 @@ impl Ctx {
             home,
             config_path,
             files_path,
+            recent_path,
             legacy_kf_path,
             history_path,
             utc_offset,
@@ -203,6 +226,39 @@ impl Ctx {
 
     pub fn pwd_str(&self) -> &str {
         &self.pwd_s
+    }
+
+    /// Reorder `items` so what has been selected before comes first, and hand
+    /// back the clock reading it was ordered against — [`Ctx::remember`] dates
+    /// the selection with the same one, so a row cannot be scored against a
+    /// moment before it was chosen.
+    ///
+    /// A store that cannot be read leaves the order alone: an unreadable file
+    /// of past selections is not a reason to fail the selection in hand.
+    pub fn by_recency<T>(&self, items: Vec<T>, key: impl Fn(&T) -> &str) -> (Vec<T>, i64) {
+        let now = unix_now();
+        if !self.config.selector.recent {
+            return (items, now);
+        }
+        let uses = recent::parse(&std::fs::read_to_string(&self.recent_path).unwrap_or_default());
+        (recent::order(items, key, &uses, now), now)
+    }
+
+    /// Record that `key` was selected at `now`.
+    ///
+    /// Best effort: the selection has already happened and been acted on, and
+    /// failing it afterwards over a file that only decides an ordering would be
+    /// reporting the wrong thing.
+    pub fn remember(&self, key: &str, now: i64) {
+        if !self.config.selector.recent {
+            return;
+        }
+        let uses = recent::parse(&std::fs::read_to_string(&self.recent_path).unwrap_or_default());
+        let uses = recent::bump(uses, key, now);
+        if let Err(err) = write_recent(&self.recent_path, &recent::render(&uses)) {
+            self.log
+                .warn(&format!("could not record the selection: {err:#}"));
+        }
     }
 
     /// Copy the standalone `kf` tool's list into place on first use.

--- a/src/main.rs
+++ b/src/main.rs
@@ -225,6 +225,11 @@ enum RepoCmd {
         absolute_paths: bool,
     },
     /// Fuzzy-select a repository and print its absolute path
+    ///
+    /// The ones you have chosen before come first, most-used-recently first;
+    /// the rest stay in path order below them. `[selector] recent = false`
+    /// turns that off, and stops the choices being recorded. `ls` is unaffected
+    /// — the set it prints keeps one order so it can be piped.
     Sel,
     /// Open a repository's GitHub page in the browser
     ///
@@ -279,6 +284,9 @@ enum FileCmd {
         exists: bool,
     },
     /// Fuzzy-select a known file and print its absolute path
+    ///
+    /// Ordered like `repo sel`: what you have opened before comes first. The
+    /// same list, and the same order, as `scriv edit --tracked`.
     Sel,
     /// Add a file; omit the path to select one from the current directory
     Add {

--- a/src/recent.rs
+++ b/src/recent.rs
@@ -1,0 +1,307 @@
+//! What you have chosen before, and how much that should count for.
+//!
+//! A list of two hundred repositories is alphabetical, and the five you are
+//! living in this week are scattered through it. This records each selection
+//! and floats the ones that are both frequent and recent back to the top —
+//! frecency, as Firefox's address bar named it.
+//!
+//! Everything here is pure: the file read, the file write and the clock live in
+//! the [`cmd`](crate::cmd) modules that call it.
+
+use std::path::{Path, PathBuf};
+
+/// One thing that has been chosen, and how its choosing has gone.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Use {
+    /// What was chosen — the value a selector returned, so an absolute path.
+    pub key: String,
+    /// How many times.
+    pub count: u32,
+    /// Unix seconds of the most recent time.
+    pub when: i64,
+}
+
+/// The store, beside the config file and the known-files list.
+///
+/// A third file in that directory rather than a key in `config.toml`: this one
+/// is written by scriv on every selection, and machine writes have no business
+/// in a file somebody hand-edits.
+pub fn path(config_path: &Path) -> PathBuf {
+    config_path
+        .parent()
+        .filter(|p| !p.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."))
+        .join("recent")
+}
+
+/// How many entries the store keeps. Well past what anyone selects from, and
+/// low enough that reading it stays free; the lowest-scoring go first.
+const CAPACITY: usize = 500;
+
+/// Parse the store: `<count> <unix-seconds> <key>`, one per line.
+///
+/// A line that does not parse is skipped rather than refused. Nothing about
+/// this file is worth failing a selection over — at worst the ordering is the
+/// one it would have had anyway.
+pub fn parse(text: &str) -> Vec<Use> {
+    text.lines()
+        .filter_map(|line| {
+            let mut fields = line.splitn(3, ' ');
+            let count = fields.next()?.parse().ok()?;
+            let when = fields.next()?.parse().ok()?;
+            // The key is last and unsplit: a path may contain spaces.
+            let key = fields.next()?;
+            (!key.is_empty()).then(|| Use {
+                key: key.to_string(),
+                count,
+                when,
+            })
+        })
+        .collect()
+}
+
+/// Render the store back, in the order given.
+pub fn render(uses: &[Use]) -> String {
+    let mut out = String::new();
+    for used in uses {
+        // A key holding a newline would come back as two entries, neither of
+        // them the path. Nothing produces one, and this is what keeps it so.
+        if used.key.contains('\n') {
+            continue;
+        }
+        out.push_str(&format!("{} {} {}\n", used.count, used.when, used.key));
+    }
+    out
+}
+
+/// How long each weight applies for, and what it is worth: a choice made
+/// within the hour counts for four of the same choice made last month, and
+/// sixteen of one made last year.
+///
+/// Recency multiplies frequency rather than replacing it, and the multiplier is
+/// deliberately small next to the range counts reach. Something opened forty
+/// times still outranks something opened twice this morning — it is the better
+/// guess, and one selection is all it takes to put the newcomer on top for the
+/// rest of the hour.
+const WEIGHTS: &[(i64, f64)] = &[
+    (60 * 60, 4.0),           // within the hour
+    (24 * 60 * 60, 2.0),      // today
+    (7 * 24 * 60 * 60, 1.0),  // this week
+    (30 * 24 * 60 * 60, 0.5), // this month
+];
+
+/// What an older-than-every-weight entry is worth. Not zero: something chosen
+/// two hundred times last year is still a better guess than something never
+/// chosen at all.
+const STALE_WEIGHT: f64 = 0.25;
+
+/// How much this use is worth at `now`.
+pub fn score(used: &Use, now: i64) -> f64 {
+    let age = now.saturating_sub(used.when).max(0);
+    let weight = WEIGHTS
+        .iter()
+        .find(|(within, _)| age < *within)
+        .map(|(_, weight)| *weight)
+        .unwrap_or(STALE_WEIGHT);
+    f64::from(used.count) * weight
+}
+
+/// Record a choice: a new entry, or one more of an existing one.
+///
+/// Trimmed to [`CAPACITY`] by score, so the file cannot grow without bound —
+/// what goes is what was already least likely to be offered first.
+pub fn bump(mut uses: Vec<Use>, key: &str, now: i64) -> Vec<Use> {
+    match uses.iter_mut().find(|used| used.key == key) {
+        Some(used) => {
+            used.count = used.count.saturating_add(1);
+            used.when = now;
+        }
+        None => uses.push(Use {
+            key: key.to_string(),
+            count: 1,
+            when: now,
+        }),
+    }
+
+    if uses.len() > CAPACITY {
+        uses.sort_by(|a, b| by_score(a, b, now));
+        uses.truncate(CAPACITY);
+    }
+    uses
+}
+
+/// Best first: score, then the more recent of a tie, then by key so the order
+/// is the same on every run.
+fn by_score(a: &Use, b: &Use, now: i64) -> std::cmp::Ordering {
+    score(b, now)
+        .partial_cmp(&score(a, now))
+        .unwrap_or(std::cmp::Ordering::Equal)
+        .then(b.when.cmp(&a.when))
+        .then(a.key.cmp(&b.key))
+}
+
+/// Reorder `items` so the ones chosen before come first, best guess first.
+///
+/// Everything unchosen keeps the order it arrived in, below them: the list a
+/// command builds is already meaningful — alphabetical, or newest first — and
+/// having no history is not a reason to shuffle it.
+pub fn order<T>(items: Vec<T>, key: impl Fn(&T) -> &str, uses: &[Use], now: i64) -> Vec<T> {
+    if uses.is_empty() {
+        return items;
+    }
+
+    let mut seen: Vec<(f64, T)> = Vec::new();
+    let mut rest: Vec<T> = Vec::new();
+    for item in items {
+        match uses.iter().find(|used| used.key == key(&item)) {
+            Some(used) => seen.push((score(used, now), item)),
+            None => rest.push(item),
+        }
+    }
+
+    // Stable, so two rows of equal score stay in the order the command built
+    // them in rather than swapping between runs.
+    seen.sort_by(|(a, _), (b, _)| b.partial_cmp(a).unwrap_or(std::cmp::Ordering::Equal));
+
+    let mut out: Vec<T> = seen.into_iter().map(|(_, item)| item).collect();
+    out.extend(rest);
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const HOUR: i64 = 60 * 60;
+    const DAY: i64 = 24 * HOUR;
+    const NOW: i64 = 1_785_394_626;
+
+    fn used(key: &str, count: u32, ago: i64) -> Use {
+        Use {
+            key: key.to_string(),
+            count,
+            when: NOW - ago,
+        }
+    }
+
+    #[test]
+    fn a_store_round_trips() {
+        let uses = vec![
+            used("/home/u/dev/scriv", 3, HOUR),
+            used("/home/u/a b", 1, 0),
+        ];
+        assert_eq!(parse(&render(&uses)), uses);
+    }
+
+    /// A path may contain spaces, and the key is the rest of the line.
+    #[test]
+    fn a_key_with_spaces_survives() {
+        let parsed = parse("2 100 /home/u/my repo/file.txt\n");
+        assert_eq!(parsed[0].key, "/home/u/my repo/file.txt");
+        assert_eq!(parsed[0].count, 2);
+    }
+
+    #[test]
+    fn a_line_that_makes_no_sense_is_skipped_rather_than_fatal() {
+        let parsed = parse("garbage\n\n1 notanumber /x\n2 100 /y\n1 200\n");
+        assert_eq!(parsed.len(), 1);
+        assert_eq!(parsed[0].key, "/y");
+    }
+
+    #[test]
+    fn the_same_count_ranks_by_how_recently_it_was_used() {
+        assert!(score(&used("a", 3, HOUR / 2), NOW) > score(&used("b", 3, 3 * DAY), NOW));
+        assert!(score(&used("b", 3, 3 * DAY), NOW) > score(&used("c", 3, 300 * DAY), NOW));
+    }
+
+    /// The multiplier is small next to the range counts reach, on purpose: a
+    /// repository opened forty times is a better guess than one opened twice,
+    /// and one selection is all it takes to put the newcomer on top.
+    #[test]
+    fn frequency_is_not_drowned_out_by_recency() {
+        let old_favourite = used("a", 40, 300 * DAY);
+        let newcomer = used("b", 2, HOUR / 2);
+        assert!(score(&old_favourite, NOW) > score(&newcomer, NOW));
+
+        let bumped = bump(vec![newcomer], "b", NOW);
+        assert!(
+            score(&bumped[0], NOW) > score(&old_favourite, NOW),
+            "one more selection did not put the newcomer on top",
+        );
+    }
+
+    #[test]
+    fn an_old_choice_still_beats_no_choice_at_all() {
+        assert!(score(&used("a", 1, 900 * DAY), NOW) > 0.0);
+    }
+
+    /// A clock that has gone backwards — a laptop waking with the wrong time,
+    /// a store copied between machines — must not make a score enormous.
+    #[test]
+    fn a_use_from_the_future_is_not_worth_more_than_one_from_now() {
+        assert_eq!(
+            score(&used("a", 1, -DAY), NOW),
+            score(&used("a", 1, 0), NOW)
+        );
+    }
+
+    #[test]
+    fn bumping_counts_a_repeat_and_dates_it() {
+        let uses = bump(vec![used("/a", 2, DAY)], "/a", NOW);
+        assert_eq!(uses.len(), 1);
+        assert_eq!(uses[0].count, 3);
+        assert_eq!(uses[0].when, NOW);
+    }
+
+    #[test]
+    fn bumping_something_new_records_it() {
+        let uses = bump(vec![used("/a", 2, DAY)], "/b", NOW);
+        assert_eq!(uses.len(), 2);
+        assert_eq!(uses[1], used("/b", 1, 0));
+    }
+
+    #[test]
+    fn the_store_does_not_grow_without_bound() {
+        let mut uses: Vec<Use> = (0..CAPACITY)
+            .map(|i| used(&format!("/old{i}"), 1, 500 * DAY))
+            .collect();
+        // One entry worth keeping among a full store of stale ones.
+        uses[0] = used("/kept", 50, HOUR);
+
+        let uses = bump(uses, "/new", NOW);
+        assert_eq!(uses.len(), CAPACITY);
+        assert!(
+            uses.iter().any(|u| u.key == "/kept"),
+            "dropped the best one"
+        );
+        assert!(
+            uses.iter().any(|u| u.key == "/new"),
+            "dropped what it just recorded"
+        );
+    }
+
+    #[test]
+    fn chosen_rows_come_first_and_the_rest_keep_their_order() {
+        let items = vec!["/a", "/b", "/c", "/d"];
+        let uses = vec![used("/c", 1, HOUR), used("/a", 5, HOUR)];
+
+        let got = order(items, |s| s, &uses, NOW);
+        assert_eq!(got, vec!["/a", "/c", "/b", "/d"]);
+    }
+
+    #[test]
+    fn nothing_chosen_leaves_the_list_exactly_as_it_was() {
+        let items = vec!["/a", "/b", "/c"];
+        assert_eq!(order(items.clone(), |s| s, &[], NOW), items);
+        let unrelated = vec![used("/z", 9, 0)];
+        assert_eq!(order(items.clone(), |s| s, &unrelated, NOW), items);
+    }
+
+    #[test]
+    fn the_store_lives_beside_the_config_it_belongs_to() {
+        assert_eq!(
+            path(Path::new("/home/u/.config/scriv/config.toml")),
+            PathBuf::from("/home/u/.config/scriv/recent")
+        );
+    }
+}


### PR DESCRIPTION
Two hundred repositories in path order means typing past a hundred and ninety-five of them to reach the five you are in this week.

- `repo sel`, `repo open`, `file sel` and `edit --tracked` lead with what you have chosen before. Everything unchosen keeps the order it had, below.
- Frecency, Firefox-style: recency multiplies frequency. Forty visits last year still outrank two this morning — and one more selection puts the newcomer on top.
- `ls` is untouched. It prints a set, and one order is what makes it pipeable.
- `[selector] recent = false` turns it off and stops the recording.

Cost: a third file beside `config.toml` and `files`, rewritten on every selection — capped at 500 entries by score. An unreadable store leaves the order alone rather than failing the selection; a failed write is a `--verbose` warning.

Tests are the pure module's. The ordering sits between building the rows and handing them to skim, so nothing script-callable reaches it — `tests/cli.rs` would have to drive a pty.

CLI help: `repo sel` and `file sel` say how they order and how to turn it off. README: unchanged, no new group or table row. `docs/demo.gif`: the demo records `branch checkout`, `edit` and `pr ls`, none of which order by recency, and the sandbox has no store — nothing on screen changed. CHANGELOG: one line under Added. `Release: minor` is on the commit.