### PR TITLE
Read a vault of notes, and open the one you meant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,30 @@ raised, never by hand.
 
 ## Unreleased
 
+### Added
+
+- `scriv note` reads a directory of Markdown files — an Obsidian vault, or any
+  tree of notes — as one more thing to select from. `ls` prints them,
+  `sel` prints the path of the one you pick, and `edit` opens what you pick,
+  several at a time on `tab`. Point `[note] root` at the vault to turn it on.
+  fish binds `f10` to `note edit`.
+- A note list is ordered by what you touched last, and each row carries what
+  the note calls itself, the folder it is filed under and its tags, behind two
+  dim columns saying how long ago it was modified and created. Titles, tags and
+  creation dates are read from YAML front matter, which is also why a synced or
+  freshly cloned vault still shows the dates you wrote rather than the afternoon
+  the files arrived. Inline `#tags` in the body are not indexed.
+- The preview pane for a note is drawn by scriv rather than by `bat`: the
+  header spells out both dates and the tags, and the body arrives with its
+  headings, quotes, lists, task boxes, wikilinks and tags coloured, with the
+  front matter left out since the header has already said it. Nothing is
+  spawned, so it keeps up with a held-down arrow key through a vault of
+  thousands.
+- `[note] editor` chooses what opens a note, since that is as often a reader as
+  an editor — `glow` and `nvim` are both answers. Unset, it is `$VISUAL` then
+  `$EDITOR`, as `scriv edit` uses. `scriv config check` reports the vault, how
+  many notes are in it, and whether that editor is on `PATH`.
+
 ## v0.8.0
 
 *Released 2026-08-17*

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@
 Provides fuzzy-completion for various local and remote resources.
 
 A single fuzzy selector over resources that would otherwise each need their own
-command and output parser: Git repositories, tracked files, branches,
-worktrees, GitHub pull requests, system processes and fish history. Each group
-lists its set, selects from it, and acts on the selection.
+command and output parser: Git repositories, tracked files, Markdown notes,
+branches, worktrees, GitHub pull requests, system processes and fish history.
+Each group lists its set, selects from it, and acts on the selection.
 
 The finder is linked into the binary — no `fzf` dependency and no subprocess.
 `scriv init fish` emits shell functions, key bindings and completions.
@@ -37,8 +37,8 @@ Supported platform: macOS on Apple Silicon. `scriv proc` depends on Darwin's
 signal numbers, and the crate refuses to compile for any other target.
 
 External requirements: `git`, plus `gh` for `pr` and `repo clone`/`open`, a
-fish history file for `history`, and `$VISUAL` or `$EDITOR` for `edit`.
-`scriv config check` reports on each.
+fish history file for `history`, and `$VISUAL` or `$EDITOR` for `edit` — or
+`[note] editor` for `note`. `scriv config check` reports on each.
 
 ## Setup
 
@@ -66,6 +66,10 @@ that must be set: repositories are located at `<root>/<owner>/<repo>`.
 root = "~/dev/github.com"
 ignore = ["node_modules", "target"]
 # labels = { personal = ["your-github-user"], work = ["acme", "acme-labs"] }
