### PR TITLE
chore: release v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ raised, never by hand.
 
 ## Unreleased
 
+## v0.8.0
+
+*Released 2026-08-17*
+
 ### Added
 
 - A selector now says what it can do, in a line under the prompt, and can do

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,6 @@ raised, never by hand.
   another search. In a repository list, f1 opens it on GitHub.
 - ctrl-v hides and shows the preview pane in every selector that has one, which
   is what a row too wide to read wants.
-
 - The repositories and files you actually work in are offered first.
   `repo sel`, `repo open`, `file sel` and `edit --tracked` now lead with what
   you have chosen before — frequently and recently both count — instead of

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1621,7 +1621,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scriv"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scriv"
-version = "0.7.1"
+version = "0.8.0"
 edition = "2024"
 description = "Provides fuzzy-completion for various local and remote resources."
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `scriv`: 0.7.1 -> 0.8.0

<details><summary><i><b>Changelog</b></i></summary><p>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).