+
+[note]
+root = "~/notes"    # an Obsidian vault, or any tree of Markdown files
+editor = "nvim"     # what `note edit` opens one with; unset, $VISUAL / $EDITOR
 ```
 
 ## Commands
@@ -74,6 +78,7 @@ ignore = ["node_modules", "target"]
 | --- | --- |
 | `scriv repo` | `ls` `sel` `open` `clone` |
 | `scriv file` | `ls` `sel` `add` `rm` `prune` |
+| `scriv note` | `ls` `sel` `edit` |
 | `scriv branch` | `ls` `sel` `checkout` `rm` |
 | `scriv worktree` | `ls` `sel` `add` `rm` |
 | `scriv pr` | `ls` `sel` `checkout` `open` `merge` |
@@ -85,8 +90,8 @@ ignore = ["node_modules", "target"]
 
 `ls` prints the set, `sel` fuzzy-selects one entry, and the remaining verbs act
 on the selection. `sel` prints to stdout and composes: `cd (scriv repo sel)`.
-Groups abbreviate to one letter — `r`, `f`, `b`, `w`, `e`, `h`, `c`, and `pc`
-for `proc`.
+Groups abbreviate to one letter — `r`, `f`, `n`, `b`, `w`, `e`, `h`, `c`, and
+`pc` for `proc`.
 
 ## Key bindings
 
@@ -103,6 +108,7 @@ for `proc`.
 | `f2` | open this branch's pull request, or the list if it has none |
 | `f3` | open a tracked file in `$EDITOR` |
 | `f7` | check out a pull request |
+| `f10` | open a note from your vault |
 
 `scriv init fish` also defines `fe` (`scriv edit`, arguments passed through) and
 `kl` (`scriv proc kill --force`).

--- a/src/cmd/config.rs
+++ b/src/cmd/config.rs
@@ -7,7 +7,7 @@ use std::process::{Command, Stdio};
 use anyhow::{Context, Result, bail};
 
 use crate::path::expand_home_dir;
-use crate::{Ctx, files, gh, history, repo, term};
+use crate::{Ctx, cmd, files, gh, history, repo, term};
 
 /// A commented starter config. Settings are grouped by the command that reads
 /// them; users edit it to taste.
@@ -49,6 +49,20 @@ ignore = ["node_modules", "target"]
 # absolute path holds the trees of every repository, under the repository's own
 # name.
 # root = ".worktrees"
+
+# `scriv note`: where your notes are, and what opens one.
+[note]
+
+# The directory holding them — an Obsidian vault, or any tree of Markdown
+# files. Notes below it are listed most recently modified first, and what each
+# one is called, which tags it carries and when it was created come from its
+# YAML front matter. Without this, `scriv note` has nowhere to look.
+# root = "~/notes"
+
+# What `note edit` launches, split on whitespace like $EDITOR. Its own setting
+# because a note is as often read as written — `glow` and `nvim` are both
+# answers. Unset, it is $VISUAL then $EDITOR, as `scriv edit` uses.
+# editor = "nvim"
 
 # `scriv history`: which shell history to search.
 [history]
@@ -127,6 +141,18 @@ pub fn print(ctx: &Ctx) -> Result<()> {
             println!("  {label}: {}", owners.join(", "));
         }
     }
+
+    println!();
+    println!("[note]");
+    println!(
+        "root: {}",
+        ctx.config.note.root.as_deref().unwrap_or("(unset)")
+    );
+    println!(
+        "editor: {}",
+        ctx.note_editor_setting()
+            .unwrap_or("(unset — set `[note] editor`, $VISUAL or $EDITOR)")
+    );
 
     println!();
     println!("[history]");
@@ -404,6 +430,49 @@ fn editor_check(ctx: &Ctx) -> Check {
     }
 }
 
+/// The notes vault: where it is, and how many notes are in it.
+///
+/// One row rather than two — a root that resolves and a count of what is under
+/// it are the same question — and a warning rather than a failure when it is
+/// unset, since every other group works without one.
+fn note_checks(ctx: &Ctx) -> Vec<Check> {
+    let mut checks = Vec::new();
+
+    if ctx.config.note.root.is_none() {
+        checks.push(Check::warn(
+            "note vault",
+            "`[note] root` not set — `scriv note` has nowhere to look",
+        ));
+    } else {
+        checks.push(match cmd::note::vault_summary(ctx) {
+            Err(err) => Check::fail("note vault", format!("{err:#}")),
+            Ok((root, 0)) => Check::warn(
+                "note vault",
+                format!("{} holds no Markdown files", root.display()),
+            ),
+            Ok((root, count)) => Check::ok(
+                "note vault",
+                format!("{count} note(s) in {}", root.display()),
+            ),
+        });
+    }
+
+    // Only when it is set: unset, it is the editor the row above already
+    // reported, and a second row saying so is a second row saying so.
+    if let Some(setting) = ctx.config.note.editor.as_deref() {
+        let program = setting.split_whitespace().next().unwrap_or(setting);
+        checks.push(match on_path(program) {
+            Some(found) => Check::ok("note editor", format!("{setting} ({})", found.display())),
+            None => Check::fail(
+                "note editor",
+                format!("{setting} — `{program}` is not on PATH"),
+            ),
+        });
+    }
+
+    checks
+}
+
 /// fish's history file: whether it is where scriv looked, and how much is in
 /// it.
 fn history_check(ctx: &Ctx) -> Check {
@@ -483,6 +552,7 @@ fn collect(ctx: &Ctx) -> Vec<Check> {
     ));
     checks.push(history_check(ctx));
     checks.push(files_check(ctx));
+    checks.extend(note_checks(ctx));
     checks
 }
 

--- a/src/cmd/edit.rs
+++ b/src/cmd/edit.rs
@@ -130,13 +130,22 @@ fn cancellable(result: Result<Vec<String>>) -> Result<Option<Vec<String>>> {
     }
 }
 
-/// Launch the editor on `targets`, inheriting the terminal. A non-zero exit is
-/// [`Reported`], since the editor has already had the terminal.
+/// Launch `$VISUAL`/`$EDITOR` on `targets`.
 fn open(ctx: &Ctx, targets: &[String]) -> Result<()> {
-    let editor = ctx.editor()?;
+    launch(ctx, &ctx.editor()?, targets)
+}
+
+/// Launch `editor` — a program and its arguments — on `targets`, inheriting the
+/// terminal. A non-zero exit is [`Reported`], since the editor has already had
+/// the terminal and said whatever it had to say on it.
+///
+/// Shared with [`crate::cmd::note`], which launches a different command over
+/// the same contract: `--` first, the terminal inherited, the child's status
+/// passed through.
+pub(crate) fn launch(ctx: &Ctx, editor: &[String], targets: &[String]) -> Result<()> {
     let (program, args) = editor
         .split_first()
-        .expect("Ctx::editor rejects an empty command");
+        .expect("an editor command is resolved non-empty");
 
     ctx.log
         .info(&format!("opening {} file(s) with {program}", targets.len()));

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -9,6 +9,7 @@ pub mod config;
 pub mod edit;
 pub mod file;
 pub mod history;
+pub mod note;
 pub mod pr;
 pub mod proc;
 pub mod repo;

--- a/src/cmd/note.rs
+++ b/src/cmd/note.rs
@@ -1,0 +1,345 @@
+//! `scriv note` — list, select and open the notes in your vault.
+//!
+//! A registry like `repo` and `file`: the set is every Markdown file under
+//! `[note] root`, and the verbs act on what is selected from it. The imperative
+//! half lives here — the walk, the file reads, the clock and the editor;
+//! [`crate::note`] decides everything else.
+
+use std::io::Read;
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+use std::time::SystemTime;
+
+use anyhow::{Result, bail};
+
+use crate::note::{self, Note, Widths};
+use crate::path::expand_home_dir;
+use crate::select::{Preview, SelectItem};
+use crate::{Ctx, cmd, select, term};
+
+/// How much of a note is read to find its front matter.
+///
+/// The block sits at the very top of the file, so this is all a listing needs
+/// and a vault is spared having every byte of every note read to build one. A
+/// block longer than this is not front matter anybody wrote by hand, and the
+/// note is listed by its filename as though it had none.
+const HEAD_BYTES: u64 = 8 * 1024;
+
+/// How much of a note the preview pane reads. Bounded for the same reason a
+/// `Preview::Command` is: skim runs one on every move through the list.
+const PREVIEW_BYTES: u64 = 128 * 1024;
+
+/// The vault, expanded — the one directory `note` looks in.
+fn vault(ctx: &Ctx) -> Result<PathBuf> {
+    let root = ctx.config.note.root.as_deref().ok_or_else(|| {
+        anyhow::anyhow!(
+            "`[note] root` is not set in {} — `scriv note` has nowhere to look",
+            ctx.config_path.display()
+        )
+    })?;
+    let path = expand_home_dir(root, ctx.home());
+    if !path.is_dir() {
+        bail!(
+            "`[note] root` is {}, which is not a directory",
+            path.display()
+        );
+    }
+    Ok(path)
+}
+
+/// Every note in the vault, most recently modified first.
+///
+/// The walk and the head reads run on the walker's own threads, so a vault is
+/// one pass rather than a walk followed by a read per note. Dotfiles are
+/// skipped, which is what leaves Obsidian's `.obsidian` and `.trash` out
+/// without naming either.
+fn load(ctx: &Ctx) -> Result<Vec<Note>> {
+    let root = vault(ctx)?;
+    let offset = ctx.utc_offset();
+    let found = Mutex::new(Vec::new());
+
+    ignore::WalkBuilder::new(&root)
+        .hidden(true)
+        .require_git(false)
+        .add_custom_ignore_filename(".fdignore")
+        .build_parallel()
+        .run(|| {
+            Box::new(|entry| {
+                if let Ok(entry) = entry
+                    && entry.file_type().is_some_and(|ft| ft.is_file())
+                    && note::is_note(entry.path())
+                    && let Some(found_note) = read_note(entry.path(), &root, offset)
+                {
+                    found
+                        .lock()
+                        .unwrap_or_else(|e| e.into_inner())
+                        .push(found_note);
+                }
+                ignore::WalkState::Continue
+            })
+        });
+
+    let mut notes = found.into_inner().unwrap_or_else(|e| e.into_inner());
+    note::newest_first(&mut notes);
+    ctx.log
+        .info(&format!("{} note(s) under {}", notes.len(), root.display()));
+    if notes.is_empty() {
+        bail!(
+            "no notes under {} — `scriv note` lists Markdown files",
+            root.display()
+        );
+    }
+    Ok(notes)
+}
+
+/// One note, read: its times from the directory entry's metadata, its front
+/// matter from the first [`HEAD_BYTES`].
+///
+/// `None` for a file whose metadata cannot be read, which is one note missing
+/// from a listing rather than the listing failing — the same way the walk
+/// treats a directory it may not enter.
+fn read_note(path: &Path, root: &Path, offset: time::UtcOffset) -> Option<Note> {
+    let meta = path.metadata().ok()?;
+    let modified = unix(meta.modified().ok()?)?;
+    let birth = meta.created().ok().and_then(unix);
+
+    let head = read_head(path, HEAD_BYTES).unwrap_or_default();
+    let front = match note::split_front_matter(&head) {
+        (Some(block), _) => note::parse_front(block, offset),
+        (None, _) => note::Front::default(),
+    };
+
+    Some(Note {
+        rel: path
+            .strip_prefix(root)
+            .unwrap_or(path)
+            .to_string_lossy()
+            .into_owned(),
+        path: path.to_path_buf(),
+        modified,
+        created: note::created(front.created, birth, modified),
+        front,
+    })
+}
+
+/// The first `limit` bytes of `path`, as text. A note is whatever the user's
+/// editor wrote, so invalid UTF-8 — and a multi-byte character the limit cut in
+/// half — is replaced rather than refused.
+fn read_head(path: &Path, limit: u64) -> Option<String> {
+    let file = std::fs::File::open(path).ok()?;
+    let mut bytes = Vec::new();
+    std::io::BufReader::new(file)
+        .take(limit)
+        .read_to_end(&mut bytes)
+        .ok()?;
+    Some(String::from_utf8_lossy(&bytes).into_owned())
+}
+
+fn unix(time: SystemTime) -> Option<i64> {
+    match time.duration_since(SystemTime::UNIX_EPOCH) {
+        Ok(since) => Some(since.as_secs() as i64),
+        // Before 1970. A file dated that way is a clock that was wrong, not a
+        // note to leave out of the list.
+        Err(before) => Some(-(before.duration().as_secs() as i64)),
+    }
+}
+
+/// `scriv note ls` — print the notes, most recently modified first.
+///
+/// Plain, one path below the vault per line, which is the name `note edit`
+/// takes. `--status` adds the tags and both dates; `--absolute-paths` prints
+/// what a pipe can open.
+pub fn ls(ctx: &Ctx, absolute_paths: bool, status: bool) -> Result<()> {
+    let notes = load(ctx)?;
+    let widths = Widths::of(&notes, crate::unix_now());
+    let offset = ctx.utc_offset();
+
+    let mut out = term::Listing::stdout();
+    for note in &notes {
+        let row = match (absolute_paths, status) {
+            (true, _) => note.path.display().to_string(),
+            (false, false) => note.rel.clone(),
+            (false, true) => note::status_row(note, &widths, offset),
+        };
+        if !out.line(&row)? {
+            break;
+        }
+    }
+    out.finish()?;
+    Ok(())
+}
+
+/// `scriv note sel` — fuzzy-select a note and print its absolute path.
+pub fn sel(ctx: &Ctx) -> Result<()> {
+    let notes = load(ctx)?;
+    let choice = select::select_one(items(ctx, &notes), "Select a note", &ctx.config.selector)?;
+    println!("{choice}");
+    Ok(())
+}
+
+/// `scriv note edit [NAME]...` — open notes in `[note] editor`, selecting them
+/// when none are named.
+pub fn edit(ctx: &Ctx, names: &[String]) -> Result<()> {
+    let editor = ctx.note_editor()?;
+
+    let targets = if names.is_empty() {
+        match select_notes(ctx)? {
+            Some(targets) => targets,
+            None => return Ok(()),
+        }
+    } else {
+        let root = vault(ctx)?;
+        names
+            .iter()
+            .map(|name| resolve(&root, ctx.home(), name))
+            .collect()
+    };
+
+    if targets.is_empty() {
+        return Ok(());
+    }
+    cmd::edit::launch(ctx, &editor, &targets)
+}
+
+/// A note named on the command line, as a path. A name is relative to the
+/// vault, so `scriv note edit` takes back exactly what `scriv note ls` printed;
+/// an absolute path, or one that begins with `~`, is left where it points.
+fn resolve(root: &Path, home: &Path, name: &str) -> String {
+    let path = expand_home_dir(name, home);
+    if path.is_absolute() {
+        return path.to_string_lossy().into_owned();
+    }
+    root.join(path).to_string_lossy().into_owned()
+}
+
+/// Choose notes from the vault. `Ok(None)` when the user cancels.
+fn select_notes(ctx: &Ctx) -> Result<Option<Vec<String>>> {
+    let notes = load(ctx)?;
+    match select::select_many(items(ctx, &notes), "Edit a note", &ctx.config.selector) {
+        Ok(chosen) => Ok(Some(chosen)),
+        Err(e) if e.is::<select::Cancelled>() => Ok(None),
+        Err(e) => Err(e),
+    }
+}
+
+/// Selector rows: the dim age columns as a prefix, the title, folder and tags
+/// as the label, and the note's absolute path as the value.
+///
+/// Every pane is built when its row is highlighted rather than now — see
+/// [`Preview::Deferred`]. A vault read up front is one file read per note for
+/// panes the user scrolls past.
+fn items(ctx: &Ctx, notes: &[Note]) -> Vec<SelectItem> {
+    let now = crate::unix_now();
+    let widths = Widths::of(notes, now);
+    let offset = ctx.utc_offset();
+
+    notes
+        .iter()
+        .map(|note| {
+            let (label, tints) = note::row(note, &widths);
+            let note = note.clone();
+            SelectItem::new(label, note.path.to_string_lossy().into_owned())
+                .prefix(note::prefix(&note, now, &widths))
+                .tints(tints)
+                .preview(Preview::Deferred(Box::new(move || {
+                    let text = read_head(&note.path, PREVIEW_BYTES).unwrap_or_default();
+                    note::preview(&note, &text, now, offset)
+                })))
+        })
+        .collect()
+}
+
+/// The `config check` row for the vault: where it is, and how much is in it.
+/// One row rather than two, since a root that resolves and holds nothing has
+/// already been reported by the count.
+pub(crate) fn vault_summary(ctx: &Ctx) -> Result<(PathBuf, usize)> {
+    let root = vault(ctx)?;
+    let count = ignore::WalkBuilder::new(&root)
+        .hidden(true)
+        .require_git(false)
+        .build()
+        .flatten()
+        .filter(|entry| entry.file_type().is_some_and(|ft| ft.is_file()))
+        .filter(|entry| note::is_note(entry.path()))
+        .count();
+    Ok((root, count))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn utc() -> time::UtcOffset {
+        time::UtcOffset::UTC
+    }
+
+    #[test]
+    fn a_note_takes_its_name_from_where_it_sits_below_the_vault() {
+        let dir = TempDir::new().unwrap();
+        let root = dir.path();
+        std::fs::create_dir_all(root.join("work/meetings")).unwrap();
+        let path = root.join("work/meetings/standup.md");
+        std::fs::write(&path, "# Standup\n").unwrap();
+
+        let note = read_note(&path, root, utc()).unwrap();
+
+        assert_eq!(note.rel, "work/meetings/standup.md");
+        assert_eq!(note.title(), "standup");
+        assert_eq!(note.folder(), "work/meetings");
+    }
+
+    #[test]
+    fn front_matter_is_read_from_the_head_of_the_file() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("a.md");
+        std::fs::write(
+            &path,
+            "---\ntitle: Error handling\ntags: [rust, til]\n---\n\nbody\n",
+        )
+        .unwrap();
+
+        let note = read_note(&path, dir.path(), utc()).unwrap();
+
+        assert_eq!(note.title(), "Error handling");
+        assert_eq!(note.tag_column(), "#rust #til");
+    }
+
+    /// The bound is what keeps a vault one pass rather than a full read per
+    /// note; a note longer than it must still list, by its filename.
+    #[test]
+    fn a_note_larger_than_the_head_bound_still_lists() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("long.md");
+        let body = "x".repeat(HEAD_BYTES as usize * 2);
+        std::fs::write(&path, format!("---\ntitle: Long\n---\n{body}")).unwrap();
+
+        let note = read_note(&path, dir.path(), utc()).unwrap();
+
+        assert_eq!(note.title(), "Long");
+    }
+
+    /// A note nothing named a creation date for falls back to the filesystem,
+    /// and never reads as newer than its own last edit.
+    #[test]
+    fn an_undated_note_is_created_no_later_than_it_was_modified() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("a.md");
+        std::fs::write(&path, "body\n").unwrap();
+
+        let note = read_note(&path, dir.path(), utc()).unwrap();
+
+        assert!(note.created <= note.modified, "{note:?}");
+    }
+
+    #[test]
+    fn a_named_note_resolves_against_the_vault_but_an_absolute_path_does_not() {
+        let (root, home) = (Path::new("/vault"), Path::new("/home/me"));
+        assert_eq!(
+            resolve(root, home, "work/standup.md"),
+            "/vault/work/standup.md"
+        );
+        assert_eq!(resolve(root, home, "/elsewhere/a.md"), "/elsewhere/a.md");
+        assert_eq!(resolve(root, home, "~/inbox.md"), "/home/me/inbox.md");
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,9 +6,9 @@
 //!
 //! - `config.toml` — hand-edited settings, grouped by the command that reads
 //!   them: `[repo]` for discovery and labelling, `[worktree]` for where a new
-//!   tree goes, `[history]` for the shell history to search, `[selector]` for
-//!   the finder every command shares. A legacy `config.json` is still read when
-//!   no TOML file is present.
+//!   tree goes, `[note]` for the vault and what opens a note, `[history]` for
+//!   the shell history to search, `[selector]` for the finder every command
+//!   shares. A legacy `config.json` is still read when no TOML file is present.
 //! - `files` — the known-files list, rewritten programmatically by
 //!   `scriv file add`/`rm`/`prune`. Kept separate so machine writes never
 //!   clobber hand-written settings or comments.
@@ -48,6 +48,7 @@ pub type Labels = IndexMap<String, Vec<String>>;
 pub struct Config {
     pub repo: RepoConfig,
     pub worktree: WorktreeConfig,
+    pub note: NoteConfig,
     pub history: HistoryConfig,
     pub selector: SelectorConfig,
 }
@@ -136,6 +137,22 @@ impl Default for WorktreeConfig {
 /// Where trees go when nothing says otherwise: beside the checkout, in a
 /// directory git itself will not confuse for part of it.
 const DEFAULT_WORKTREE_ROOT: &str = ".worktrees";
+
+/// `[note]` — where the notes are, and what opens one.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Deserialize)]
+#[serde(default)]
+pub struct NoteConfig {
+    /// The directory the notes live in — an Obsidian vault, or any tree of
+    /// Markdown files. Unset, `scriv note` has nowhere to look.
+    pub root: Option<String>,
+    /// What `note edit` launches, split on whitespace like `$EDITOR`. Unset, it
+    /// is `$VISUAL` then `$EDITOR`.
+    ///
+    /// A key of its own because a note is not source: the thing that opens one
+    /// is as often a Markdown reader as it is the editor the rest of scriv
+    /// hands a file to.
+    pub editor: Option<String>,
+}
 
 /// `[history]` — which shell history `scriv history` searches.
 #[derive(Debug, Clone, PartialEq, Eq, Default, Deserialize)]
@@ -235,6 +252,8 @@ struct RawToml {
     repo: RepoConfig,
     #[serde(default)]
     worktree: WorktreeConfig,
+    #[serde(default)]
+    note: NoteConfig,
     #[serde(default)]
     history: HistoryConfig,
     #[serde(default)]
@@ -517,6 +536,7 @@ fn parse_toml(data: &str) -> Result<Config> {
     Ok(Config {
         repo: raw.repo,
         worktree: raw.worktree,
+        note: raw.note,
         history: raw.history,
         selector: raw.selector.into(),
     })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
-//! `scriv` — select repositories, files, git branches and worktrees, GitHub
-//! pull requests and running processes from one fuzzy finder.
+//! `scriv` — select repositories, files, notes, git branches and worktrees,
+//! GitHub pull requests and running processes from one fuzzy finder.
 //!
 //! The crate is split into an I/O-free core and an imperative shell: the
 //! [`cmd`] modules read the environment, touch the filesystem, shell out to
@@ -13,6 +13,7 @@ pub mod gh;
 pub mod git;
 pub mod history;
 pub mod logger;
+pub mod note;
 pub mod path;
 pub mod proc;
 pub mod recent;
@@ -90,6 +91,9 @@ pub struct Ctx {
     utc_offset: time::UtcOffset,
     /// The editor `scriv edit` launches, from the environment.
     editor: Option<String>,
+    /// The command `scriv note edit` launches: `[note] editor`, else the one
+    /// above. Resolved here so no command looks the environment up itself.
+    note_editor: Option<String>,
     /// `GH_REPO`, which names the repository `gh` acts on when the working
     /// directory is not one.
     gh_repo: Option<String>,
@@ -157,6 +161,17 @@ impl Ctx {
             std::env::var("EDITOR").ok().as_deref(),
         );
 
+        // `[note] editor` first, since it exists to be something other than
+        // the editor: `glow` reads a note where `nvim` writes one.
+        let note_editor = config
+            .note
+            .editor
+            .as_deref()
+            .map(str::trim)
+            .filter(|command| !command.is_empty())
+            .map(str::to_string)
+            .or_else(|| editor.clone());
+
         let gh_repo = std::env::var("GH_REPO")
             .ok()
             .filter(|repo| !repo.trim().is_empty());
@@ -172,6 +187,7 @@ impl Ctx {
             history_path,
             utc_offset,
             editor,
+            note_editor,
             gh_repo,
             color: color.for_stdout(),
             config,
@@ -200,6 +216,27 @@ impl Ctx {
         let parts = config::split_editor(command);
         if parts.is_empty() {
             anyhow::bail!("the configured editor is empty");
+        }
+        Ok(parts)
+    }
+
+    /// The command `scriv note edit` launches, or `None` when neither
+    /// `[note] editor` nor the environment names one. For reporting;
+    /// [`Ctx::note_editor`] is what launching goes through.
+    pub fn note_editor_setting(&self) -> Option<&str> {
+        self.note_editor.as_deref()
+    }
+
+    /// The command `scriv note edit` launches, split into program and
+    /// arguments.
+    pub fn note_editor(&self) -> Result<Vec<String>> {
+        let command = self
+            .note_editor
+            .as_deref()
+            .context("no editor set — set `[note] editor`, $VISUAL or $EDITOR")?;
+        let parts = config::split_editor(command);
+        if parts.is_empty() {
+            anyhow::bail!("the configured note editor is empty");
         }
         Ok(parts)
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,10 +2,10 @@
 //! dispatch to the [`cmd`] implementations. All decision logic lives in the
 //! library crate.
 //!
-//! Top-level commands: `repo`, `file`, `branch`, `worktree`, `pr`, `proc` and
-//! `history` work with the things scriv finds; `edit` opens a file from the
-//! directory the user is in; `config` manages its configuration; `init` prints
-//! shell integration.
+//! Top-level commands: `repo`, `file`, `note`, `branch`, `worktree`, `pr`,
+//! `proc` and `history` work with the things scriv finds; `edit` opens a file
+//! from the directory the user is in; `config` manages its configuration;
+//! `init` prints shell integration.
 
 use std::process::ExitCode;
 
@@ -116,6 +116,23 @@ enum Command {
         /// Select from your tracked files instead of the current directory
         #[arg(short, long, conflicts_with = "files")]
         tracked: bool,
+    },
+    /// Manage the notes in your vault
+    ///
+    /// The set is every Markdown file under `[note] root` — an Obsidian vault,
+    /// or any tree of notes — most recently modified first.
+    ///
+    /// A row is what the note calls itself, the folder it is filed under and
+    /// its tags, behind two dim columns: how long ago it was modified, then how
+    /// long ago it was created. Both are spelled out in the preview pane, which
+    /// is drawn by scriv rather than by `bat`.
+    ///
+    /// Titles, tags and creation dates come from a note's YAML front matter and
+    /// from nowhere else — inline `#tags` in the body are not indexed.
+    #[command(visible_alias = "n")]
+    Note {
+        #[command(subcommand)]
+        command: NoteCmd,
     },
     /// Manage local and remote Git branches
     ///
@@ -350,6 +367,40 @@ impl BranchScope {
     fn filter(&self) -> Filter {
         Filter::from_flags(self.local, self.remote)
     }
+}
+
+#[derive(Subcommand)]
+enum NoteCmd {
+    /// List every note in the vault, most recently modified first
+    #[command(visible_alias = "list")]
+    Ls {
+        /// Return absolute file paths
+        #[arg(short = 'A', long)]
+        absolute_paths: bool,
+        /// Also show each note's tags, when it was last modified, and when it
+        /// was created
+        ///
+        /// Modified carries a time of day and created does not: a creation date
+        /// may have come from front matter, which names a day.
+        #[arg(long)]
+        status: bool,
+    },
+    /// Fuzzy-select a note and print its absolute path
+    Sel,
+    /// Open notes; omit the names to select them
+    ///
+    /// `tab` selects several and they open together. A name is a path below the
+    /// vault, exactly as `note ls` prints it.
+    ///
+    /// The command is `[note] editor`, falling back to `$VISUAL` then
+    /// `$EDITOR`. It is a setting of its own because a note is as often read as
+    /// written — `glow` and `nvim` are both answers. The fish integration binds
+    /// this to f10.
+    Edit {
+        /// Notes to open; omit to select interactively
+        #[arg(value_name = "NAME")]
+        notes: Vec<String>,
+    },
 }
 
 #[derive(Subcommand)]
@@ -717,6 +768,14 @@ fn run(cli: Cli) -> anyhow::Result<()> {
         } => match command.unwrap_or(EditCmd::File { files, tracked }) {
             EditCmd::File { files, tracked } => cmd::edit::file(&ctx, &files, tracked),
             EditCmd::Dir { dirs } => cmd::edit::dir(&ctx, &dirs),
+        },
+        Command::Note { command } => match command {
+            NoteCmd::Ls {
+                absolute_paths,
+                status,
+            } => cmd::note::ls(&ctx, absolute_paths, status),
+            NoteCmd::Sel => cmd::note::sel(&ctx),
+            NoteCmd::Edit { notes } => cmd::note::edit(&ctx, &notes),
         },
         Command::Branch { command } => match command {
             BranchCmd::Ls { status, scope } => {

--- a/src/note.rs
+++ b/src/note.rs
@@ -1,0 +1,1146 @@
+//! Notes: a tree of Markdown files — an Obsidian vault, or anything shaped like
+//! one — read as rows in a selector.
+//!
+//! Everything here is pure. The walk, the file reads and the clock live in
+//! [`cmd::note`](crate::cmd::note); this module turns the bytes they hand back
+//! into a title, a set of tags, two dates, an aligned row and a rendered
+//! preview.
+//!
+//! A note says what it is in its YAML front matter, which is the only metadata
+//! this reads. Inline `#tags` in the body are deliberately not indexed: finding
+//! them means scanning every byte of every note and then telling a tag apart
+//! from a heading, a colour literal and a URL fragment, and a tag column that is
+//! right most of the time is worse than one that is right always.
+
+use std::path::{Path, PathBuf};
+
+use crate::select::Tint;
+
+/// How the columns of a note row are coloured — indices into the ANSI
+/// 256-colour table, so they follow the terminal's own theme. Blue for the
+/// folder, as every file listing colours a directory; magenta for tags, which
+/// is the one hue no status in scriv already means something with.
+///
+/// The title carries no colour of its own: it is what the query matches, and
+/// skim's match highlighting has to be the brightest thing on the row.
+const FOLDER_COLOR: u8 = 4;
+const TAG_COLOR: u8 = 5;
+
+/// What a note's front matter said about it.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct Front {
+    /// `title:`, when the note names itself something other than its filename.
+    pub title: Option<String>,
+    /// `tags:`/`tag:`, in the order written, without a leading `#`.
+    pub tags: Vec<String>,
+    /// `created:`/`date:`, as local midnight on the day it names.
+    pub created: Option<i64>,
+}
+
+/// One note, as a listing sees it.
+///
+/// Built by the shell from a directory entry, its metadata and the first few
+/// kilobytes of the file.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Note {
+    /// Absolute path — what a row returns and what an editor is handed.
+    pub path: PathBuf,
+    /// Path below the vault root, extension and all. The name a note is known
+    /// by on the command line.
+    pub rel: String,
+    /// Last modified, in Unix seconds.
+    pub modified: i64,
+    /// Created, in Unix seconds. See [`created`].
+    pub created: i64,
+    pub front: Front,
+}
+
+impl Note {
+    /// What the note calls itself: its front matter's `title`, else the
+    /// filename without its extension. Obsidian links notes by filename, so the
+    /// filename is the name unless the note says otherwise.
+    pub fn title(&self) -> &str {
+        match &self.front.title {
+            Some(title) => title,
+            None => stem(&self.rel),
+        }
+    }
+
+    /// The directory the note sits in, below the vault root — empty for a note
+    /// at the root itself.
+    pub fn folder(&self) -> &str {
+        match self.rel.rfind('/') {
+            Some(at) => &self.rel[..at],
+            None => "",
+        }
+    }
+
+    /// The tags column: every tag, `#`-prefixed, space-separated.
+    pub fn tag_column(&self) -> String {
+        self.front
+            .tags
+            .iter()
+            .map(|tag| format!("#{tag}"))
+            .collect::<Vec<_>>()
+            .join(" ")
+    }
+}
+
+/// When a note was created: what its front matter says, else what the
+/// filesystem says.
+///
+/// The front matter wins because the filesystem's answer is so often wrong — a
+/// vault that arrives by `git clone`, by a sync client or by a copy has every
+/// note born the same afternoon, and a column that says that of five hundred
+/// notes says nothing. `birth` is `None` on a filesystem that does not record
+/// one, and the modification time is the last resort: nothing is newer than
+/// itself.
+pub fn created(front: Option<i64>, birth: Option<i64>, modified: i64) -> i64 {
+    front.or(birth).unwrap_or(modified)
+}
+
+/// The filename, without its directories or its extension.
+fn stem(rel: &str) -> &str {
+    let name = rel.rsplit('/').next().unwrap_or(rel);
+    match name.rfind('.') {
+        // A leading dot is the whole name, not an extension.
+        Some(at) if at > 0 => &name[..at],
+        _ => name,
+    }
+}
+
+// --- front matter -----------------------------------------------------------
+
+/// Split `text` into its YAML front matter block and the body below it.
+///
+/// The block is what sits between a first line of exactly `---` and the next
+/// line of exactly `---` or `...`. An unterminated block is not one: a note
+/// opening with a horizontal rule would otherwise lose its entire body.
+pub fn split_front_matter(text: &str) -> (Option<&str>, &str) {
+    let Some(after) = open_fence(text) else {
+        return (None, text);
+    };
+    let mut at = 0;
+    for line in after.split_inclusive('\n') {
+        if matches!(line.trim_end_matches(['\n', '\r']), "---" | "...") {
+            return (Some(&after[..at]), &after[at + line.len()..]);
+        }
+        at += line.len();
+    }
+    (None, text)
+}
+
+/// What follows the opening `---` line, when that is how `text` begins.
+fn open_fence(text: &str) -> Option<&str> {
+    let rest = text.strip_prefix("---")?;
+    rest.strip_prefix("\r\n")
+        .or_else(|| rest.strip_prefix('\n'))
+}
+
+/// Read a front matter block.
+///
+/// A deliberately small reader rather than a YAML parser: it takes top-level
+/// `key: value` lines and the block or flow sequences under them, and skips
+/// everything else — nested mappings, anchors, multi-line scalars. The three
+/// keys it looks for are a scalar or a list of scalars in every vault that
+/// writes them, and a YAML dependency would parse a great deal this never
+/// reads.
+///
+/// `offset` dates a `created:` value, which names a day rather than an instant:
+/// the day is the writer's own, so it becomes local midnight rather than UTC.
+pub fn parse_front(block: &str, offset: time::UtcOffset) -> Front {
+    let mut front = Front::default();
+    // Whether the block sequence being read is the one `tags:` opened.
+    let mut in_tags = false;
+
+    for raw in block.lines() {
+        let line = raw.trim_end_matches('\r');
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+        if let Some(item) = sequence_item(trimmed) {
+            if in_tags {
+                push_tag(&mut front.tags, item);
+            }
+            continue;
+        }
+        // Indented and not a sequence item: part of a mapping this does not
+        // read, rather than a key of its own.
+        if line.starts_with([' ', '\t']) {
+            continue;
+        }
+        in_tags = false;
+        let Some((key, value)) = line.split_once(':') else {
+            continue;
+        };
+        let value = value.trim();
+        match key.trim().to_ascii_lowercase().as_str() {
+            "title" => front.title = scalar(value),
+            "tags" | "tag" => {
+                // A key with nothing after it opens a block sequence; anything
+                // else is the whole list, on this line.
+                if value.is_empty() {
+                    in_tags = true;
+                } else {
+                    for tag in split_tags(value) {
+                        push_tag(&mut front.tags, tag);
+                    }
+                }
+            }
+            // `created` is the one a vault writes deliberately, so it is not
+            // displaced by a `date` further down the block.
+            "created" | "date" => front.created = front.created.or(date_at(value, offset)),
+            _ => {}
+        }
+    }
+    front
+}
+
+/// The value of a `- item` line, at any indentation.
+fn sequence_item(trimmed: &str) -> Option<&str> {
+    let rest = trimmed.strip_prefix('-')?;
+    if rest.is_empty() {
+        return Some("");
+    }
+    rest.strip_prefix(' ').map(str::trim)
+}
+
+/// A scalar value: unquoted and trimmed, `None` when nothing is left of it.
+fn scalar(value: &str) -> Option<String> {
+    let value = unquote(value.trim());
+    (!value.is_empty()).then(|| value.to_string())
+}
+
+/// Drop one matching pair of surrounding quotes.
+fn unquote(value: &str) -> &str {
+    for quote in ['"', '\''] {
+        if let Some(inner) = value
+            .strip_prefix(quote)
+            .and_then(|rest| rest.strip_suffix(quote))
+        {
+            return inner;
+        }
+    }
+    value
+}
+
+/// Split a one-line tag list. `[a, b]`, `a, b` and `a b` are all written in the
+/// wild, and none of them can hold a tag with a space in it.
+fn split_tags(value: &str) -> impl Iterator<Item = &str> {
+    let inner = value
+        .strip_prefix('[')
+        .and_then(|rest| rest.strip_suffix(']'))
+        .unwrap_or(value);
+    inner.split([',', ' ', '\t'])
+}
+
+/// Add `tag` to `tags` unless it is empty or already there. The leading `#` an
+/// Obsidian tag is often written with is not part of the tag.
+fn push_tag(tags: &mut Vec<String>, tag: &str) {
+    let Some(tag) = scalar(tag) else { return };
+    let tag = tag.trim_start_matches('#').to_string();
+    if !tag.is_empty() && !tags.contains(&tag) {
+        tags.push(tag);
+    }
+}
+
+/// A front matter date as local midnight on the day it names.
+///
+/// Whatever follows the date — a time, a zone — is dropped: the column shows a
+/// day, and a note that writes `09:00` has not said which zone that was.
+fn date_at(value: &str, offset: time::UtcOffset) -> Option<i64> {
+    let date = unquote(value.trim()).split(['T', ' ']).next()?;
+    let mut parts = date.split('-');
+    let year: i32 = parts.next()?.trim().parse().ok()?;
+    let month: u8 = parts.next()?.trim().parse().ok()?;
+    let day: u8 = parts.next()?.trim().parse().ok()?;
+    if parts.next().is_some() {
+        return None;
+    }
+    let month = time::Month::try_from(month).ok()?;
+    Some(
+        time::Date::from_calendar_date(year, month, day)
+            .ok()?
+            .midnight()
+            .assume_offset(offset)
+            .unix_timestamp(),
+    )
+}
+
+// --- dates ------------------------------------------------------------------
+
+const MINUTE: i64 = 60;
+const HOUR: i64 = 60 * MINUTE;
+const DAY: i64 = 24 * HOUR;
+const WEEK: i64 = 7 * DAY;
+const YEAR: i64 = 365 * DAY;
+const MONTH: i64 = YEAR / 12;
+
+/// How long ago `then` was, in three or four characters — `now`, `42m`, `6d`,
+/// `11mo`, `3y`.
+///
+/// The selector dates a note this way rather than with the calendar date the
+/// listing prints: two calendar columns are twenty-two characters of a pane
+/// already sharing its width with a preview, and the question a note list
+/// answers is "which of these did I touch recently", not "on which Tuesday".
+///
+/// A note dated in the future — a clock that went backwards, a front matter
+/// date typed ahead — reads as `now` rather than as a negative age.
+pub fn age(now: i64, then: i64) -> String {
+    let seconds = (now - then).max(0);
+    match seconds {
+        s if s < MINUTE => "now".to_string(),
+        s if s < HOUR => format!("{}m", s / MINUTE),
+        s if s < DAY => format!("{}h", s / HOUR),
+        s if s < WEEK => format!("{}d", s / DAY),
+        s if s < 5 * WEEK => format!("{}w", s / WEEK),
+        // Never `0mo`: the arm above stops five weeks short of the average
+        // month this divides by.
+        s if s < YEAR => format!("{}mo", (s / MONTH).max(1)),
+        s => format!("{}y", s / YEAR),
+    }
+}
+
+/// A calendar date, `YYYY-MM-DD`, in local time.
+pub fn date(when: i64, offset: time::UtcOffset) -> String {
+    match local(when, offset) {
+        Some(dt) => format!("{:04}-{:02}-{:02}", dt.year(), dt.month() as u8, dt.day()),
+        None => BLANK_DATE.to_string(),
+    }
+}
+
+/// A calendar date and the time of day, `YYYY-MM-DD HH:MM`, in local time.
+pub fn timestamp(when: i64, offset: time::UtcOffset) -> String {
+    match local(when, offset) {
+        Some(dt) => format!(
+            "{:04}-{:02}-{:02} {:02}:{:02}",
+            dt.year(),
+            dt.month() as u8,
+            dt.day(),
+            dt.hour(),
+            dt.minute(),
+        ),
+        None => BLANK_TIMESTAMP.to_string(),
+    }
+}
+
+/// [`date`]- and [`timestamp`]-shaped blanks, so a time no calendar can
+/// represent costs the listing a value rather than a column.
+const BLANK_DATE: &str = "          ";
+const BLANK_TIMESTAMP: &str = "                ";
+
+fn local(when: i64, offset: time::UtcOffset) -> Option<time::OffsetDateTime> {
+    time::OffsetDateTime::from_unix_timestamp(when)
+        .ok()
+        .map(|dt| dt.to_offset(offset))
+}
+
+// --- rows -------------------------------------------------------------------
+
+/// The width of every column a note listing shares, measured over the whole
+/// list so the columns line up.
+///
+/// Counted in characters, not bytes: `{:<width$}` pads by character count, so a
+/// byte length would over-pad a title with an accent in it.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct Widths {
+    pub modified: usize,
+    pub created: usize,
+    pub title: usize,
+    pub folder: usize,
+    pub rel: usize,
+    pub tags: usize,
+}
+
+impl Widths {
+    pub fn of(notes: &[Note], now: i64) -> Self {
+        let widest = |f: &dyn Fn(&Note) -> usize| notes.iter().map(f).max().unwrap_or(0);
+        Self {
+            modified: widest(&|n| age(now, n.modified).chars().count()),
+            created: widest(&|n| age(now, n.created).chars().count()),
+            title: widest(&|n| n.title().chars().count()),
+            folder: widest(&|n| n.folder().chars().count()),
+            rel: widest(&|n| n.rel.chars().count()),
+            tags: widest(&|n| n.tag_column().chars().count()),
+        }
+    }
+}
+
+/// The dim column ahead of a selector row: how long ago the note was modified,
+/// then how long ago it was created.
+///
+/// A [`crate::select::SelectItem::prefix`] rather than part of the label, so it
+/// is shown without being searched — matched, a query of `3` would rank every
+/// note that is three days old above the one being looked for. Modified comes
+/// first because it is the order the list is in.
+pub fn prefix(note: &Note, now: i64, widths: &Widths) -> String {
+    format!(
+        "{modified:>mw$} {created:>cw$}  ",
+        modified = age(now, note.modified),
+        mw = widths.modified,
+        created = age(now, note.created),
+        cw = widths.created,
+    )
+}
+
+/// One selector row: what the note calls itself, the folder it is filed under,
+/// and its tags.
+///
+/// The row and its colours are built together because a tint is a character
+/// range into the row, and counting those ranges out a second time is how they
+/// drift.
+pub fn row(note: &Note, widths: &Widths) -> (String, Vec<Tint>) {
+    let mut row = String::new();
+    let mut tints = Vec::new();
+
+    push_column(&mut row, note.title(), widths.title);
+
+    if widths.folder > 0 {
+        row.push_str("  ");
+        let at = row.chars().count();
+        push_column(&mut row, note.folder(), widths.folder);
+        tints.push(Tint {
+            range: at..at + note.folder().chars().count(),
+            color: FOLDER_COLOR,
+        });
+    }
+
+    let tags = note.tag_column();
+    if !tags.is_empty() {
+        row.push_str("  ");
+        let at = row.chars().count();
+        row.push_str(&tags);
+        tints.push(Tint {
+            range: at..row.chars().count(),
+            color: TAG_COLOR,
+        });
+    }
+
+    (row.trim_end().to_string(), tints)
+}
+
+/// One `note ls --status` row: the note's name, its tags, and both dates.
+///
+/// The name comes first, so the plain listing is a prefix of this one. Modified
+/// carries a time of day and created does not: a created date may have come
+/// from front matter, which names a day.
+pub fn status_row(note: &Note, widths: &Widths, offset: time::UtcOffset) -> String {
+    let mut row = String::new();
+    push_column(&mut row, &note.rel, widths.rel);
+    if widths.tags > 0 {
+        row.push_str("  ");
+        push_column(&mut row, &note.tag_column(), widths.tags);
+    }
+    row.push_str("  ");
+    row.push_str(&timestamp(note.modified, offset));
+    row.push_str("  ");
+    row.push_str(&date(note.created, offset));
+    row.trim_end().to_string()
+}
+
+/// Append `text` and pad it out to `width` characters.
+fn push_column(row: &mut String, text: &str, width: usize) {
+    row.push_str(text);
+    for _ in text.chars().count()..width {
+        row.push(' ');
+    }
+}
+
+/// Order a vault: most recently modified first, then by path so notes written
+/// in the same second do not shuffle between runs.
+///
+/// Deliberately not [`crate::Ctx::by_recency`], which every other selector is
+/// ordered by: opening a note is what changes its modification time, so the
+/// file already records what that store would, and two orderings of one fact
+/// can only disagree.
+pub fn newest_first(notes: &mut [Note]) {
+    notes.sort_by(|a, b| b.modified.cmp(&a.modified).then_with(|| a.rel.cmp(&b.rel)));
+}
+
+/// Whether a path is one a note listing offers, by extension.
+pub fn is_note(path: &Path) -> bool {
+    path.extension()
+        .and_then(|ext| ext.to_str())
+        .is_some_and(|ext| {
+            NOTE_EXTENSIONS
+                .iter()
+                .any(|kind| ext.eq_ignore_ascii_case(kind))
+        })
+}
+
+/// What counts as a note. Obsidian writes Markdown and reads nothing else, and
+/// a vault's other files — its attachments, its `.obsidian` settings — are not
+/// things to hand an editor.
+const NOTE_EXTENSIONS: &[&str] = &["md", "markdown"];
+
+// --- preview ----------------------------------------------------------------
+
+/// Colours the preview pane draws with. Grey for everything that is context
+/// rather than content, cyan for headings, blue for a link, green for a task
+/// that is done.
+const DIM: u8 = 8;
+const HEADING_COLOR: u8 = 6;
+const LINK_COLOR: u8 = 4;
+const DONE_COLOR: u8 = 2;
+
+/// How much of a note the preview pane shows, matching what `bat` is asked for
+/// elsewhere. A pane is thirty rows; anything past this is for the editor.
+const PREVIEW_LINES: usize = 200;
+
+/// The preview pane for a note: what the row could not fit, then the note.
+///
+/// The header is where the two age columns on the row are spelled out — a
+/// column reading `3d  2y` says which is which only once something says it,
+/// and the pane has the width to.
+///
+/// The body is drawn rather than shelled out to `bat`: a vault is thousands of
+/// notes and skim runs a preview on every move through the list, so the pane
+/// that costs nothing to produce is the one that keeps up. Front matter is not
+/// repeated — the header above is what it says, read.
+///
+/// Rendering is line-level. Headings, quotes, list markers, task boxes and code
+/// fences are what a note is made of at a glance; `**bold**` and its friends
+/// are left as the author wrote them, since a pane that hides the markup it
+/// cannot render is lying about the file.
+pub fn preview(note: &Note, text: &str, now: i64, offset: time::UtcOffset) -> String {
+    let mut out = String::new();
+
+    out.push_str(&bold(&crate::term::one_row(note.title())));
+    out.push('\n');
+    out.push_str(&paint(&crate::term::one_row(&note.rel), DIM));
+    out.push('\n');
+
+    let tags = note.tag_column();
+    if !tags.is_empty() {
+        out.push_str(&paint(&crate::term::one_row(&tags), TAG_COLOR));
+        out.push('\n');
+    }
+
+    out.push_str(&paint(
+        &format!(
+            "modified {} ({})   created {} ({})",
+            timestamp(note.modified, offset),
+            age(now, note.modified),
+            date(note.created, offset),
+            age(now, note.created),
+        ),
+        DIM,
+    ));
+    out.push('\n');
+
+    let (_, body) = split_front_matter(text);
+    let mut fenced = false;
+    for line in body
+        .lines()
+        .skip_while(|line| line.trim().is_empty())
+        .take(PREVIEW_LINES)
+    {
+        // Every line reaching the terminal is a note's own bytes, so its
+        // control characters go before anything is drawn: a note holding an
+        // escape sequence would otherwise repaint the pane around it.
+        out.push('\n');
+        out.push_str(&markdown_line(&crate::term::one_row(line), &mut fenced));
+    }
+    out
+}
+
+/// One body line, drawn. `fenced` carries whether the line before it was inside
+/// a fenced code block, which is the only state a line-level renderer needs.
+fn markdown_line(line: &str, fenced: &mut bool) -> String {
+    let trimmed = line.trim_start();
+
+    if trimmed.starts_with("```") || trimmed.starts_with("~~~") {
+        *fenced = !*fenced;
+        return paint(line, DIM);
+    }
+    // Inside a fence every character is the author's, `#` and `[[` included.
+    if *fenced {
+        return line.to_string();
+    }
+
+    if let Some(heading) = heading(trimmed) {
+        return format!("\x1b[1;38;5;{HEADING_COLOR}m{heading}\x1b[0m");
+    }
+    if trimmed.starts_with('>') || is_rule(trimmed) {
+        return paint(line, DIM);
+    }
+    match task_or_bullet(line) {
+        Some((marker, rest)) => format!("{marker}{}", inline(rest)),
+        None => inline(line),
+    }
+}
+
+/// An ATX heading's text, `#` marks and all — kept, because a level is
+/// something a reader counts.
+fn heading(trimmed: &str) -> Option<&str> {
+    let hashes = trimmed.len() - trimmed.trim_start_matches('#').len();
+    ((1..=6).contains(&hashes) && trimmed[hashes..].starts_with(' ')).then_some(trimmed)
+}
+
+/// Whether the line is a thematic break rather than text.
+fn is_rule(trimmed: &str) -> bool {
+    let mark = trimmed.chars().next().filter(|c| "-*_".contains(*c));
+    mark.is_some_and(|mark| {
+        trimmed.chars().filter(|c| *c == mark).count() >= 3
+            && trimmed.chars().all(|c| c == mark || c == ' ')
+    })
+}
+
+/// A list line split into its drawn marker and the text after it: the bullet
+/// dim, a task's box green once it is ticked.
+fn task_or_bullet(line: &str) -> Option<(String, &str)> {
+    let indent = line.len() - line.trim_start().len();
+    let (bullet, after) = bullet(&line[indent..])?;
+    let head = &line[..indent + bullet.len()];
+
+    let Some(box_end) = task_box(after) else {
+        return Some((paint(head, DIM), after));
+    };
+    let (ticked, rest) = after.split_at(box_end);
+    let done = !ticked.contains(|c: char| c == ' ' && ticked.starts_with("[ "));
+    Some((
+        format!(
+            "{}{}",
+            paint(head, DIM),
+            paint(ticked, if done { DONE_COLOR } else { DIM })
+        ),
+        rest,
+    ))
+}
+
+/// The `- `, `* `, `+ ` or `1. ` opening a list item, and what follows it.
+fn bullet(text: &str) -> Option<(&str, &str)> {
+    if let Some(rest) = text
+        .strip_prefix(['-', '*', '+'])
+        .and_then(|r| r.strip_prefix(' '))
+    {
+        return Some((&text[..2], rest));
+    }
+    let digits = text.len() - text.trim_start_matches(|c: char| c.is_ascii_digit()).len();
+    if digits == 0 {
+        return None;
+    }
+    let rest = text[digits..].strip_prefix(['.', ')'])?.strip_prefix(' ')?;
+    Some((&text[..digits + 2], rest))
+}
+
+/// Where a task checkbox ends, when the text opens with one.
+fn task_box(text: &str) -> Option<usize> {
+    let inner = text.strip_prefix('[')?;
+    let mut chars = inner.chars();
+    let mark = chars.next()?;
+    chars.next().filter(|c| *c == ']')?;
+    // `[ ]` and `[x]` and nothing wider: `[2024-01-01]` opens a link, not a
+    // task.
+    (mark == ' ' || !mark.is_whitespace()).then_some(3)
+}
+
+/// Colour what a note's body says about itself: `[[wikilinks]]` and `#tags`.
+fn inline(line: &str) -> String {
+    let mut out = String::with_capacity(line.len());
+    let mut at = 0;
+    // A tag opens a word; `C#` in a sentence and a `#fragment` on a URL do not.
+    let mut boundary = true;
+
+    while at < line.len() {
+        if line[at..].starts_with("[[")
+            && let Some(end) = line[at + 2..].find("]]")
+        {
+            let link = &line[at..at + 2 + end + 2];
+            out.push_str(&paint(link, LINK_COLOR));
+            at += link.len();
+            boundary = false;
+            continue;
+        }
+        if boundary && let Some(tag) = tag_at(&line[at..]) {
+            out.push_str(&paint(tag, TAG_COLOR));
+            at += tag.len();
+            boundary = false;
+            continue;
+        }
+        let ch = line[at..].chars().next().expect("scanning by character");
+        boundary = ch.is_whitespace();
+        out.push(ch);
+        at += ch.len_utf8();
+    }
+    out
+}
+
+/// The tag `text` opens with, if it opens with one. A tag is `#` and at least
+/// one character of `[A-Za-z0-9/_-]`, not all of them digits — Obsidian's own
+/// rule, and what keeps `#1234` an issue number and `#fff` a colour.
+fn tag_at(text: &str) -> Option<&str> {
+    let rest = text.strip_prefix('#')?;
+    let len = rest
+        .find(|c: char| !(c.is_alphanumeric() || "/_-".contains(c)))
+        .unwrap_or(rest.len());
+    let tag = &rest[..len];
+    (!tag.is_empty() && !tag.chars().all(|c| c.is_ascii_digit())).then(|| &text[..len + 1])
+}
+
+fn paint(text: &str, color: u8) -> String {
+    crate::term::paint(text, color, true)
+}
+
+fn bold(text: &str) -> String {
+    format!("\x1b[1m{text}\x1b[0m")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn utc() -> time::UtcOffset {
+        time::UtcOffset::UTC
+    }
+
+    fn note(rel: &str, front: Front) -> Note {
+        Note {
+            path: PathBuf::from("/vault").join(rel),
+            rel: rel.to_string(),
+            modified: 0,
+            created: 0,
+            front,
+        }
+    }
+
+    fn front(text: &str) -> Front {
+        let (block, _) = split_front_matter(text);
+        parse_front(block.expect("front matter"), utc())
+    }
+
+    // --- front matter ---
+
+    #[test]
+    fn a_block_is_what_sits_between_the_two_fences() {
+        let (block, body) = split_front_matter("---\ntitle: A\n---\n# Heading\n");
+        assert_eq!(block, Some("title: A\n"));
+        assert_eq!(body, "# Heading\n");
+    }
+
+    /// A note that opens with a horizontal rule has no front matter, and must
+    /// not lose its body to a block that never closes.
+    #[test]
+    fn an_unterminated_block_is_not_front_matter() {
+        let text = "---\njust a rule, then prose\n";
+        assert_eq!(split_front_matter(text), (None, text));
+    }
+
+    #[test]
+    fn a_note_with_no_block_keeps_its_whole_body() {
+        let text = "# Heading\n\nbody\n";
+        assert_eq!(split_front_matter(text), (None, text));
+    }
+
+    #[test]
+    fn a_block_may_close_with_the_other_yaml_terminator() {
+        let (block, body) = split_front_matter("---\ntitle: A\n...\nbody\n");
+        assert_eq!(block, Some("title: A\n"));
+        assert_eq!(body, "body\n");
+    }
+
+    #[test]
+    fn tags_are_read_from_a_flow_sequence_a_block_sequence_or_a_bare_list() {
+        for written in [
+            "tags: [rust, til]",
+            "tags:\n  - rust\n  - til",
+            "tags:\n- rust\n- til",
+            "tags: rust til",
+            "tags: rust, til",
+            "tags: [\"rust\", 'til']",
+            "tag: #rust #til",
+        ] {
+            let parsed = front(&format!("---\n{written}\n---\n"));
+            assert_eq!(parsed.tags, vec!["rust", "til"], "{written:?}");
+        }
+    }
+
+    /// The tag column is drawn with a `#`, so a vault that writes them that way
+    /// must not end up with two.
+    #[test]
+    fn a_tag_is_stored_without_the_hash_it_is_drawn_with() {
+        let parsed = front("---\ntags: [\"#rust\"]\n---\n");
+        assert_eq!(parsed.tags, vec!["rust"]);
+        assert_eq!(note("a.md", parsed).tag_column(), "#rust");
+    }
+
+    #[test]
+    fn a_repeated_tag_is_listed_once() {
+        assert_eq!(front("---\ntags: [a, b, a]\n---\n").tags, vec!["a", "b"]);
+    }
+
+    /// A block sequence belongs to the key that opened it. `aliases` is the one
+    /// every vault has, and its items are not tags.
+    #[test]
+    fn a_sequence_under_another_key_is_not_read_as_tags() {
+        let parsed = front("---\ntags:\n  - real\naliases:\n  - other\n  - names\n---\n");
+        assert_eq!(parsed.tags, vec!["real"]);
+    }
+
+    #[test]
+    fn a_nested_mapping_is_skipped_rather_than_read_as_keys() {
+        let parsed = front("---\nobsidian:\n  title: nested\ntitle: real\n---\n");
+        assert_eq!(parsed.title.as_deref(), Some("real"));
+    }
+
+    #[test]
+    fn a_quoted_title_loses_its_quotes() {
+        assert_eq!(
+            front("---\ntitle: \"Error handling\"\n---\n")
+                .title
+                .as_deref(),
+            Some("Error handling")
+        );
+    }
+
+    /// A title with a colon in it is one value, not a key and a value: only the
+    /// first colon separates them.
+    #[test]
+    fn a_title_may_contain_a_colon() {
+        assert_eq!(
+            front("---\ntitle: Rust: error handling\n---\n")
+                .title
+                .as_deref(),
+            Some("Rust: error handling")
+        );
+    }
+
+    #[test]
+    fn a_created_date_becomes_local_midnight_on_the_day_it_names() {
+        let offset = time::UtcOffset::from_hms(2, 0, 0).unwrap();
+        let (block, _) = split_front_matter("---\ncreated: 2024-03-01\n---\n");
+        let parsed = parse_front(block.unwrap(), offset);
+        assert_eq!(date(parsed.created.unwrap(), offset), "2024-03-01");
+    }
+
+    #[test]
+    fn a_created_value_carrying_a_time_still_names_a_day() {
+        for written in ["2024-03-01T09:30:00", "2024-03-01 09:30", "\"2024-03-01\""] {
+            let parsed = front(&format!("---\ncreated: {written}\n---\n"));
+            assert_eq!(
+                date(parsed.created.expect(written), utc()),
+                "2024-03-01",
+                "{written:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_created_value_that_is_not_a_date_is_no_date_at_all() {
+        for written in ["someday", "2024", "not-a-date-x", "2024-13-01"] {
+            let parsed = front(&format!("---\ncreated: {written}\n---\n"));
+            assert_eq!(parsed.created, None, "{written:?}");
+        }
+    }
+
+    #[test]
+    fn a_vault_writing_date_rather_than_created_is_read_the_same_way() {
+        let parsed = front("---\ndate: 2024-03-01\n---\n");
+        assert_eq!(date(parsed.created.unwrap(), utc()), "2024-03-01");
+    }
+
+    // --- what a note calls itself ---
+
+    #[test]
+    fn a_note_falls_back_to_its_filename_and_takes_a_title_over_it() {
+        assert_eq!(note("work/standup.md", Front::default()).title(), "standup");
+        assert_eq!(
+            note(
+                "work/standup.md",
+                Front {
+                    title: Some("Daily standup".into()),
+                    ..Front::default()
+                }
+            )
+            .title(),
+            "Daily standup"
+        );
+    }
+
+    #[test]
+    fn a_note_at_the_vault_root_is_filed_under_nothing() {
+        assert_eq!(note("inbox.md", Front::default()).folder(), "");
+        assert_eq!(note("a/b/c.md", Front::default()).folder(), "a/b");
+    }
+
+    /// The filesystem dates a synced or freshly cloned vault the day it
+    /// arrived, which is why front matter wins.
+    #[test]
+    fn a_creation_date_prefers_front_matter_then_the_filesystem_then_the_edit() {
+        assert_eq!(created(Some(10), Some(20), 30), 10);
+        assert_eq!(created(None, Some(20), 30), 20);
+        assert_eq!(created(None, None, 30), 30);
+    }
+
+    // --- dates ---
+
+    #[test]
+    fn an_age_reads_as_the_largest_unit_that_fits() {
+        let cases = [
+            (0, "now"),
+            (59, "now"),
+            (60, "1m"),
+            (59 * MINUTE, "59m"),
+            (HOUR, "1h"),
+            (DAY, "1d"),
+            (6 * DAY, "6d"),
+            (WEEK, "1w"),
+            (4 * WEEK, "4w"),
+            (5 * WEEK, "1mo"),
+            (364 * DAY, "11mo"),
+            (YEAR, "1y"),
+        ];
+        for (elapsed, want) in cases {
+            assert_eq!(age(elapsed, 0), want, "{elapsed}s");
+        }
+    }
+
+    /// A clock that went backwards, or a front matter date typed ahead, must
+    /// not print a negative age into a right-aligned column.
+    #[test]
+    fn a_note_dated_in_the_future_reads_as_now() {
+        assert_eq!(age(0, 10_000), "now");
+    }
+
+    #[test]
+    fn an_age_never_rounds_down_to_no_months_at_all() {
+        for elapsed in (5 * WEEK)..YEAR {
+            let stamp = age(elapsed, 0);
+            assert!(stamp.starts_with(|c: char| c != '0'), "{elapsed}s: {stamp}");
+        }
+    }
+
+    // --- rows ---
+
+    fn vault() -> Vec<Note> {
+        vec![
+            Note {
+                modified: 3 * DAY,
+                created: 3 * DAY,
+                ..note(
+                    "work/meetings/standup.md",
+                    Front {
+                        tags: vec!["work".into()],
+                        ..Front::default()
+                    },
+                )
+            },
+            Note {
+                modified: 0,
+                created: 0,
+                ..note("inbox.md", Front::default())
+            },
+        ]
+    }
+
+    fn labels(notes: &[Note]) -> Vec<String> {
+        let widths = Widths::of(notes, 0);
+        notes.iter().map(|n| row(n, &widths).0).collect()
+    }
+
+    #[test]
+    fn a_row_carries_the_title_the_folder_and_the_tags() {
+        assert_eq!(
+            labels(&vault())[0],
+            "standup  work/meetings  #work",
+            "{:?}",
+            labels(&vault())
+        );
+    }
+
+    #[test]
+    fn a_row_without_tags_ends_at_its_folder() {
+        assert_eq!(labels(&vault())[1], "inbox");
+    }
+
+    /// The columns are what make a listing scannable; a title one character
+    /// longer must not shift the folder on every other row.
+    #[test]
+    fn the_columns_line_up_across_the_whole_list() {
+        let notes = vault();
+        let widths = Widths::of(&notes, 0);
+        let at = |label: &str| {
+            label
+                .find("work/meetings")
+                .or_else(|| label.find("  "))
+                .unwrap()
+        };
+        let rows: Vec<String> = notes.iter().map(|n| row(n, &widths).0).collect();
+        assert_eq!(
+            rows[0].find("work/meetings"),
+            Some(widths.title + 2),
+            "{rows:?}"
+        );
+        assert!(at(&rows[0]) >= widths.title, "{rows:?}");
+    }
+
+    #[test]
+    fn column_width_counts_characters_not_bytes() {
+        let notes = vec![
+            note("café.md", Front::default()),
+            note("a.md", Front::default()),
+        ];
+        let widths = Widths::of(&notes, 0);
+        assert_eq!(widths.title, "café".chars().count());
+    }
+
+    #[test]
+    fn a_row_tints_its_folder_and_its_tags_and_leaves_the_title_alone() {
+        let notes = vault();
+        let widths = Widths::of(&notes, 0);
+        let (label, tints) = row(&notes[0], &widths);
+        let text = |tint: &Tint| -> String {
+            label
+                .chars()
+                .skip(tint.range.start)
+                .take(tint.range.len())
+                .collect()
+        };
+        assert_eq!(tints.len(), 2, "{label:?}");
+        assert_eq!(text(&tints[0]), "work/meetings");
+        assert_eq!(tints[0].color, FOLDER_COLOR);
+        assert_eq!(text(&tints[1]), "#work");
+        assert_eq!(tints[1].color, TAG_COLOR);
+    }
+
+    /// The prefix is what holds the two age columns, and it is not matched
+    /// against — a query of `3` must not rank every three-day-old note first.
+    #[test]
+    fn the_prefix_holds_both_ages_and_the_label_holds_neither() {
+        let notes = vault();
+        let widths = Widths::of(&notes, 3 * DAY);
+        let (label, _) = row(&notes[0], &widths);
+        assert_eq!(prefix(&notes[0], 3 * DAY, &widths), "now now  ");
+        assert!(!label.contains("now"), "{label:?}");
+    }
+
+    #[test]
+    fn every_prefix_is_the_same_width() {
+        let notes = vault();
+        let widths = Widths::of(&notes, 10 * YEAR);
+        let rendered: Vec<usize> = notes
+            .iter()
+            .map(|n| prefix(n, 10 * YEAR, &widths).chars().count())
+            .collect();
+        assert!(rendered.windows(2).all(|w| w[0] == w[1]), "{rendered:?}");
+    }
+
+    #[test]
+    fn a_status_row_leads_with_the_name_and_ends_with_both_dates() {
+        let notes = vault();
+        let widths = Widths::of(&notes, 0);
+        let row = status_row(&notes[0], &widths, utc());
+        assert!(row.starts_with("work/meetings/standup.md"), "{row:?}");
+        assert!(row.contains("#work"), "{row:?}");
+        assert!(row.ends_with("1970-01-04"), "{row:?}");
+    }
+
+    #[test]
+    fn a_listing_leads_with_what_was_touched_most_recently() {
+        let mut notes = vault();
+        newest_first(&mut notes);
+        assert_eq!(notes[0].rel, "work/meetings/standup.md");
+    }
+
+    #[test]
+    fn only_markdown_is_a_note() {
+        for name in ["a.md", "a.markdown", "a.MD"] {
+            assert!(is_note(Path::new(name)), "{name}");
+        }
+        for name in ["a.png", "a.canvas", "a", "a.md.bak"] {
+            assert!(!is_note(Path::new(name)), "{name}");
+        }
+    }
+
+    // --- preview ---
+
+    fn preview_of(text: &str) -> String {
+        preview(&note("work/a.md", Front::default()), text, 0, utc())
+    }
+
+    /// The header is where the row's two age columns are named; without it the
+    /// pair reads as two numbers.
+    #[test]
+    fn the_preview_names_both_dates_the_row_only_shows() {
+        let rendered = preview_of("body\n");
+        assert!(rendered.contains("modified "), "{rendered}");
+        assert!(rendered.contains("created "), "{rendered}");
+    }
+
+    /// The header already says everything the block does, spelled out.
+    #[test]
+    fn the_preview_shows_the_body_and_not_the_front_matter() {
+        let rendered = preview_of("---\ntitle: A\ntags: [x]\n---\n\n# Heading\n");
+        assert!(rendered.contains("Heading"), "{rendered}");
+        assert!(!rendered.contains("tags: [x]"), "{rendered}");
+    }
+
+    /// A note is foreign text: an escape sequence in one would otherwise
+    /// repaint the pane around it. Only scriv's own colours survive the body.
+    #[test]
+    fn a_note_cannot_colour_the_pane_with_its_own_escapes() {
+        let rendered = preview_of("plain \x1b[31mred\x1b[0m\n");
+        let body = rendered.split_once("\n\n").expect("a body").1;
+        assert!(body.contains("red"), "{body:?}");
+        assert!(!body.contains('\x1b'), "{body:?}");
+    }
+
+    #[test]
+    fn a_preview_stops_at_the_line_it_is_bounded_to() {
+        let long = "line\n".repeat(PREVIEW_LINES * 2);
+        let rendered = preview_of(&long);
+        assert_eq!(rendered.matches("line").count(), PREVIEW_LINES);
+    }
+
+    fn drawn(line: &str) -> String {
+        markdown_line(line, &mut false)
+    }
+
+    #[test]
+    fn a_heading_keeps_its_hashes_so_its_level_is_still_countable() {
+        assert!(drawn("## Notes").contains("## Notes"));
+    }
+
+    #[test]
+    fn a_ticked_task_and_an_open_one_are_not_drawn_alike() {
+        assert_ne!(drawn("- [x] done"), drawn("- [ ] open"));
+        assert!(drawn("- [x] done").contains("done"));
+    }
+
+    #[test]
+    fn a_wikilink_and_a_tag_are_coloured_where_they_appear() {
+        let rendered = drawn("see [[other note]] about #rust");
+        assert!(
+            rendered.contains(&paint("[[other note]]", LINK_COLOR)),
+            "{rendered:?}"
+        );
+        assert!(
+            rendered.contains(&paint("#rust", TAG_COLOR)),
+            "{rendered:?}"
+        );
+    }
+
+    /// A `#` that opens no word is not a tag: `#1234` is an issue number and
+    /// `#fff` a colour, and both sit in the middle of prose.
+    #[test]
+    fn a_hash_that_is_not_a_tag_is_left_alone() {
+        for line in ["issue #1234", "C# is a language", "url#fragment"] {
+            assert_eq!(drawn(line), line, "{line:?}");
+        }
+    }
+
+    /// Inside a fence every character is the author's, `#` and `[[` included.
+    #[test]
+    fn a_fenced_block_is_not_rendered_as_markdown() {
+        let mut fenced = false;
+        markdown_line("```sh", &mut fenced);
+        assert!(fenced);
+        assert_eq!(
+            markdown_line("# not a heading", &mut fenced),
+            "# not a heading"
+        );
+        markdown_line("```", &mut fenced);
+        assert!(!fenced);
+    }
+}

--- a/src/select.rs
+++ b/src/select.rs
@@ -56,6 +56,14 @@ pub enum Preview {
     /// counterpart, and deferred for the same reason — the directory walk is
     /// streamed too.
     Dir,
+    /// Text scriv builds itself, the moment the row is highlighted.
+    ///
+    /// [`Preview::Text`] for a pane too expensive to hold one of per row: a
+    /// vault of two thousand notes read and rendered up front is two thousand
+    /// panes nobody looks at. Runs on skim's preview thread, so it is held to
+    /// the same bar as a [`Preview::Command`] — local, bounded, tens of
+    /// milliseconds — and ANSI escapes in what it returns are honoured.
+    Deferred(Box<dyn Fn() -> String + Send + Sync>),
 }
 
 /// Quote `arg` for the shell that runs a [`Preview::Command`], so a branch name
@@ -278,6 +286,7 @@ impl SkimItem for SkItem {
             Some(Preview::Command(cmd)) => ItemPreview::Command(cmd.clone()),
             Some(Preview::File) => ItemPreview::Command(file_preview_cmd(self.item.value())),
             Some(Preview::Dir) => ItemPreview::Command(dir_preview_cmd(self.item.value())),
+            Some(Preview::Deferred(build)) => ItemPreview::AnsiText(build()),
             // Blank rather than `Global`, which would run the empty global
             // preview command.
             None => ItemPreview::Text(String::new()),

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -104,6 +104,12 @@ function kl --description "Fuzzy-select running processes and kill them"
     command scriv proc kill --force $argv
 end
 
+# `scriv note edit` spawns its own editor, which may be a reader rather than an
+# editor — hence a wrapper here and not a `cd` helper.
+function scriv-note-edit --description "Select a note and open it"
+    command scriv note edit
+end
+
 function scriv-branch-checkout --description "Select a git branch and check it out"
     command scriv branch checkout
 end
@@ -150,8 +156,8 @@ end
 # around the cursor, which is worth less than a jump between worktrees — and up
 # over `up-line`, which scriv-history-up hands back wherever the selector would
 # be wrong. ctrl-p/ctrl-n are deliberately left as `up-line`/`down-line`. f1, f2,
-# f3 and f7 displace nothing; f4 and f5 are skipped because users' own tools
-# cluster there. alt-<letter> is not free: fish presets alt-b, alt-e, alt-o and
+# f3, f7 and f10 displace nothing; f4 and f5 are skipped because users' own
+# tools cluster there. alt-<letter> is not free: fish presets alt-b, alt-e, alt-o and
 # alt-p among others.
 #
 # Rebind by calling `bind` yourself after `scriv_key_bindings`; the last binding
@@ -168,6 +174,7 @@ function scriv_key_bindings --description "Bind scriv selectors to keys"
     bind f3     "scriv-run-as-command scriv-file-edit"
     bind ctrl-g "scriv-run-as-command scriv-branch-checkout"
     bind f7     "scriv-run-as-command scriv-pr-checkout"
+    bind f10    "scriv-run-as-command scriv-note-edit"
     bind ctrl-r "scriv-history-select; commandline -f repaint"
     bind up     "scriv-history-up; commandline -f repaint"
 end
@@ -193,6 +200,7 @@ mod tests {
         assert!(out.contains("function scriv-file-edit"));
         assert!(out.contains("function fe"));
         assert!(out.contains("function kl"));
+        assert!(out.contains("function scriv-note-edit"));
         assert!(out.contains("function scriv-branch-checkout"));
         assert!(out.contains("function scriv-pr-checkout"));
         assert!(out.contains("function scriv-pr-open"));
@@ -211,6 +219,7 @@ mod tests {
         assert!(out.contains("bind f2"));
         assert!(out.contains("bind f3"));
         assert!(out.contains("bind f7"));
+        assert!(out.contains("bind f10"));
         assert!(out.contains("bind ctrl-g"));
         assert!(out.contains("bind ctrl-r"));
         assert!(out.contains("bind up"));
@@ -310,7 +319,7 @@ mod tests {
     #[test]
     fn bindings_that_produce_output_run_through_the_command_line() {
         let out = integration(Shell::Fish, &mut dummy());
-        for key in ["ctrl-o", "ctrl-t", "f1", "f2", "f3", "ctrl-g", "f7"] {
+        for key in ["ctrl-o", "ctrl-t", "f1", "f2", "f3", "ctrl-g", "f7", "f10"] {
             let bind = binding_for(&out, key);
             assert!(
                 bind.contains("scriv-run-as-command"),

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -259,6 +259,7 @@ fn the_documented_abbreviations_resolve() {
         &["w", "--help"][..],
         &["f", "--help"][..],
         &["h", "--help"][..],
+        &["n", "--help"][..],
         &["pc", "--help"][..],
         &["branch", "co", "--help"][..],
         &["repo", "list", "--help"][..],
@@ -355,7 +356,7 @@ fn pr_outside_a_repository_says_so_before_gh_does() {
 fn every_registry_exposes_sel() {
     let sandbox = Sandbox::new();
     for group in [
-        "repo", "file", "branch", "worktree", "pr", "proc", "history",
+        "repo", "file", "note", "branch", "worktree", "pr", "proc", "history",
     ] {
         sandbox.run(&[group, "sel", "--help"]).ok();
     }
@@ -1603,4 +1604,162 @@ fn init_works_before_there_is_any_config() {
     let sandbox = Sandbox::new();
     assert!(!sandbox.config_path().exists());
     sandbox.run(&["init", "fish"]).ok();
+}
+
+// --- notes ------------------------------------------------------------------
+
+/// Write a note into `<home>/notes`, dated `modified` seconds after the epoch
+/// so a listing's order is decided rather than raced for.
+fn mk_note(vault: &Path, rel: &str, body: &str, modified: u64) {
+    let path = vault.join(rel);
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    std::fs::write(&path, body).unwrap();
+    let when = std::time::UNIX_EPOCH + std::time::Duration::from_secs(modified);
+    std::fs::File::options()
+        .write(true)
+        .open(&path)
+        .unwrap()
+        .set_times(std::fs::FileTimes::new().set_modified(when))
+        .unwrap();
+}
+
+/// A vault of three notes, the newest last in the alphabet so ordering by name
+/// and ordering by date cannot be mistaken for each other.
+fn mk_vault(sandbox: &Sandbox) -> PathBuf {
+    let vault = sandbox.home().join("notes");
+    mk_note(
+        &vault,
+        "archive/old.md",
+        "---\ntags: [done]\n---\n\nold\n",
+        1_000,
+    );
+    mk_note(
+        &vault,
+        "inbox.md",
+        "---\ntitle: Inbox\ntags:\n  - todo\n  - work\ncreated: 2024-03-01\n---\n\n# Inbox\n",
+        3_000,
+    );
+    mk_note(&vault, "zeta.md", "no front matter\n", 2_000);
+    sandbox.write_config(&format!(
+        "[note]\nroot = {:?}\neditor = \"echo\"\n",
+        vault.display().to_string()
+    ));
+    vault
+}
+
+#[test]
+fn note_ls_names_every_note_below_the_vault_newest_first() {
+    let sandbox = Sandbox::new();
+    mk_vault(&sandbox);
+    let run = sandbox.run(&["note", "ls"]);
+    run.ok();
+    assert_eq!(run.lines(), vec!["inbox.md", "zeta.md", "archive/old.md"]);
+}
+
+/// The vault holds an attachment and an Obsidian settings directory, neither of
+/// which is a note.
+#[test]
+fn note_ls_offers_markdown_and_not_the_rest_of_the_vault() {
+    let sandbox = Sandbox::new();
+    let vault = mk_vault(&sandbox);
+    std::fs::write(vault.join("diagram.png"), "").unwrap();
+    std::fs::create_dir_all(vault.join(".obsidian")).unwrap();
+    std::fs::write(vault.join(".obsidian/app.md"), "").unwrap();
+
+    let run = sandbox.run(&["note", "ls"]);
+    run.ok();
+
+    assert!(!run.stdout.contains("diagram"), "{}", run.stdout);
+    assert!(!run.stdout.contains("obsidian"), "{}", run.stdout);
+}
+
+#[test]
+fn note_ls_absolute_paths_are_absolute() {
+    let sandbox = Sandbox::new();
+    let vault = mk_vault(&sandbox);
+    let run = sandbox.run(&["note", "ls", "--absolute-paths"]);
+    run.ok();
+    for line in run.lines() {
+        assert!(line.starts_with(vault.to_str().unwrap()), "{line}");
+    }
+}
+
+/// The status listing is what a script reads a note's metadata out of, so the
+/// name it leads with has to be the one `note edit` takes back.
+#[test]
+fn note_ls_status_carries_the_tags_and_both_dates() {
+    let sandbox = Sandbox::new();
+    mk_vault(&sandbox);
+    let run = sandbox.run(&["note", "ls", "--status"]);
+    run.ok();
+
+    let inbox = run.lines()[0].to_string();
+    assert!(inbox.starts_with("inbox.md"), "{inbox}");
+    assert!(inbox.contains("#todo #work"), "{inbox}");
+    // The front matter's creation date, not the file's: this vault was written
+    // moments ago.
+    assert!(inbox.ends_with("2024-03-01"), "{inbox}");
+}
+
+#[test]
+fn note_without_a_vault_says_which_key_is_missing() {
+    let sandbox = Sandbox::new();
+    sandbox.write_config("[repo]\nroot = \"~/dev\"\n");
+    let run = sandbox.run(&["note", "ls"]);
+    run.code(1);
+    assert!(run.stderr.contains("[note] root"), "{}", run.stderr);
+}
+
+#[test]
+fn note_with_a_vault_that_is_not_there_says_so() {
+    let sandbox = Sandbox::new();
+    sandbox.write_config("[note]\nroot = \"~/nowhere\"\n");
+    let run = sandbox.run(&["note", "ls"]);
+    run.code(1);
+    assert!(run.stderr.contains("not a directory"), "{}", run.stderr);
+}
+
+/// `[note] editor` is `echo` here, so what it was asked to open comes back on
+/// stdout. A name is a path below the vault — what `note ls` printed.
+#[test]
+fn note_edit_resolves_a_name_against_the_vault() {
+    let sandbox = Sandbox::new();
+    let vault = mk_vault(&sandbox);
+    let run = sandbox.run(&["note", "edit", "archive/old.md"]);
+    run.ok();
+    assert_eq!(
+        run.stdout.trim(),
+        format!("-- {}", vault.join("archive/old.md").display())
+    );
+}
+
+/// The key exists so a note can be opened by something other than the editor
+/// the rest of scriv uses; with none set, it is that editor.
+#[test]
+fn note_edit_falls_back_to_the_environment_editor() {
+    let sandbox = Sandbox::new();
+    let vault = sandbox.home().join("notes");
+    mk_note(&vault, "a.md", "a\n", 1_000);
+    sandbox.write_config(&format!(
+        "[note]\nroot = {:?}\n",
+        vault.display().to_string()
+    ));
+
+    let run = sandbox.run_with_env(&["note", "edit", "a.md"], &[("EDITOR", "echo")]);
+    run.ok();
+    assert_eq!(
+        run.stdout.trim(),
+        format!("-- {}", vault.join("a.md").display())
+    );
+}
+
+/// `config check` is what a setup script runs, so a configured vault has to
+/// report as found rather than as a thing scriv knows nothing about.
+#[test]
+fn config_check_counts_the_notes_in_the_vault() {
+    let sandbox = Sandbox::new();
+    mk_vault(&sandbox);
+    let run = sandbox.run(&["config", "check"]);
+    assert!(run.stdout.contains("3 note(s)"), "{}", run.stdout);
+    assert!(run.stdout.contains("note editor"), "{}", run.stdout);
 }


### PR DESCRIPTION
- `scriv note ls`/`sel`/`edit` over a directory of Markdown files, named by `[note] root`.
- Titles, tags and creation dates come from YAML front matter; inline `#tags` are not indexed.
- A creation date prefers the front matter over the filesystem's, which a synced or cloned vault gets wrong for every note at once.
- Rows are ordered by modification time, not `Ctx::by_recency` — opening a note is what changes that time.
- Two dim age columns ahead of each row, modified then created, named in the preview header.
- The preview pane is drawn in-process through a new `Preview::Deferred`, so no subprocess runs per keystroke.
- `[note] editor` picks what opens a note, falling back to `$VISUAL`/`$EDITOR`.
- fish binds f10 to `note edit`.

Cost: a vault is read on every `note` invocation — one `stat` and an 8 KiB head read per Markdown file, on the walker's threads. A thousand-note vault is tens of milliseconds; there is no cache.

Docs: `src/main.rs` help, README (command table, key bindings, config, requirements) and `CHANGELOG.md` under `## Unreleased` are all updated. `docs/demo.gif` is unchanged — nothing altered what an existing selector draws, and the tape does not visit a vault.