### PR TITLE
Read a note by what is true of it, and search inside every one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,38 @@ raised, never by hand.
 
 ## Unreleased
 
+### Added
+
+- `scriv note new` starts a note and drops you straight into your editor. It
+  asks nothing first — being asked to name a note is being asked what it is
+  about before writing it — so with no name it calls the file after the date and
+  time, to the minute. A name with a `/` in it makes the directory. The file
+  itself is left for the editor to write, so a note started and abandoned is one
+  that never existed rather than an empty one in every listing after it.
+- `scriv note rg` searches inside every note as you type. The query goes to
+  ripgrep rather than to the fuzzy matcher, so the list is every matching *line*
+  in the vault, rebuilt on each keystroke, with the note around the match in the
+  preview pane. `tab` takes several; what you pick opens at its line and the
+  rest land in the quickfix list behind it. `ctrl-q` switches to filtering what
+  came back.
+- `[note] labels` names the directories directly below your vault, one label to
+  many directories — the same shape as `[repo] labels`, and the same colours, so
+  `work` reads the same in both. Label two of five directories and the other
+  three still show up, under their own names.
+
+### Changed
+
+- A note row is laid out differently. The note's own name comes first, where it
+  is what the eye runs down and what the query matches, and everything else is
+  an attribute in a column of its own with a colour that says which: the label
+  or directory it is filed under, the folders below that, its tags, how many of
+  its tasks are still open, and — no longer leading the row — how long ago it
+  was modified and created. The dates and the task count are drawn but never
+  searched, so typing `3` finds the note you meant rather than every note that
+  is three days old. A column nothing in your vault fills is not drawn at all.
+- The preview pane's header now names the label and spells out how many tasks a
+  note has left.
+
 ## v0.9.0
 
 *Released 2026-08-25*

--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ cargo install --git https://github.com/joakimen/scriv
 Supported platform: macOS on Apple Silicon. `scriv proc` depends on Darwin's
 signal numbers, and the crate refuses to compile for any other target.
 
-External requirements: `git`, plus `gh` for `pr` and `repo clone`/`open`, a
-fish history file for `history`, and `$VISUAL` or `$EDITOR` for `edit` — or
-`[note] editor` for `note`. `scriv config check` reports on each.
+External requirements: `git`, plus `gh` for `pr` and `repo clone`/`open`, `rg`
+for `note rg`, a fish history file for `history`, and `$VISUAL` or `$EDITOR` for
+`edit` — or `[note] editor` for `note`. `scriv config check` reports on each.
 
 ## Setup
 
@@ -69,7 +69,8 @@ ignore = ["node_modules", "target"]
 
 [note]
 root = "~/notes"    # an Obsidian vault, or any tree of Markdown files
-editor = "nvim"     # what `note edit` opens one with; unset, $VISUAL / $EDITOR
+editor = "nvim"     # what `note` opens one with; unset, $VISUAL / $EDITOR
+# labels = { work = ["projects", "clients"], personal = ["journal"] }
 ```
 
 ## Commands
@@ -78,7 +79,7 @@ editor = "nvim"     # what `note edit` opens one with; unset, $VISUAL / $EDITOR
 | --- | --- |
 | `scriv repo` | `ls` `sel` `open` `clone` |
 | `scriv file` | `ls` `sel` `add` `rm` `prune` |
-| `scriv note` | `ls` `sel` `edit` |
+| `scriv note` | `ls` `sel` `new` `edit` `rg` |
 | `scriv branch` | `ls` `sel` `checkout` `rm` |
 | `scriv worktree` | `ls` `sel` `add` `rm` |
 | `scriv pr` | `ls` `sel` `checkout` `open` `merge` |
@@ -87,6 +88,12 @@ editor = "nvim"     # what `note edit` opens one with; unset, $VISUAL / $EDITOR
 | `scriv edit` | `file` `dir` — found below `$PWD`, opened in `$EDITOR` |
 | `scriv config` | `init` `print` `path` `check` |
 | `scriv init` | `fish` and every other shell — see Setup |
+
+A note row leads with what the note calls itself and then says what is true of
+it in a colour-coded column each: the label its directory carries, the folders
+below that, its tags, how many of its tasks are still open, and how long ago it
+was modified and created. `note rg` searches inside every note as you type and
+turns what you pick into a quickfix list.
 
 `ls` prints the set, `sel` fuzzy-selects one entry, and the remaining verbs act
 on the selection. `sel` prints to stdout and composes: `cd (scriv repo sel)`.

--- a/src/cmd/config.rs
+++ b/src/cmd/config.rs
@@ -59,6 +59,14 @@ ignore = ["node_modules", "target"]
 # YAML front matter. Without this, `scriv note` has nowhere to look.
 # root = "~/notes"
 
+# Labels for the directories directly below the root, one label to many
+# directories — the same idea as `[repo] labels`, and the same colours, so
+# `work` reads the same in both. A directory with no label still shows up in
+# the label column, under its own name and uncoloured.
+#
+# Written inline, on one line, for the reason `[repo] labels` is.
+# labels = { work = ["projects", "clients"], personal = ["journal"] }
+
 # What `note edit` launches, split on whitespace like $EDITOR. Its own setting
 # because a note is as often read as written — `glow` and `nvim` are both
 # answers. Unset, it is $VISUAL then $EDITOR, as `scriv edit` uses.
@@ -148,6 +156,12 @@ pub fn print(ctx: &Ctx) -> Result<()> {
         "root: {}",
         ctx.config.note.root.as_deref().unwrap_or("(unset)")
     );
+    if !ctx.config.note.labels.is_empty() {
+        println!("labels:");
+        for (label, dirs) in &ctx.config.note.labels {
+            println!("  {label}: {}", dirs.join(", "));
+        }
+    }
     println!(
         "editor: {}",
         ctx.note_editor_setting()
@@ -542,6 +556,12 @@ fn collect(ctx: &Ctx) -> Vec<Check> {
         "`branch` and `repo` cannot work without it",
     ));
     checks.push(gh_check());
+    checks.push(tool_check(
+        "rg",
+        "rg",
+        false,
+        "only `note rg` needs it (https://github.com/BurntSushi/ripgrep)",
+    ));
     // `kill` and `lsof` get no row: both ship in the same base system `ps`
     // does, and a report of three lines saying the same thing is one line.
     checks.push(tool_check(

--- a/src/cmd/note.rs
+++ b/src/cmd/note.rs
@@ -7,10 +7,10 @@
 
 use std::io::Read;
 use std::path::{Path, PathBuf};
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 use std::time::SystemTime;
 
-use anyhow::{Result, bail};
+use anyhow::{Context, Result, bail};
 
 use crate::note::{self, Note, Widths};
 use crate::path::expand_home_dir;
@@ -93,7 +93,7 @@ fn load(ctx: &Ctx) -> Result<Vec<Note>> {
 }
 
 /// One note, read: its times from the directory entry's metadata, its front
-/// matter from the first [`HEAD_BYTES`].
+/// matter and its checkboxes from the first [`HEAD_BYTES`].
 ///
 /// `None` for a file whose metadata cannot be read, which is one note missing
 /// from a listing rather than the listing failing — the same way the walk
@@ -104,21 +104,28 @@ fn read_note(path: &Path, root: &Path, offset: time::UtcOffset) -> Option<Note> 
     let birth = meta.created().ok().and_then(unix);
 
     let head = read_head(path, HEAD_BYTES).unwrap_or_default();
-    let front = match note::split_front_matter(&head) {
-        (Some(block), _) => note::parse_front(block, offset),
-        (None, _) => note::Front::default(),
-    };
+    let (block, body) = note::split_front_matter(&head);
+    let front = block.map_or_else(note::Front::default, |block| {
+        note::parse_front(block, offset)
+    });
+    // Counted from the bytes already read rather than from a second pass: a
+    // note longer than the bound is one whose last checkboxes go uncounted,
+    // which is a number slightly low rather than a vault read twice.
+    let tasks = note::count_tasks(body);
 
+    let rel = path
+        .strip_prefix(root)
+        .unwrap_or(path)
+        .to_string_lossy()
+        .into_owned();
     Some(Note {
-        rel: path
-            .strip_prefix(root)
-            .unwrap_or(path)
-            .to_string_lossy()
-            .into_owned(),
+        dir: note::top_dir(&rel).to_string(),
+        rel,
         path: path.to_path_buf(),
         modified,
         created: note::created(front.created, birth, modified),
         front,
+        tasks,
     })
 }
 
@@ -151,7 +158,8 @@ fn unix(time: SystemTime) -> Option<i64> {
 /// what a pipe can open.
 pub fn ls(ctx: &Ctx, absolute_paths: bool, status: bool) -> Result<()> {
     let notes = load(ctx)?;
-    let widths = Widths::of(&notes, crate::unix_now());
+    let cfg = &ctx.config.note;
+    let widths = Widths::of(&notes, cfg, crate::unix_now());
     let offset = ctx.utc_offset();
 
     let mut out = term::Listing::stdout();
@@ -159,7 +167,7 @@ pub fn ls(ctx: &Ctx, absolute_paths: bool, status: bool) -> Result<()> {
         let row = match (absolute_paths, status) {
             (true, _) => note.path.display().to_string(),
             (false, false) => note.rel.clone(),
-            (false, true) => note::status_row(note, &widths, offset),
+            (false, true) => note::status_row(note, cfg, &widths, offset),
         };
         if !out.line(&row)? {
             break;
@@ -222,31 +230,391 @@ fn select_notes(ctx: &Ctx) -> Result<Option<Vec<String>>> {
     }
 }
 
-/// Selector rows: the dim age columns as a prefix, the title, folder and tags
-/// as the label, and the note's absolute path as the value.
+/// Selector rows: the note's name first, then what is true of it, then the
+/// columns nobody searches for — see [`note::row`] and [`note::suffix`].
 ///
 /// Every pane is built when its row is highlighted rather than now — see
 /// [`Preview::Deferred`]. A vault read up front is one file read per note for
 /// panes the user scrolls past.
 fn items(ctx: &Ctx, notes: &[Note]) -> Vec<SelectItem> {
     let now = crate::unix_now();
-    let widths = Widths::of(notes, now);
+    let cfg = ctx.config.note.clone();
+    let widths = Widths::of(notes, &cfg, now);
     let offset = ctx.utc_offset();
 
     notes
         .iter()
         .map(|note| {
-            let (label, tints) = note::row(note, &widths);
+            let (label, tints) = note::row(note, &cfg, &widths);
+            let (suffix, suffix_tints) = note::suffix(note, now, &widths);
             let note = note.clone();
+            let cfg = cfg.clone();
             SelectItem::new(label, note.path.to_string_lossy().into_owned())
-                .prefix(note::prefix(&note, now, &widths))
                 .tints(tints)
+                .suffix(suffix, suffix_tints)
                 .preview(Preview::Deferred(Box::new(move || {
                     let text = read_head(&note.path, PREVIEW_BYTES).unwrap_or_default();
-                    note::preview(&note, &text, now, offset)
+                    note::preview(&note, &cfg, &text, now, offset)
                 })))
         })
         .collect()
+}
+
+/// `scriv note new [NAME]` — start a note and open it.
+///
+/// No question is asked first. Being asked to name a note is being asked what
+/// it is about before writing it, and a note that has to be named before it can
+/// be started is one that does not get started; the generated name sorts, and
+/// renaming it afterwards is what the editor is already open for.
+///
+/// The file is not created here — the editor writes it, or nothing does. An
+/// abandoned note is then a note that never existed rather than an empty one in
+/// every listing from now on.
+pub fn new(ctx: &Ctx, name: Option<&str>) -> Result<()> {
+    let editor = ctx.note_editor()?;
+    let root = vault(ctx)?;
+
+    let named = match name {
+        Some(name) => with_extension(name),
+        None => note::generated_name(crate::unix_now(), ctx.utc_offset()),
+    };
+    let path = PathBuf::from(resolve(&root, ctx.home(), &named));
+
+    let dir = path.parent().unwrap_or(&root).to_path_buf();
+    let file = path
+        .file_name()
+        .map(|f| f.to_string_lossy().into_owned())
+        .unwrap_or_else(|| named.clone());
+    let file = note::free_name(&file, |candidate| dir.join(candidate).exists());
+
+    // The editor cannot write into a directory that is not there, and a name
+    // with a `/` in it is a request for one.
+    std::fs::create_dir_all(&dir).with_context(|| format!("creating {}", dir.display()))?;
+
+    let target = dir.join(file).to_string_lossy().into_owned();
+    ctx.log.info(&format!("new note at {target}"));
+    cmd::edit::launch(ctx, &editor, std::slice::from_ref(&target))
+}
+
+/// Give a name the extension a listing looks for, unless it already has one of
+/// its own. A name with no dot in it is a name; one with a dot has been spelled
+/// out and is left as typed.
+fn with_extension(name: &str) -> String {
+    let last = name.rsplit('/').next().unwrap_or(name);
+    match last.contains('.') {
+        true => name.to_string(),
+        false => format!("{name}.md"),
+    }
+}
+
+// --- searching --------------------------------------------------------------
+
+/// The most matches one search hands back.
+///
+/// A two-character query against a vault matches tens of thousands of lines,
+/// and a list nobody can reach the bottom of is not more useful than one they
+/// can. Reaching it stops ripgrep rather than reading the rest and dropping it.
+const MATCH_LIMIT: usize = 2000;
+
+/// The width a search row's `note:line` column is padded to. A fixed number
+/// rather than the widest in the batch, because rows arrive while the search is
+/// still running and there is no widest yet.
+const MATCH_COLUMN: usize = 40;
+
+/// `scriv note rg [QUERY]` — search every note as you type, and open what you
+/// pick.
+///
+/// The query goes to ripgrep rather than to the fuzzy matcher, so the list is
+/// every matching *line* in the vault rather than the notes whose names match.
+/// `tab` takes several; they become a quickfix list.
+pub fn rg(ctx: &Ctx, query: Option<&str>) -> Result<()> {
+    let root = vault(ctx)?;
+    let editor = ctx.note_editor()?;
+    if which("rg").is_none() {
+        bail!("`rg` is not on PATH — `scriv note rg` searches with ripgrep");
+    }
+
+    // A query given on the command line is where the selector opens, not a
+    // search run without one: what comes back is still chosen by hand.
+    let chosen = match select::select_many_searching(
+        searcher(root.clone()),
+        "Search notes",
+        query.unwrap_or_default(),
+        &ctx.config.selector,
+    ) {
+        Ok(chosen) => chosen,
+        Err(e) if e.is::<select::Cancelled>() => return Ok(()),
+        Err(e) => return Err(e),
+    };
+
+    let matches: Vec<note::Match> = chosen
+        .iter()
+        .filter_map(|value| note::decode_match(value, &root))
+        .collect();
+    if matches.is_empty() {
+        return Ok(());
+    }
+    open_matches(ctx, &editor, &matches)
+}
+
+/// The closure the selector calls on every keystroke: one ripgrep run per
+/// query, its rows streamed as ripgrep prints them.
+fn searcher(root: PathBuf) -> select::Search {
+    Box::new(move |query: &str| {
+        // An empty pattern matches every line of every note, which is neither
+        // an answer nor a cheap question.
+        if query.trim().is_empty() {
+            return select::Searching {
+                rows: Box::new(std::iter::empty()),
+                stop: Box::new(|| {}),
+            };
+        }
+        match Search::start(&root, query) {
+            Ok(search) => search.into_searching(),
+            // A failed spawn is an empty list: the selector is open and has
+            // nowhere to report an error to, and the next keystroke tries
+            // again.
+            Err(_) => select::Searching {
+                rows: Box::new(std::iter::empty()),
+                stop: Box::new(|| {}),
+            },
+        }
+    })
+}
+
+/// One ripgrep run, read line by line.
+///
+/// The child is held behind a mutex the reader never takes, so
+/// [`select::Searching::stop`] can kill it from another thread while this one
+/// is blocked waiting for output — which is the whole point, since the thing
+/// being waited on is exactly what has to stop.
+struct Search {
+    lines: std::io::Lines<std::io::BufReader<std::process::ChildStdout>>,
+    child: Arc<Mutex<Option<std::process::Child>>>,
+    root: PathBuf,
+    found: usize,
+}
+
+impl Search {
+    fn start(root: &Path, query: &str) -> std::io::Result<Self> {
+        let mut child = std::process::Command::new("rg")
+            .args([
+                "--line-number",
+                "--column",
+                "--no-heading",
+                "--color=never",
+                "--smart-case",
+                // A minified file or a base64 attachment in a vault is one
+                // line several megabytes long, and drawing it is the only
+                // slow thing a row can do.
+                "--max-columns=400",
+                "--glob=*.md",
+                "--glob=*.markdown",
+            ])
+            // `-e` rather than a bare positional: a query beginning with `-`
+            // is a pattern, not a flag, and the user is typing it live.
+            .arg("-e")
+            .arg(query)
+            .arg("--")
+            .arg(root)
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::piped())
+            // ripgrep's complaints about an unfinished regex arrive on every
+            // keystroke and belong nowhere: the selector owns the screen.
+            .stderr(std::process::Stdio::null())
+            .spawn()?;
+
+        let stdout = child
+            .stdout
+            .take()
+            .expect("stdout was piped, so it is there to take");
+        Ok(Self {
+            lines: std::io::BufRead::lines(std::io::BufReader::new(stdout)),
+            child: Arc::new(Mutex::new(Some(child))),
+            root: root.to_path_buf(),
+            found: 0,
+        })
+    }
+
+    fn into_searching(self) -> select::Searching {
+        let child = Arc::clone(&self.child);
+        select::Searching {
+            rows: Box::new(self),
+            stop: Box::new(move || reap(&child)),
+        }
+    }
+}
+
+impl Iterator for Search {
+    type Item = SelectItem;
+
+    fn next(&mut self) -> Option<SelectItem> {
+        loop {
+            if self.found >= MATCH_LIMIT {
+                reap(&self.child);
+                return None;
+            }
+            // A line that is not valid UTF-8 ends the read: ripgrep is
+            // searching Markdown, and the alternative is a row nobody can see
+            // the text of anyway.
+            let line = self.lines.next()?.ok()?;
+            let Some(found) = note::parse_match(&line, &self.root) else {
+                continue;
+            };
+            self.found += 1;
+            let (label, tints) = note::match_row(&found, MATCH_COLUMN);
+            let path = found.path.clone();
+            let line = found.line;
+            return Some(
+                SelectItem::new(label, note::encode_match(&found))
+                    .tints(tints)
+                    .preview(Preview::Deferred(Box::new(move || {
+                        let text = read_head(&path, PREVIEW_BYTES).unwrap_or_default();
+                        note::match_preview(
+                            &note::Match {
+                                path: path.clone(),
+                                rel: path.to_string_lossy().into_owned(),
+                                line,
+                                column: 1,
+                                text: String::new(),
+                            },
+                            &text,
+                        )
+                    }))),
+            );
+        }
+    }
+}
+
+impl Drop for Search {
+    fn drop(&mut self) {
+        reap(&self.child);
+    }
+}
+
+/// Kill the search and collect it, so a vault-wide grep abandoned mid-word
+/// leaves neither a running ripgrep nor a zombie behind. Idempotent: `stop` and
+/// the drop both call it, and the selector may do so in either order.
+fn reap(child: &Arc<Mutex<Option<std::process::Child>>>) {
+    let mut held = child.lock().unwrap_or_else(|e| e.into_inner());
+    if let Some(mut child) = held.take() {
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+}
+
+/// Open what was selected: the first match in the editor at its line, and every
+/// other one in the quickfix list behind it.
+///
+/// Quickfix is a vim idea, so this is the shape of a vim command line. An
+/// editor that is not one of that family is handed the files and nothing else —
+/// there is no portable way to say "line 41" to an arbitrary program, and
+/// inventing one per editor is a list that is never finished.
+fn open_matches(ctx: &Ctx, editor: &[String], matches: &[note::Match]) -> Result<()> {
+    let (program, args) = editor
+        .split_first()
+        .expect("an editor is resolved non-empty");
+    if !vim_family(program) {
+        let mut files: Vec<String> = Vec::new();
+        for found in matches {
+            let path = found.path.to_string_lossy().into_owned();
+            if !files.contains(&path) {
+                files.push(path);
+            }
+        }
+        ctx.log.info(&format!(
+            "{program} takes no line number; opening the files"
+        ));
+        return cmd::edit::launch(ctx, editor, &files);
+    }
+
+    let list = QuickfixFile::write(matches)?;
+    let mut command = args.to_vec();
+    command.push("-c".into());
+    command.push("set errorformat=%f:%l:%c:%m".into());
+    command.push("-c".into());
+    command.push(format!(
+        "cfile {}",
+        vim_escape(&list.path.to_string_lossy())
+    ));
+    command.push("-c".into());
+    command.push("cfirst".into());
+    // One match is a jump, not a list to walk: the window would be a pane
+    // showing the line already on screen.
+    if matches.len() > 1 {
+        command.push("-c".into());
+        command.push("copen".into());
+    }
+
+    let status = std::process::Command::new(program)
+        .args(&command)
+        .status()
+        .map_err(|e| match e.kind() {
+            std::io::ErrorKind::NotFound => anyhow::anyhow!("`{program}` was not found on PATH"),
+            _ => anyhow::Error::new(e).context(format!("running {program}")),
+        })?;
+    if !status.success() {
+        return Err(crate::Reported(status.code().unwrap_or(1)).into());
+    }
+    Ok(())
+}
+
+/// The quickfix list on disk, removed when it goes out of scope — vim reads it
+/// at startup and never looks again, so it is scriv's to clean up.
+struct QuickfixFile {
+    path: PathBuf,
+}
+
+impl QuickfixFile {
+    fn write(matches: &[note::Match]) -> Result<Self> {
+        let path = std::env::temp_dir().join(format!("scriv-quickfix-{}.txt", std::process::id()));
+        let body: String = matches
+            .iter()
+            .map(|found| format!("{}\n", note::quickfix_line(found)))
+            .collect();
+        std::fs::write(&path, body).with_context(|| format!("writing {}", path.display()))?;
+        Ok(Self { path })
+    }
+}
+
+impl Drop for QuickfixFile {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.path);
+    }
+}
+
+/// Whether `program` is a vim, and so understands a quickfix list.
+fn vim_family(program: &str) -> bool {
+    let name = Path::new(program)
+        .file_stem()
+        .map(|s| s.to_string_lossy().into_owned())
+        .unwrap_or_else(|| program.to_string());
+    matches!(
+        name.as_str(),
+        "vim" | "nvim" | "vi" | "view" | "gvim" | "mvim" | "nvim-qt"
+    )
+}
+
+/// Escape a path for a vim command line, where a space separates arguments and
+/// `%` and `#` name the current and alternate file.
+fn vim_escape(path: &str) -> String {
+    let mut out = String::with_capacity(path.len());
+    for ch in path.chars() {
+        if matches!(ch, ' ' | '\t' | '%' | '#' | '|' | '"' | '\\') {
+            out.push('\\');
+        }
+        out.push(ch);
+    }
+    out
+}
+
+/// Whether `program` resolves on `PATH`.
+fn which(program: &str) -> Option<PathBuf> {
+    std::env::var_os("PATH").and_then(|path| {
+        std::env::split_paths(&path)
+            .map(|dir| dir.join(program))
+            .find(|candidate| candidate.exists())
+    })
 }
 
 /// The `config check` row for the vault: where it is, and how much is in it.
@@ -286,7 +654,11 @@ mod tests {
 
         assert_eq!(note.rel, "work/meetings/standup.md");
         assert_eq!(note.title(), "standup");
-        assert_eq!(note.folder(), "work/meetings");
+        assert_eq!(note.dir, "work");
+        assert_eq!(
+            note.folder(&crate::config::NoteConfig::default()),
+            "meetings"
+        );
     }
 
     #[test]
@@ -330,6 +702,38 @@ mod tests {
         let note = read_note(&path, dir.path(), utc()).unwrap();
 
         assert!(note.created <= note.modified, "{note:?}");
+    }
+
+    #[test]
+    fn a_name_gains_the_extension_a_listing_looks_for() {
+        assert_eq!(with_extension("standup"), "standup.md");
+        assert_eq!(with_extension("work/standup"), "work/standup.md");
+        // Spelled out already, and left as typed.
+        assert_eq!(with_extension("standup.md"), "standup.md");
+        assert_eq!(with_extension("notes.v2.txt"), "notes.v2.txt");
+        // The dot is in a directory, not in the name.
+        assert_eq!(with_extension("v1.2/standup"), "v1.2/standup.md");
+    }
+
+    /// Only a vim has a quickfix list. Anything else is handed the files.
+    #[test]
+    fn only_a_vim_is_offered_a_quickfix_list() {
+        for editor in ["nvim", "vim", "/usr/bin/vi", "/opt/homebrew/bin/nvim"] {
+            assert!(vim_family(editor), "{editor}");
+        }
+        for editor in ["glow", "code", "hx", "emacs", "bat"] {
+            assert!(!vim_family(editor), "{editor}");
+        }
+    }
+
+    /// A space separates arguments on a vim command line, and `%` and `#` name
+    /// the current and alternate file — so a temp path holding one would open
+    /// something else entirely.
+    #[test]
+    fn a_path_handed_to_vim_is_escaped() {
+        assert_eq!(vim_escape("/tmp/a b.txt"), r"/tmp/a\ b.txt");
+        assert_eq!(vim_escape("/tmp/100%.txt"), r"/tmp/100\%.txt");
+        assert_eq!(vim_escape("/tmp/plain.txt"), "/tmp/plain.txt");
     }
 
     #[test]

--- a/src/cmd/repo.rs
+++ b/src/cmd/repo.rs
@@ -8,7 +8,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 
 use anyhow::{Context, Result, bail};
 
-use crate::config::{Labels, RepoDisplay};
+use crate::config::{RepoDisplay, label_colors};
 use crate::gh::{self, Repo};
 use crate::path::{display_path, expand_home_dir, relative_label};
 use crate::repo::FoundRepo;
@@ -72,54 +72,6 @@ pub fn ls(ctx: &Ctx, absolute: bool) -> Result<()> {
     }
     out.finish()?;
     Ok(())
-}
-
-/// ANSI 256-colour indices used to tint labels, in assignment order.
-/// Standard hues (cyan, green, yellow, magenta, blue, red) so they read well and
-/// follow the terminal theme; cycles if there are more labels than colours.
-const LABEL_COLORS: &[u8] = &[6, 2, 3, 5, 4, 1];
-
-/// Labels whose colour is fixed by name rather than by config order, so the hue
-/// means the same thing in every checkout. Everything else takes the next
-/// unused hue, in config order.
-const NAMED_LABEL_COLORS: &[(&str, u8)] = &[("work", 6), ("personal", 2)];
-
-/// The fixed colour for `label`, if it is one of the conventional names.
-fn named_color(label: &str) -> Option<u8> {
-    NAMED_LABEL_COLORS
-        .iter()
-        .find(|(name, _)| name.eq_ignore_ascii_case(label))
-        .map(|&(_, color)| color)
-}
-
-/// Map each configured label to a colour.
-/// [`UNLABELLED`](crate::config::UNLABELLED) is deliberately absent: it is not a
-/// label competing for a hue, and stays the terminal's default foreground.
-fn label_colors(labels: &Labels) -> std::collections::HashMap<&str, u8> {
-    // Hues spoken for by a named label actually present, so an unnamed label
-    // never collides with `work`'s cyan.
-    let taken: Vec<u8> = labels.keys().filter_map(|l| named_color(l)).collect();
-    let mut free: Vec<u8> = LABEL_COLORS
-        .iter()
-        .copied()
-        .filter(|c| !taken.contains(c))
-        .collect();
-    if free.is_empty() {
-        free = LABEL_COLORS.to_vec();
-    }
-
-    let mut next = 0;
-    labels
-        .keys()
-        .map(|label| {
-            let color = named_color(label).unwrap_or_else(|| {
-                let color = free[next % free.len()];
-                next += 1;
-                color
-            });
-            (label.as_str(), color)
-        })
-        .collect()
 }
 
 /// The selector rows for the discovered repositories: each prefixed with its
@@ -569,6 +521,7 @@ fn finish(ctx: &Ctx, root: &Path, chosen: Vec<String>) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::Labels;
 
     fn repos() -> Vec<Repo> {
         gh::parse_repos(

--- a/src/config.rs
+++ b/src/config.rs
@@ -113,6 +113,55 @@ impl RepoConfig {
     }
 }
 
+/// ANSI 256-colour indices used to tint labels, in assignment order.
+/// Standard hues (cyan, green, yellow, magenta, blue, red) so they read well and
+/// follow the terminal theme; cycles if there are more labels than colours.
+const LABEL_COLORS: &[u8] = &[6, 2, 3, 5, 4, 1];
+
+/// Labels whose colour is fixed by name rather than by config order, so the hue
+/// means the same thing in every checkout — and in every group. A repository
+/// owner labelled `work` and a notes directory labelled `work` are the same
+/// word about the same things, and reading as the same colour is the point.
+const NAMED_LABEL_COLORS: &[(&str, u8)] = &[("work", 6), ("personal", 2)];
+
+/// The fixed colour for `label`, if it is one of the conventional names.
+fn named_color(label: &str) -> Option<u8> {
+    NAMED_LABEL_COLORS
+        .iter()
+        .find(|(name, _)| name.eq_ignore_ascii_case(label))
+        .map(|&(_, color)| color)
+}
+
+/// Map each configured label to a colour.
+/// [`UNLABELLED`] is deliberately absent: it is not a label competing for a
+/// hue, and stays the terminal's default foreground.
+pub fn label_colors(labels: &Labels) -> std::collections::HashMap<&str, u8> {
+    // Hues spoken for by a named label actually present, so an unnamed label
+    // never collides with `work`'s cyan.
+    let taken: Vec<u8> = labels.keys().filter_map(|l| named_color(l)).collect();
+    let mut free: Vec<u8> = LABEL_COLORS
+        .iter()
+        .copied()
+        .filter(|c| !taken.contains(c))
+        .collect();
+    if free.is_empty() {
+        free = LABEL_COLORS.to_vec();
+    }
+
+    let mut next = 0;
+    labels
+        .keys()
+        .map(|label| {
+            let color = named_color(label).unwrap_or_else(|| {
+                let color = free[next % free.len()];
+                next += 1;
+                color
+            });
+            (label.as_str(), color)
+        })
+        .collect()
+}
+
 /// `[worktree]` — where `scriv worktree add` puts a new working tree.
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 #[serde(default)]
@@ -145,6 +194,17 @@ pub struct NoteConfig {
     /// The directory the notes live in — an Obsidian vault, or any tree of
     /// Markdown files. Unset, `scriv note` has nowhere to look.
     pub root: Option<String>,
+    /// Labels for the directories directly below [`Self::root`], one label to
+    /// many directories, so a vault split across five of them can be read as
+    /// the two or three kinds of note it actually holds.
+    ///
+    /// The same shape and the same colours as `[repo] labels`, which name
+    /// owners rather than directories. A directory with no label still shows
+    /// up — just uncoloured — and so do notes sitting at the root itself.
+    ///
+    /// Written as an inline table — `labels = { work = ["projects"] }` — for
+    /// the reason `[repo] labels` is.
+    pub labels: Labels,
     /// What `note edit` launches, split on whitespace like `$EDITOR`. Unset, it
     /// is `$VISUAL` then `$EDITOR`.
     ///
@@ -152,6 +212,23 @@ pub struct NoteConfig {
     /// is as often a Markdown reader as it is the editor the rest of scriv
     /// hands a file to.
     pub editor: Option<String>,
+}
+
+impl NoteConfig {
+    /// The label the directory `dir` carries, or `None` when it has none.
+    /// Matched case-insensitively, as a directory name is on Darwin.
+    pub fn label_of(&self, dir: &str) -> Option<&str> {
+        self.labels
+            .iter()
+            .find(|(_, dirs)| dirs.iter().any(|d| d.eq_ignore_ascii_case(dir)))
+            .map(|(label, _)| label.as_str())
+    }
+
+    /// The hue `label` takes, by the same assignment `[repo] labels` uses — so
+    /// `work` is one colour across both groups.
+    pub fn color_of(&self, label: &str) -> Option<u8> {
+        label_colors(&self.labels).get(label).copied()
+    }
 }
 
 /// `[history]` — which shell history `scriv history` searches.

--- a/src/main.rs
+++ b/src/main.rs
@@ -122,13 +122,17 @@ enum Command {
     /// The set is every Markdown file under `[note] root` — an Obsidian vault,
     /// or any tree of notes — most recently modified first.
     ///
-    /// A row is what the note calls itself, the folder it is filed under and
-    /// its tags, behind two dim columns: how long ago it was modified, then how
-    /// long ago it was created. Both are spelled out in the preview pane, which
-    /// is drawn by scriv rather than by `bat`.
+    /// A row leads with what the note calls itself, then says what is true of
+    /// it in a column each: the label its directory carries — or the directory
+    /// itself, where it carries none — the folder below that, and its tags.
+    /// Behind those, and never searched, come how many of its tasks are still
+    /// open and how long ago it was modified and created.
     ///
     /// Titles, tags and creation dates come from a note's YAML front matter and
     /// from nowhere else — inline `#tags` in the body are not indexed.
+    ///
+    /// `[note] labels` names the directories directly below the root, one label
+    /// to many directories, the way `[repo] labels` names owners.
     #[command(visible_alias = "n")]
     Note {
         #[command(subcommand)]
@@ -387,6 +391,36 @@ enum NoteCmd {
     },
     /// Fuzzy-select a note and print its absolute path
     Sel,
+    /// Start a note and open it straight away
+    ///
+    /// No question is asked first: with no NAME the note is called after the
+    /// date and time, to the minute, and renaming it is what the editor is
+    /// already open for. A NAME with a `/` in it names a directory below the
+    /// vault, which is created if it is not there, and one with no `.` in it
+    /// gains `.md`.
+    ///
+    /// The file itself is left for the editor to write, so a note started and
+    /// abandoned is one that never existed rather than an empty one in every
+    /// listing after it.
+    New {
+        /// What to call it; omit for the date and time
+        #[arg(value_name = "NAME")]
+        name: Option<String>,
+    },
+    /// Search inside every note, as you type
+    ///
+    /// The query goes to `ripgrep` rather than to the fuzzy matcher, so the
+    /// list is every matching *line* in the vault and it is rebuilt on each
+    /// keystroke. `ctrl-q` switches to filtering what came back.
+    ///
+    /// `tab` takes several. What you pick opens at its line, and anything else
+    /// you picked lands in the quickfix list behind it — which needs a vim; any
+    /// other editor is handed the files and no line numbers.
+    Rg {
+        /// Text to open the search with
+        #[arg(value_name = "QUERY", allow_hyphen_values = true)]
+        query: Option<String>,
+    },
     /// Open notes; omit the names to select them
     ///
     /// `tab` selects several and they open together. A name is a path below the
@@ -776,6 +810,8 @@ fn run(cli: Cli) -> anyhow::Result<()> {
             } => cmd::note::ls(&ctx, absolute_paths, status),
             NoteCmd::Sel => cmd::note::sel(&ctx),
             NoteCmd::Edit { notes } => cmd::note::edit(&ctx, &notes),
+            NoteCmd::New { name } => cmd::note::new(&ctx, name.as_deref()),
+            NoteCmd::Rg { query } => cmd::note::rg(&ctx, query.as_deref()),
         },
         Command::Branch { command } => match command {
             BranchCmd::Ls { status, scope } => {

--- a/src/note.rs
+++ b/src/note.rs
@@ -25,6 +25,13 @@ use crate::select::Tint;
 /// skim's match highlighting has to be the brightest thing on the row.
 const FOLDER_COLOR: u8 = 4;
 const TAG_COLOR: u8 = 5;
+const OPEN_COLOR: u8 = 3;
+
+/// The task column's two glyphs: how many are left, or that none are. Shapes
+/// rather than colour alone, so the column still says something where the
+/// terminal's palette does not.
+const OPEN_TASK: &str = "\u{2610}";
+const ALL_DONE: &str = "\u{2713}";
 
 /// What a note's front matter said about it.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -48,11 +55,90 @@ pub struct Note {
     /// Path below the vault root, extension and all. The name a note is known
     /// by on the command line.
     pub rel: String,
+    /// The directory directly below the root that the note is filed under, or
+    /// empty for a note at the root itself. What `[note] labels` labels.
+    pub dir: String,
     /// Last modified, in Unix seconds.
     pub modified: i64,
     /// Created, in Unix seconds. See [`created`].
     pub created: i64,
     pub front: Front,
+    pub tasks: Tasks,
+}
+
+/// The checkboxes in a note's body: how much of what it asked for is done.
+///
+/// The one thing a Markdown note says about itself that is neither its name nor
+/// its metadata, and the one worth a column: a vault is full of notes that are
+/// finished and notes that are still owed something, and nothing else on the
+/// row tells them apart.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct Tasks {
+    pub open: usize,
+    pub done: usize,
+}
+
+impl Tasks {
+    pub fn total(self) -> usize {
+        self.open + self.done
+    }
+
+    /// The column: how many are left, or a tick once none are.
+    fn column(self) -> String {
+        match (self.open, self.done) {
+            (0, 0) => String::new(),
+            (0, _) => ALL_DONE.to_string(),
+            (open, _) => format!("{open}{OPEN_TASK}"),
+        }
+    }
+
+    fn color(self) -> u8 {
+        if self.open == 0 {
+            DONE_COLOR
+        } else {
+            OPEN_COLOR
+        }
+    }
+}
+
+/// Count the checkboxes in a note's body. A task is a list item whose marker is
+/// followed by `[ ]` or `[x]`, which is the form every Markdown renderer that
+/// draws a checkbox agrees on.
+pub fn count_tasks(body: &str) -> Tasks {
+    let mut tasks = Tasks::default();
+    let mut fenced = false;
+    for line in body.lines() {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with("```") || trimmed.starts_with("~~~") {
+            fenced = !fenced;
+            continue;
+        }
+        // A checkbox inside a fence is an example of one, not one.
+        if fenced {
+            continue;
+        }
+        let Some((_, after)) = bullet(trimmed) else {
+            continue;
+        };
+        match ticked(after) {
+            Some(true) => tasks.done += 1,
+            Some(false) => tasks.open += 1,
+            None => {}
+        }
+    }
+    tasks
+}
+
+/// Whether the text opens with a ticked box, an empty one, or neither.
+fn ticked(text: &str) -> Option<bool> {
+    let mut chars = text.strip_prefix('[')?.chars();
+    let mark = chars.next()?;
+    chars.next().filter(|c| *c == ']')?;
+    match mark {
+        ' ' => Some(false),
+        'x' | 'X' => Some(true),
+        _ => None,
+    }
 }
 
 impl Note {
@@ -66,11 +152,40 @@ impl Note {
         }
     }
 
-    /// The directory the note sits in, below the vault root — empty for a note
-    /// at the root itself.
-    pub fn folder(&self) -> &str {
-        match self.rel.rfind('/') {
-            Some(at) => &self.rel[..at],
+    /// The group column: the label [`Note::dir`] carries, or the directory's
+    /// own name when it carries none.
+    ///
+    /// Unlike `repo`, which writes [`UNLABELLED`](crate::config::UNLABELLED)
+    /// for an owner with no label, an unlabelled directory names itself here.
+    /// A repository row still carries its owner in the path beside the label
+    /// column; a note row does not, and a vault of five directories with two of
+    /// them labelled would otherwise show three rows that say only `-`.
+    pub fn group<'a>(&'a self, labels: &'a crate::config::NoteConfig) -> &'a str {
+        labels.label_of(&self.dir).unwrap_or(&self.dir)
+    }
+
+    /// Whether the group column is a configured label rather than a bare
+    /// directory name — which is what decides whether it takes a colour.
+    pub fn labelled(&self, labels: &crate::config::NoteConfig) -> bool {
+        labels.label_of(&self.dir).is_some()
+    }
+
+    /// The directories the note is filed under that the group column has not
+    /// already named.
+    ///
+    /// Which ones those are depends on the group: a *label* is a word of the
+    /// user's own — `work` says nothing about which directory — so the whole
+    /// path below the root is still news. An unlabelled group is the directory
+    /// itself, already drawn one column to the left, so only what sits below it
+    /// is. Between them the two columns spell out the note's path exactly once.
+    pub fn folder<'a>(&'a self, cfg: &'a crate::config::NoteConfig) -> &'a str {
+        let below = match self.labelled(cfg) {
+            true => &self.rel[..],
+            // The separator too, which is why this is not `dir.len()`.
+            false => &self.rel[(self.dir.len() + 1).min(self.rel.len())..],
+        };
+        match below.rfind('/') {
+            Some(at) => &below[..at],
             None => "",
         }
     }
@@ -83,6 +198,15 @@ impl Note {
             .map(|tag| format!("#{tag}"))
             .collect::<Vec<_>>()
             .join(" ")
+    }
+}
+
+/// The directory directly below `root` that `rel` is filed under, or empty for
+/// a path at the root itself.
+pub fn top_dir(rel: &str) -> &str {
+    match rel.find('/') {
+        Some(at) => &rel[..at],
+        None => "",
     }
 }
 
@@ -342,99 +466,171 @@ fn local(when: i64, offset: time::UtcOffset) -> Option<time::OffsetDateTime> {
 /// list so the columns line up.
 ///
 /// Counted in characters, not bytes: `{:<width$}` pads by character count, so a
-/// byte length would over-pad a title with an accent in it.
+/// byte length would over-pad a title with an accent in it. A column measuring
+/// zero is one nothing in this vault fills, and is left out of the row rather
+/// than padded — a vault with no labels and no tags spends its width on names.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct Widths {
+    pub title: usize,
+    pub group: usize,
+    pub folder: usize,
+    pub tags: usize,
+    pub tasks: usize,
     pub modified: usize,
     pub created: usize,
-    pub title: usize,
-    pub folder: usize,
     pub rel: usize,
-    pub tags: usize,
 }
 
 impl Widths {
-    pub fn of(notes: &[Note], now: i64) -> Self {
+    pub fn of(notes: &[Note], cfg: &crate::config::NoteConfig, now: i64) -> Self {
         let widest = |f: &dyn Fn(&Note) -> usize| notes.iter().map(f).max().unwrap_or(0);
         Self {
+            title: widest(&|n| n.title().chars().count()),
+            group: widest(&|n| n.group(cfg).chars().count()),
+            folder: widest(&|n| n.folder(cfg).chars().count()),
+            tags: widest(&|n| n.tag_column().chars().count()),
+            tasks: widest(&|n| n.tasks.column().chars().count()),
             modified: widest(&|n| age(now, n.modified).chars().count()),
             created: widest(&|n| age(now, n.created).chars().count()),
-            title: widest(&|n| n.title().chars().count()),
-            folder: widest(&|n| n.folder().chars().count()),
             rel: widest(&|n| n.rel.chars().count()),
-            tags: widest(&|n| n.tag_column().chars().count()),
         }
     }
 }
 
-/// The dim column ahead of a selector row: how long ago the note was modified,
-/// then how long ago it was created.
+/// One selector row: what the note calls itself first, then what is true of it.
 ///
-/// A [`crate::select::SelectItem::prefix`] rather than part of the label, so it
-/// is shown without being searched — matched, a query of `3` would rank every
-/// note that is three days old above the one being looked for. Modified comes
-/// first because it is the order the list is in.
-pub fn prefix(note: &Note, now: i64, widths: &Widths) -> String {
-    format!(
-        "{modified:>mw$} {created:>cw$}  ",
-        modified = age(now, note.modified),
-        mw = widths.modified,
-        created = age(now, note.created),
-        cw = widths.created,
-    )
-}
-
-/// One selector row: what the note calls itself, the folder it is filed under,
-/// and its tags.
+/// The name leads because it is what is being looked for and what the query
+/// matches; everything after it is an attribute, in a column of its own, in a
+/// colour that says which attribute it is — the group cyan or green where it is
+/// a configured label and grey where it is a bare directory name, the folder
+/// blue as a path is everywhere, the tags magenta.
 ///
 /// The row and its colours are built together because a tint is a character
 /// range into the row, and counting those ranges out a second time is how they
 /// drift.
-pub fn row(note: &Note, widths: &Widths) -> (String, Vec<Tint>) {
+///
+/// Not padded to the full width: what follows on the row is
+/// [`suffix`], and a row's trailing columns are only worth aligning when
+/// something is drawn in them.
+pub fn row(note: &Note, cfg: &crate::config::NoteConfig, widths: &Widths) -> (String, Vec<Tint>) {
     let mut row = String::new();
     let mut tints = Vec::new();
-
-    push_column(&mut row, note.title(), widths.title);
-
-    if widths.folder > 0 {
-        row.push_str("  ");
+    let mut column = |row: &mut String, text: &str, width: usize, color: Option<u8>| {
+        if width == 0 {
+            return;
+        }
+        if !row.is_empty() {
+            row.push_str(COLUMN_GAP);
+        }
         let at = row.chars().count();
-        push_column(&mut row, note.folder(), widths.folder);
-        tints.push(Tint {
-            range: at..at + note.folder().chars().count(),
-            color: FOLDER_COLOR,
-        });
-    }
+        push_column(row, text, width);
+        if let Some(color) = color.filter(|_| !text.is_empty()) {
+            tints.push(Tint {
+                range: at..at + text.chars().count(),
+                color,
+            });
+        }
+    };
 
-    let tags = note.tag_column();
-    if !tags.is_empty() {
-        row.push_str("  ");
-        let at = row.chars().count();
-        row.push_str(&tags);
-        tints.push(Tint {
-            range: at..row.chars().count(),
-            color: TAG_COLOR,
-        });
-    }
+    column(&mut row, note.title(), widths.title, None);
+    // A bare directory name is grey and a label is its own colour, so the
+    // column says whether it was configured as well as what it holds.
+    let group_color = note
+        .labelled(cfg)
+        .then(|| cfg.color_of(note.group(cfg)))
+        .flatten()
+        .or(Some(UNLABELLED_COLOR));
+    column(&mut row, note.group(cfg), widths.group, group_color);
+    column(
+        &mut row,
+        note.folder(cfg),
+        widths.folder,
+        Some(FOLDER_COLOR),
+    );
+    column(&mut row, &note.tag_column(), widths.tags, Some(TAG_COLOR));
 
-    (row.trim_end().to_string(), tints)
+    // Deliberately not trimmed: [`suffix`] is drawn straight after this, and a
+    // row whose columns were trimmed away would start its dates wherever its
+    // own text happened to stop.
+    (row, tints)
 }
 
-/// One `note ls --status` row: the note's name, its tags, and both dates.
+/// The columns drawn after the label and not matched against: how much of the
+/// note is still owed, then how long ago it was modified and created.
 ///
-/// The name comes first, so the plain listing is a prefix of this one. Modified
+/// Behind the label rather than ahead of it, because the name is what a note
+/// list is read down. Outside the label because none of it is what anybody
+/// searches for — matched, a query of `3` would rank every note that is three
+/// days old above the one being looked for.
+///
+/// Every row's is the same width, so the columns line up however narrow the
+/// name column turned out.
+pub fn suffix(note: &Note, now: i64, widths: &Widths) -> (String, Vec<Tint>) {
+    let mut suffix = String::new();
+    let mut tints = Vec::new();
+
+    if widths.tasks > 0 {
+        suffix.push_str(COLUMN_GAP);
+        let tasks = note.tasks.column();
+        let at = suffix.chars().count() + widths.tasks - tasks.chars().count();
+        // Right-aligned: the glyph is the fixed part and the count grows to
+        // the left of it.
+        for _ in tasks.chars().count()..widths.tasks {
+            suffix.push(' ');
+        }
+        suffix.push_str(&tasks);
+        if !tasks.is_empty() {
+            tints.push(Tint {
+                range: at..suffix.chars().count(),
+                color: note.tasks.color(),
+            });
+        }
+    }
+
+    suffix.push_str(COLUMN_GAP);
+    push_right(&mut suffix, &age(now, note.modified), widths.modified);
+    suffix.push(' ');
+    push_right(&mut suffix, &age(now, note.created), widths.created);
+
+    (suffix, tints)
+}
+
+/// Between two columns. Two spaces, everywhere, so a row reads as columns
+/// rather than as a sentence.
+const COLUMN_GAP: &str = "  ";
+
+/// The colour of a group column holding a bare directory name: the terminal's
+/// own grey, as [`crate::select::SelectItem::prefix`] uses, since an unlabelled
+/// directory is context rather than a statement.
+const UNLABELLED_COLOR: u8 = 8;
+
+/// One `note ls --status` row: the note's name, its group, its tags, how many
+/// tasks are open, and both dates.
+///
+/// The path comes first, so the plain listing is a prefix of this one. Modified
 /// carries a time of day and created does not: a created date may have come
 /// from front matter, which names a day.
-pub fn status_row(note: &Note, widths: &Widths, offset: time::UtcOffset) -> String {
+pub fn status_row(
+    note: &Note,
+    cfg: &crate::config::NoteConfig,
+    widths: &Widths,
+    offset: time::UtcOffset,
+) -> String {
     let mut row = String::new();
     push_column(&mut row, &note.rel, widths.rel);
-    if widths.tags > 0 {
-        row.push_str("  ");
-        push_column(&mut row, &note.tag_column(), widths.tags);
+    for (text, width) in [
+        (note.group(cfg).to_string(), widths.group),
+        (note.tag_column(), widths.tags),
+        (note.tasks.column(), widths.tasks),
+    ] {
+        if width > 0 {
+            row.push_str(COLUMN_GAP);
+            push_column(&mut row, &text, width);
+        }
     }
-    row.push_str("  ");
+    row.push_str(COLUMN_GAP);
     row.push_str(&timestamp(note.modified, offset));
-    row.push_str("  ");
+    row.push_str(COLUMN_GAP);
     row.push_str(&date(note.created, offset));
     row.trim_end().to_string()
 }
@@ -445,6 +641,14 @@ fn push_column(row: &mut String, text: &str, width: usize) {
     for _ in text.chars().count()..width {
         row.push(' ');
     }
+}
+
+/// Append `text` padded to `width` characters on its left.
+fn push_right(row: &mut String, text: &str, width: usize) {
+    for _ in text.chars().count()..width {
+        row.push(' ');
+    }
+    row.push_str(text);
 }
 
 /// Order a vault: most recently modified first, then by path so notes written
@@ -503,7 +707,13 @@ const PREVIEW_LINES: usize = 200;
 /// fences are what a note is made of at a glance; `**bold**` and its friends
 /// are left as the author wrote them, since a pane that hides the markup it
 /// cannot render is lying about the file.
-pub fn preview(note: &Note, text: &str, now: i64, offset: time::UtcOffset) -> String {
+pub fn preview(
+    note: &Note,
+    cfg: &crate::config::NoteConfig,
+    text: &str,
+    now: i64,
+    offset: time::UtcOffset,
+) -> String {
     let mut out = String::new();
 
     out.push_str(&bold(&crate::term::one_row(note.title())));
@@ -511,9 +721,29 @@ pub fn preview(note: &Note, text: &str, now: i64, offset: time::UtcOffset) -> St
     out.push_str(&paint(&crate::term::one_row(&note.rel), DIM));
     out.push('\n');
 
+    let group = note.group(cfg);
+    let mut facts = Vec::new();
+    if !group.is_empty() {
+        let color = match note.labelled(cfg) {
+            true => cfg.color_of(group).unwrap_or(UNLABELLED_COLOR),
+            false => UNLABELLED_COLOR,
+        };
+        facts.push(paint(&crate::term::one_row(group), color));
+    }
     let tags = note.tag_column();
     if !tags.is_empty() {
-        out.push_str(&paint(&crate::term::one_row(&tags), TAG_COLOR));
+        facts.push(paint(&crate::term::one_row(&tags), TAG_COLOR));
+    }
+    // Spelled out rather than left as the row's glyph and a number, which is
+    // the pane's job: it has the width the column did not.
+    if note.tasks.total() > 0 {
+        facts.push(paint(
+            &format!("{} of {} done", note.tasks.done, note.tasks.total()),
+            note.tasks.color(),
+        ));
+    }
+    if !facts.is_empty() {
+        out.push_str(&facts.join(&paint("  \u{b7}  ", DIM)));
         out.push('\n');
     }
 
@@ -698,10 +928,23 @@ mod tests {
     fn note(rel: &str, front: Front) -> Note {
         Note {
             path: PathBuf::from("/vault").join(rel),
+            dir: top_dir(rel).to_string(),
             rel: rel.to_string(),
             modified: 0,
             created: 0,
             front,
+            tasks: Tasks::default(),
+        }
+    }
+
+    /// A vault where `work` is labelled and `scratch` is not.
+    fn config() -> crate::config::NoteConfig {
+        let mut labels = crate::config::Labels::new();
+        labels.insert("work".to_string(), vec!["work".to_string()]);
+        crate::config::NoteConfig {
+            root: Some("/vault".into()),
+            labels,
+            editor: None,
         }
     }
 
@@ -858,10 +1101,15 @@ mod tests {
         );
     }
 
+    /// The folder is what sits between the group's directory and the note, so
+    /// a row never writes the group twice.
     #[test]
     fn a_note_at_the_vault_root_is_filed_under_nothing() {
-        assert_eq!(note("inbox.md", Front::default()).folder(), "");
-        assert_eq!(note("a/b/c.md", Front::default()).folder(), "a/b");
+        let bare = crate::config::NoteConfig::default();
+        assert_eq!(note("inbox.md", Front::default()).folder(&bare), "");
+        assert_eq!(note("a/c.md", Front::default()).folder(&bare), "");
+        assert_eq!(note("a/b/c.md", Front::default()).folder(&bare), "b");
+        assert_eq!(note("a/b/c/d.md", Front::default()).folder(&bare), "b/c");
     }
 
     /// The filesystem dates a synced or freshly cloned vault the day it
@@ -917,14 +1165,20 @@ mod tests {
         vec![
             Note {
                 modified: 3 * DAY,
-                created: 3 * DAY,
+                created: 400 * DAY,
+                tasks: Tasks { open: 2, done: 5 },
                 ..note(
                     "work/meetings/standup.md",
                     Front {
-                        tags: vec!["work".into()],
+                        tags: vec!["daily".into()],
                         ..Front::default()
                     },
                 )
+            },
+            Note {
+                modified: 0,
+                created: 0,
+                ..note("scratch/idea.md", Front::default())
             },
             Note {
                 modified: 0,
@@ -934,45 +1188,73 @@ mod tests {
         ]
     }
 
-    fn labels(notes: &[Note]) -> Vec<String> {
-        let widths = Widths::of(notes, 0);
-        notes.iter().map(|n| row(n, &widths).0).collect()
+    fn rows(notes: &[Note]) -> Vec<String> {
+        let cfg = config();
+        let widths = Widths::of(notes, &cfg, 0);
+        notes.iter().map(|n| row(n, &cfg, &widths).0).collect()
     }
 
+    /// The name is what the eye runs down and what the query matches, so it
+    /// leads; everything after it is an attribute in a column of its own.
     #[test]
-    fn a_row_carries_the_title_the_folder_and_the_tags() {
-        assert_eq!(
-            labels(&vault())[0],
-            "standup  work/meetings  #work",
-            "{:?}",
-            labels(&vault())
-        );
+    fn a_row_leads_with_the_note_name() {
+        for row in rows(&vault()) {
+            let first = row.split_whitespace().next().unwrap_or_default();
+            assert!(
+                ["standup", "idea", "inbox"].contains(&first),
+                "a row does not open with its name: {row:?}"
+            );
+        }
     }
 
+    /// A labelled directory shows its label; an unlabelled one shows itself,
+    /// rather than the `-` a repository row would carry. A vault of five
+    /// directories with two labelled would otherwise show three rows saying
+    /// nothing.
     #[test]
-    fn a_row_without_tags_ends_at_its_folder() {
-        assert_eq!(labels(&vault())[1], "inbox");
+    fn the_group_column_is_the_label_or_the_directory_that_has_none() {
+        let cfg = config();
+        let notes = vault();
+        assert_eq!(notes[0].group(&cfg), "work");
+        assert!(notes[0].labelled(&cfg));
+        assert_eq!(notes[1].group(&cfg), "scratch");
+        assert!(!notes[1].labelled(&cfg));
+        assert_eq!(notes[2].group(&cfg), "");
     }
 
-    /// The columns are what make a listing scannable; a title one character
-    /// longer must not shift the folder on every other row.
+    /// Between them, the group and folder columns spell out a note's path
+    /// exactly once: a label names no directory, so the whole path is still
+    /// news; a bare directory name is already drawn, so only what is below it
+    /// is.
+    #[test]
+    fn the_group_and_folder_columns_spell_the_path_out_once() {
+        let cfg = config();
+        let notes = vault();
+        // `work` is a label, so the directory it labels is still worth drawing.
+        assert_eq!(notes[0].folder(&cfg), "work/meetings");
+        // `scratch` is the directory itself, one column to the left already.
+        assert_eq!(notes[1].folder(&cfg), "");
+        assert_eq!(notes[2].folder(&cfg), "");
+    }
+
+    /// Columns are the whole point: a name one character longer must not shift
+    /// the group on every other row.
     #[test]
     fn the_columns_line_up_across_the_whole_list() {
+        let cfg = config();
         let notes = vault();
-        let widths = Widths::of(&notes, 0);
-        let at = |label: &str| {
-            label
-                .find("work/meetings")
-                .or_else(|| label.find("  "))
-                .unwrap()
-        };
-        let rows: Vec<String> = notes.iter().map(|n| row(n, &widths).0).collect();
-        assert_eq!(
-            rows[0].find("work/meetings"),
-            Some(widths.title + 2),
-            "{rows:?}"
-        );
-        assert!(at(&rows[0]) >= widths.title, "{rows:?}");
+        let widths = Widths::of(&notes, &cfg, 0);
+        for (row, note) in rows(&notes).iter().zip(&notes) {
+            let group = note.group(&cfg);
+            if group.is_empty() {
+                continue;
+            }
+            let after_name: String = row.chars().skip(widths.title + COLUMN_GAP.len()).collect();
+            assert!(
+                after_name.starts_with(group),
+                "the group column moved: {row:?}"
+            );
+        }
     }
 
     #[test]
@@ -981,15 +1263,31 @@ mod tests {
             note("café.md", Front::default()),
             note("a.md", Front::default()),
         ];
-        let widths = Widths::of(&notes, 0);
+        let widths = Widths::of(&notes, &config(), 0);
         assert_eq!(widths.title, "café".chars().count());
     }
 
+    /// A column nothing in this vault fills is left out rather than padded, so
+    /// a vault with no labels and no tags spends its width on names.
     #[test]
-    fn a_row_tints_its_folder_and_its_tags_and_leaves_the_title_alone() {
+    fn an_empty_column_is_not_drawn_at_all() {
+        let notes = vec![
+            note("a.md", Front::default()),
+            note("b.md", Front::default()),
+        ];
+        let cfg = crate::config::NoteConfig::default();
+        let widths = Widths::of(&notes, &cfg, 0);
+        assert_eq!(widths.group, 0);
+        assert_eq!(widths.tags, 0);
+        assert_eq!(row(&notes[0], &cfg, &widths).0, "a");
+    }
+
+    #[test]
+    fn a_row_tints_each_attribute_and_leaves_the_name_alone() {
+        let cfg = config();
         let notes = vault();
-        let widths = Widths::of(&notes, 0);
-        let (label, tints) = row(&notes[0], &widths);
+        let widths = Widths::of(&notes, &cfg, 0);
+        let (label, tints) = row(&notes[0], &cfg, &widths);
         let text = |tint: &Tint| -> String {
             label
                 .chars()
@@ -997,43 +1295,91 @@ mod tests {
                 .take(tint.range.len())
                 .collect()
         };
-        assert_eq!(tints.len(), 2, "{label:?}");
-        assert_eq!(text(&tints[0]), "work/meetings");
-        assert_eq!(tints[0].color, FOLDER_COLOR);
-        assert_eq!(text(&tints[1]), "#work");
-        assert_eq!(tints[1].color, TAG_COLOR);
+        let drawn: Vec<(String, u8)> = tints.iter().map(|t| (text(t), t.color)).collect();
+        assert_eq!(drawn[0].0, "work");
+        assert_eq!(drawn[1], ("work/meetings".to_string(), FOLDER_COLOR));
+        assert_eq!(drawn[2], ("#daily".to_string(), TAG_COLOR));
+        assert!(
+            !tints.iter().any(|t| t.range.start == 0),
+            "the name is tinted, and skim's match highlight has to win: {drawn:?}"
+        );
     }
 
-    /// The prefix is what holds the two age columns, and it is not matched
-    /// against — a query of `3` must not rank every three-day-old note first.
+    /// An unlabelled directory is context rather than a statement, so it is
+    /// grey where a configured label takes its own hue.
     #[test]
-    fn the_prefix_holds_both_ages_and_the_label_holds_neither() {
+    fn a_bare_directory_name_is_not_coloured_like_a_label() {
+        let cfg = config();
         let notes = vault();
-        let widths = Widths::of(&notes, 3 * DAY);
-        let (label, _) = row(&notes[0], &widths);
-        assert_eq!(prefix(&notes[0], 3 * DAY, &widths), "now now  ");
+        let widths = Widths::of(&notes, &cfg, 0);
+        let color_of = |n: &Note| row(n, &cfg, &widths).1.first().map(|t| t.color);
+        assert_eq!(color_of(&notes[1]), Some(UNLABELLED_COLOR));
+        assert_ne!(color_of(&notes[0]), Some(UNLABELLED_COLOR));
+    }
+
+    /// The dates and the task count sit behind the name and outside what the
+    /// query matches — typed, `3` must not rank every three-day-old note above
+    /// the one being looked for.
+    #[test]
+    fn the_suffix_holds_what_nobody_searches_for() {
+        let cfg = config();
+        let notes = vault();
+        let widths = Widths::of(&notes, &cfg, 3 * DAY);
+        let (label, _) = row(&notes[0], &cfg, &widths);
+        let (suffix, _) = suffix(&notes[0], 3 * DAY, &widths);
+        assert!(suffix.contains("now"), "{suffix:?}");
+        assert!(suffix.contains(OPEN_TASK), "{suffix:?}");
         assert!(!label.contains("now"), "{label:?}");
+        assert!(!label.contains(OPEN_TASK), "{label:?}");
     }
 
     #[test]
-    fn every_prefix_is_the_same_width() {
+    fn every_suffix_is_the_same_width() {
+        let cfg = config();
         let notes = vault();
-        let widths = Widths::of(&notes, 10 * YEAR);
-        let rendered: Vec<usize> = notes
+        let widths = Widths::of(&notes, &cfg, 10 * YEAR);
+        let widths_drawn: Vec<usize> = notes
             .iter()
-            .map(|n| prefix(n, 10 * YEAR, &widths).chars().count())
+            .map(|n| suffix(n, 10 * YEAR, &widths).0.chars().count())
             .collect();
-        assert!(rendered.windows(2).all(|w| w[0] == w[1]), "{rendered:?}");
+        assert!(
+            widths_drawn.windows(2).all(|w| w[0] == w[1]),
+            "{widths_drawn:?}"
+        );
     }
 
     #[test]
-    fn a_status_row_leads_with_the_name_and_ends_with_both_dates() {
+    fn a_note_with_tasks_left_reads_differently_from_one_without() {
+        assert_eq!(Tasks { open: 0, done: 0 }.column(), "");
+        assert_eq!(Tasks { open: 0, done: 3 }.column(), ALL_DONE);
+        assert_eq!(Tasks { open: 2, done: 3 }.column(), format!("2{OPEN_TASK}"));
+        assert_eq!(Tasks { open: 0, done: 3 }.color(), DONE_COLOR);
+        assert_eq!(Tasks { open: 2, done: 3 }.color(), OPEN_COLOR);
+    }
+
+    #[test]
+    fn tasks_are_counted_from_the_body() {
+        let counted = count_tasks("- [ ] a\n* [x] b\n  + [X] c\n- not a task\n1. [ ] d\n");
+        assert_eq!(counted, Tasks { open: 2, done: 2 });
+    }
+
+    /// A checkbox inside a fence is an example of one, not one.
+    #[test]
+    fn a_task_in_a_code_fence_is_not_counted() {
+        let counted = count_tasks("- [ ] real\n```md\n- [ ] example\n```\n");
+        assert_eq!(counted, Tasks { open: 1, done: 0 });
+    }
+
+    #[test]
+    fn a_status_row_leads_with_the_path_and_ends_with_both_dates() {
+        let cfg = config();
         let notes = vault();
-        let widths = Widths::of(&notes, 0);
-        let row = status_row(&notes[0], &widths, utc());
+        let widths = Widths::of(&notes, &cfg, 0);
+        let row = status_row(&notes[0], &cfg, &widths, utc());
         assert!(row.starts_with("work/meetings/standup.md"), "{row:?}");
-        assert!(row.contains("#work"), "{row:?}");
-        assert!(row.ends_with("1970-01-04"), "{row:?}");
+        assert!(row.contains("work"), "{row:?}");
+        assert!(row.contains("#daily"), "{row:?}");
+        assert!(row.ends_with("1971-02-05"), "{row:?}");
     }
 
     #[test]
@@ -1056,7 +1402,13 @@ mod tests {
     // --- preview ---
 
     fn preview_of(text: &str) -> String {
-        preview(&note("work/a.md", Front::default()), text, 0, utc())
+        preview(
+            &note("work/a.md", Front::default()),
+            &config(),
+            text,
+            0,
+            utc(),
+        )
     }
 
     /// The header is where the row's two age columns are named; without it the
@@ -1142,5 +1494,371 @@ mod tests {
         );
         markdown_line("```", &mut fenced);
         assert!(!fenced);
+    }
+}
+
+// --- searching --------------------------------------------------------------
+
+/// One line of a note that a search matched.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Match {
+    /// Absolute path, which is what an editor and a quickfix entry both want.
+    pub path: PathBuf,
+    /// Path below the vault root, which is what a row shows.
+    pub rel: String,
+    pub line: u32,
+    pub column: u32,
+    /// The matched line, as ripgrep printed it.
+    pub text: String,
+}
+
+/// Read one `--vimgrep` line: `path:line:column:text`.
+///
+/// Split from the left exactly three times, because only the first three fields
+/// are known not to contain a colon — a path may, and the matched text very
+/// often does.
+pub fn parse_match(line: &str, root: &Path) -> Option<Match> {
+    // The path is whatever precedes the last colon that still leaves two
+    // numbers and a text behind it, which reading from the right finds without
+    // guessing where the path ends.
+    let (head, text) = split_three(line)?;
+    let (path, line_no, column) = head;
+    let path = PathBuf::from(path);
+    Some(Match {
+        rel: path
+            .strip_prefix(root)
+            .unwrap_or(&path)
+            .to_string_lossy()
+            .into_owned(),
+        path,
+        line: line_no,
+        column,
+        text: text.to_string(),
+    })
+}
+
+/// `path:line:column:` and the rest, where `line` and `column` are the last two
+/// colon-separated numbers before the text.
+fn split_three(line: &str) -> Option<((&str, u32, u32), &str)> {
+    let mut at = 0;
+    // Walk the colons left to right: the first one whose next two fields are
+    // numbers ends the path. A path holding `x:1:2:` before the real fields is
+    // a file nobody has.
+    while let Some(next) = line[at..].find(':') {
+        let end = at + next;
+        let rest = &line[end + 1..];
+        if let Some((line_no, rest)) = take_number(rest)
+            && let Some((column, rest)) = take_number(rest)
+        {
+            return Some(((&line[..end], line_no, column), rest));
+        }
+        at = end + 1;
+    }
+    None
+}
+
+/// A run of digits followed by a colon, and what comes after it.
+fn take_number(text: &str) -> Option<(u32, &str)> {
+    let digits = text.len() - text.trim_start_matches(|c: char| c.is_ascii_digit()).len();
+    if digits == 0 {
+        return None;
+    }
+    let rest = text[digits..].strip_prefix(':')?;
+    Some((text[..digits].parse().ok()?, rest))
+}
+
+/// The field separator inside a search row's value.
+///
+/// A control character rather than a colon or a tab: the value carries a path,
+/// which may hold either, and it is read back by [`decode_match`] rather than
+/// by a person.
+const FIELD: char = '\u{1}';
+
+/// Pack a match into the string a selector row returns.
+pub fn encode_match(found: &Match) -> String {
+    format!(
+        "{}{FIELD}{}{FIELD}{}{FIELD}{}",
+        found.path.display(),
+        found.line,
+        found.column,
+        crate::term::one_row(&found.text),
+    )
+}
+
+/// Read back what [`encode_match`] wrote.
+pub fn decode_match(value: &str, root: &Path) -> Option<Match> {
+    let mut fields = value.splitn(4, FIELD);
+    let path = PathBuf::from(fields.next()?);
+    let line = fields.next()?.parse().ok()?;
+    let column = fields.next()?.parse().ok()?;
+    let text = fields.next().unwrap_or_default().to_string();
+    Some(Match {
+        rel: path
+            .strip_prefix(root)
+            .unwrap_or(&path)
+            .to_string_lossy()
+            .into_owned(),
+        path,
+        line,
+        column,
+        text,
+    })
+}
+
+/// One entry of a quickfix list, in the `file:line:column:text` shape vim's
+/// `errorformat` is told to expect.
+pub fn quickfix_line(found: &Match) -> String {
+    format!(
+        "{}:{}:{}:{}",
+        found.path.display(),
+        found.line,
+        found.column,
+        crate::term::one_row(&found.text)
+    )
+}
+
+/// The widest `rel:line` in a batch of matches, so their text columns line up.
+pub fn match_width(matches: &[Match]) -> usize {
+    matches
+        .iter()
+        .map(|m| m.rel.chars().count() + 1 + m.line.to_string().chars().count())
+        .max()
+        .unwrap_or(0)
+}
+
+/// One search row: where the match is, then the line that matched.
+///
+/// The location leads for the reason a note's name does — it is what the eye
+/// runs down — and is the only part coloured, since the matched text is the
+/// note's own words and colouring those would be scriv talking over them.
+pub fn match_row(found: &Match, width: usize) -> (String, Vec<Tint>) {
+    let location = format!("{}:{}", found.rel, found.line);
+    let mut row = String::new();
+    push_column(&mut row, &location, width);
+    row.push_str(COLUMN_GAP);
+    // Trimmed at the front only: the indentation of a matched line is noise in
+    // a list, and its trailing text is what the match is.
+    row.push_str(crate::term::one_row(found.text.trim_start()).trim_end());
+
+    let at = found.rel.chars().count();
+    (
+        row,
+        vec![
+            Tint {
+                range: 0..at,
+                color: FOLDER_COLOR,
+            },
+            Tint {
+                range: at..location.chars().count(),
+                color: LINE_COLOR,
+            },
+        ],
+    )
+}
+
+/// The colour of a `:line` suffix on a search row: yellow, as every grep-alike
+/// numbers its lines.
+const LINE_COLOR: u8 = 3;
+
+/// How much of a note the search preview shows either side of the match.
+const MATCH_CONTEXT: usize = 12;
+
+/// The preview pane for a search row: the matched line in the note around it,
+/// with the match itself marked.
+pub fn match_preview(found: &Match, text: &str) -> String {
+    let mut out = paint(&crate::term::one_row(&found.rel), DIM);
+    out.push('\n');
+
+    let line = found.line.max(1) as usize;
+    let first = line.saturating_sub(MATCH_CONTEXT).max(1);
+    let number_width = (line + MATCH_CONTEXT).to_string().len();
+
+    for (offset, body) in text
+        .lines()
+        .enumerate()
+        .skip(first - 1)
+        .take(MATCH_CONTEXT * 2 + 1)
+    {
+        let number = offset + 1;
+        let body = crate::term::one_row(body);
+        out.push('\n');
+        out.push_str(&paint(&format!("{number:>number_width$}"), DIM));
+        out.push(' ');
+        if number == line {
+            out.push_str(&format!("\x1b[1;38;5;{LINE_COLOR}m{body}\x1b[0m"));
+        } else {
+            out.push_str(&body);
+        }
+    }
+    out
+}
+
+// --- new notes --------------------------------------------------------------
+
+/// The name a new note takes when the user did not give one: the local date and
+/// time, to the minute.
+///
+/// A name rather than a prompt, because being asked to name a note is being
+/// asked what it is about before writing it — and a note that has to be named
+/// first is one that does not get written. It sorts, it is unique to the
+/// minute, and renaming it afterwards is what an editor is for.
+pub fn generated_name(now: i64, offset: time::UtcOffset) -> String {
+    let Some(dt) = local(now, offset) else {
+        return "note.md".to_string();
+    };
+    format!(
+        "{:04}-{:02}-{:02}-{:02}{:02}.md",
+        dt.year(),
+        dt.month() as u8,
+        dt.day(),
+        dt.hour(),
+        dt.minute(),
+    )
+}
+
+/// A name nothing is using yet: `name`, else `name-2`, `name-3` and so on.
+///
+/// Two notes started in the same minute is not an error, and neither is one
+/// name typed twice — the second is a second note.
+pub fn free_name(name: &str, taken: impl Fn(&str) -> bool) -> String {
+    if !taken(name) {
+        return name.to_string();
+    }
+    let (stem, ext) = match name.rsplit_once('.') {
+        Some((stem, ext)) if !stem.is_empty() => (stem, format!(".{ext}")),
+        _ => (name, String::new()),
+    };
+    // Bounded only by the filesystem: a caller that finds every name taken has
+    // a directory problem rather than a naming one.
+    (2..)
+        .map(|n| format!("{stem}-{n}{ext}"))
+        .find(|candidate| !taken(candidate))
+        .expect("the integers run out before the filenames do")
+}
+
+#[cfg(test)]
+mod search_tests {
+    use super::*;
+
+    fn root() -> PathBuf {
+        PathBuf::from("/vault")
+    }
+
+    #[test]
+    fn a_vimgrep_line_splits_into_a_place_and_the_text_that_matched() {
+        let found = parse_match("/vault/work/a.md:12:5:the matched text", &root()).unwrap();
+        assert_eq!(found.rel, "work/a.md");
+        assert_eq!((found.line, found.column), (12, 5));
+        assert_eq!(found.text, "the matched text");
+    }
+
+    /// The matched text is a line of prose, and prose is full of colons. Only
+    /// the first three fields are known not to be.
+    #[test]
+    fn a_matched_line_may_contain_colons_of_its_own() {
+        let found = parse_match("/vault/a.md:1:1:see also: the other note", &root()).unwrap();
+        assert_eq!(found.text, "see also: the other note");
+    }
+
+    /// A path may contain a colon too, which is why the split looks for the
+    /// two numbers rather than counting from the left.
+    #[test]
+    fn a_path_with_a_colon_in_it_still_parses() {
+        let found = parse_match("/vault/a:b.md:7:2:text", &root()).unwrap();
+        assert_eq!(found.path, PathBuf::from("/vault/a:b.md"));
+        assert_eq!(found.line, 7);
+    }
+
+    #[test]
+    fn a_line_that_is_not_a_match_is_not_one() {
+        for line in ["", "no colons at all", "/vault/a.md:not:a:number"] {
+            assert!(parse_match(line, &root()).is_none(), "{line:?}");
+        }
+    }
+
+    /// The value travels through skim as one string and comes back to be
+    /// opened, so what goes in has to come out — including a path holding the
+    /// characters a simpler separator would have split on.
+    #[test]
+    fn a_match_survives_the_trip_through_the_selector() {
+        let found = Match {
+            path: PathBuf::from("/vault/a:b c.md"),
+            rel: "a:b c.md".into(),
+            line: 41,
+            column: 3,
+            text: "a line with: colons and\ttabs".into(),
+        };
+        let back = decode_match(&encode_match(&found), &root()).unwrap();
+        assert_eq!(back.path, found.path);
+        assert_eq!((back.line, back.column), (41, 3));
+        assert_eq!(back.rel, "a:b c.md");
+    }
+
+    /// vim reads the list with `errorformat=%f:%l:%c:%m`, so this is the one
+    /// shape it parses.
+    #[test]
+    fn a_quickfix_entry_is_file_line_column_text() {
+        let found = parse_match("/vault/a.md:12:5:text", &root()).unwrap();
+        assert_eq!(quickfix_line(&found), "/vault/a.md:12:5:text");
+    }
+
+    /// A note's own bytes reach the terminal here; an escape sequence in one
+    /// would otherwise repaint the list around it.
+    #[test]
+    fn a_matched_line_cannot_colour_the_row_it_is_drawn_in() {
+        let found = parse_match("/vault/a.md:1:1:red \x1b[31mhere", &root()).unwrap();
+        let (row, _) = match_row(&found, 10);
+        assert!(!row.contains('\x1b'), "{row:?}");
+        assert!(!quickfix_line(&found).contains('\x1b'));
+    }
+
+    #[test]
+    fn a_search_row_colours_where_the_match_is_and_not_what_it_says() {
+        let found = parse_match("/vault/work/a.md:12:1:some words", &root()).unwrap();
+        let (row, tints) = match_row(&found, 20);
+        let text = |tint: &Tint| -> String {
+            row.chars()
+                .skip(tint.range.start)
+                .take(tint.range.len())
+                .collect()
+        };
+        assert_eq!(text(&tints[0]), "work/a.md");
+        assert_eq!(text(&tints[1]), ":12");
+        assert!(row.contains("some words"));
+        assert!(
+            tints
+                .iter()
+                .all(|t| t.range.end <= "work/a.md:12".chars().count()),
+            "the matched text is coloured over"
+        );
+    }
+
+    // --- new notes ---
+
+    /// Sortable, and unique to the minute — which is what lets a note be
+    /// started without first being named.
+    #[test]
+    fn a_generated_name_is_the_date_and_time() {
+        assert_eq!(generated_name(0, utc()), "1970-01-01-0000.md");
+        assert_eq!(
+            generated_name(3 * 3600 + 25 * 60, utc()),
+            "1970-01-01-0325.md"
+        );
+    }
+
+    #[test]
+    fn a_name_already_taken_takes_the_next_one() {
+        let taken = |name: &str| ["a.md", "a-2.md"].contains(&name);
+        assert_eq!(free_name("a.md", taken), "a-3.md");
+        assert_eq!(free_name("b.md", taken), "b.md");
+    }
+
+    #[test]
+    fn a_name_with_no_extension_is_still_given_a_free_one() {
+        assert_eq!(free_name("a", |name| name == "a"), "a-2");
+    }
+
+    fn utc() -> time::UtcOffset {
+        time::UtcOffset::UTC
     }
 }

--- a/src/select.rs
+++ b/src/select.rs
@@ -130,6 +130,14 @@ pub struct SelectItem {
     /// that identifies a row without being what one searches for, such as the
     /// date on a history entry.
     pub prefix: Option<String>,
+    /// Drawn after the label and *not* matched against — [`SelectItem::prefix`]
+    /// on the other side, for a column that belongs to the right-hand edge
+    /// rather than the left. Dim, unless [`SelectItem::suffix_tints`] says
+    /// otherwise.
+    pub suffix: Option<String>,
+    /// Colours within the suffix, as character ranges into it. Indexed from
+    /// the start of the suffix, not of the row.
+    pub suffix_tints: Vec<Tint>,
     /// `None` when the value is the label itself. Read through
     /// [`SelectItem::value`].
     value: Option<String>,
@@ -144,6 +152,8 @@ impl SelectItem {
         Self {
             label: text.into(),
             prefix: None,
+            suffix: None,
+            suffix_tints: Vec::new(),
             value: None,
             color: None,
             tints: Vec::new(),
@@ -156,6 +166,8 @@ impl SelectItem {
         Self {
             label: label.into(),
             prefix: None,
+            suffix: None,
+            suffix_tints: Vec::new(),
             value: Some(value.into()),
             color: None,
             tints: Vec::new(),
@@ -166,6 +178,14 @@ impl SelectItem {
     /// Draw `prefix` dim, ahead of the label, outside what the query matches.
     pub fn prefix(mut self, prefix: impl Into<String>) -> Self {
         self.prefix = Some(prefix.into());
+        self
+    }
+
+    /// Draw `suffix` after the label, outside what the query matches, with
+    /// `tints` colouring ranges of it.
+    pub fn suffix(mut self, suffix: impl Into<String>, tints: Vec<Tint>) -> Self {
+        self.suffix = Some(suffix.into());
+        self.suffix_tints = tints;
         self
     }
 
@@ -265,18 +285,23 @@ impl SkimItem for SkItem {
             line = tinted(line, &self.item.tints, base);
         }
 
-        let Some(prefix) = &self.item.prefix else {
+        if self.item.prefix.is_none() && self.item.suffix.is_none() {
             return line;
-        };
+        }
 
-        // Prepended as a span rather than folded into the label, so
-        // `to_line`'s highlight positions still index the matched text.
+        // Added as spans rather than folded into the label, so `to_line`'s
+        // highlight positions still index the matched text.
+        let dim = Style::default().fg(Color::Indexed(PREFIX_COLOR));
         let mut out = Line::default();
-        out.push_span(Span::styled(
-            prefix.clone(),
-            Style::default().fg(Color::Indexed(PREFIX_COLOR)),
-        ));
+        if let Some(prefix) = &self.item.prefix {
+            out.push_span(Span::styled(prefix.clone(), dim));
+        }
         out.spans.extend(line.spans);
+        if let Some(suffix) = &self.item.suffix {
+            let plain = Line::from(Span::styled(suffix.clone(), dim));
+            out.spans
+                .extend(tinted(plain, &self.item.suffix_tints, dim).spans);
+        }
         out
     }
 
@@ -318,6 +343,7 @@ pub fn select_one_queried(
         multi: false,
         query,
         reload: None,
+        search: None,
         actions: &[],
     };
     run_selector(Feed::batch(items), run, cfg)?
@@ -390,6 +416,7 @@ pub fn select_one_reloading(
         multi: false,
         query: "",
         reload: Some(reload),
+        search: None,
         actions,
     };
     chosen(run_selector(Feed::batch(items), run, cfg)?)
@@ -407,6 +434,7 @@ pub fn select_one_acting(
         multi: false,
         query: "",
         reload: None,
+        search: None,
         actions,
     };
     chosen(run_selector(Feed::batch(items), run, cfg)?)
@@ -477,6 +505,161 @@ impl CommandCollector for ReloadCollector {
 
         (rx_item, tx_interrupt)
     }
+}
+
+/// One query's worth of rows, and the means to stop producing them.
+///
+/// [`Searching::stop`] is called from another thread the moment the selector
+/// abandons this search — the query moved on, or the selector closed — and
+/// must be safe to call while `rows` is blocked waiting for the next one.
+/// Making it end the iterator is the whole contract: skim's reader busy-waits
+/// for its readers to stop, so a search that keeps producing after it was
+/// called burns a core.
+pub struct Searching {
+    pub rows: Box<dyn Iterator<Item = SelectItem> + Send>,
+    pub stop: Box<dyn Fn() + Send + Sync>,
+}
+
+/// Produces the rows for a query. Called afresh on every keystroke, on a
+/// background thread, so it may block for as long as the search takes.
+pub type Search = Box<dyn FnMut(&str) -> Searching + Send>;
+
+/// How many rows to hand skim at once, and how long the counted thread waits
+/// on the producer before looking up to see whether it has been called off.
+const SEARCH_BATCH: usize = 256;
+const SEARCH_QUEUE: usize = 4;
+const SEARCH_POLL: Duration = Duration::from_millis(20);
+
+/// Undo the shell quoting skim applies to a substituted `{q}` — the inverse of
+/// [`quote`], and the reason a search sees what was typed rather than what a
+/// shell would have been handed.
+///
+/// skim expands the query into the command template as though a shell were
+/// going to run it. Nothing here runs a shell: the "command" is this crate's
+/// own closure, and the quoting has to come back off before the search sees a
+/// pattern with `'\''` in the middle of it.
+fn unquote(quoted: &str) -> String {
+    let Some(inner) = quoted
+        .strip_prefix('\'')
+        .and_then(|rest| rest.strip_suffix('\''))
+    else {
+        return quoted.to_string();
+    };
+    inner.replace(r"'\''", "'")
+}
+
+/// The [`CommandCollector`] behind [`select_many_searching`]: skim thinks it is
+/// running a command per keystroke, and it is calling a closure.
+struct SearchCollector {
+    search: Arc<Mutex<Search>>,
+}
+
+impl CommandCollector for SearchCollector {
+    fn invoke(
+        &mut self,
+        cmd: &str,
+        components_to_stop: Arc<AtomicUsize>,
+    ) -> (SkimItemReceiver, Sender<i32>) {
+        let (tx_item, rx_item): (SkimItemSender, SkimItemReceiver) = unbounded();
+        let (tx_interrupt, rx_interrupt) = unbounded::<i32>();
+        let query = unquote(cmd);
+        let search = Arc::clone(&self.search);
+
+        // Counted, and therefore never the thread blocked in the search: as
+        // with the reload collector, `ReaderControl::kill` busy-waits on this
+        // counter, so the work happens on a second, uncounted thread.
+        components_to_stop.fetch_add(1, Ordering::SeqCst);
+        std::thread::spawn(move || {
+            let (tx_rows, rx_rows) = std::sync::mpsc::sync_channel::<Vec<SelectItem>>(SEARCH_QUEUE);
+            let (tx_stop, rx_stop) = std::sync::mpsc::channel::<Box<dyn Fn() + Send + Sync>>();
+
+            std::thread::spawn(move || {
+                let mut searching = (search.lock().expect("search closure poisoned"))(&query);
+                // Handed over before the first row is read, so the thread
+                // below can call it off while this one is still blocked.
+                if tx_stop.send(searching.stop).is_err() {
+                    return;
+                }
+                let mut batch = Vec::with_capacity(SEARCH_BATCH);
+                for row in searching.rows.by_ref() {
+                    batch.push(row);
+                    if batch.len() < SEARCH_BATCH {
+                        continue;
+                    }
+                    let full = std::mem::replace(&mut batch, Vec::with_capacity(SEARCH_BATCH));
+                    if tx_rows.send(full).is_err() {
+                        return;
+                    }
+                }
+                if !batch.is_empty() {
+                    let _ = tx_rows.send(batch);
+                }
+            });
+
+            let mut stop: Option<Box<dyn Fn() + Send + Sync>> = None;
+            loop {
+                if stop.is_none() {
+                    stop = rx_stop.try_recv().ok();
+                }
+                if matches!(rx_interrupt.try_recv(), Ok(Some(_)) | Err(_)) {
+                    // Blocking waits for it if the search has not handed one
+                    // over yet: returning first would leave the search running
+                    // with nobody left to call it off.
+                    let stop = stop.or_else(|| rx_stop.recv().ok());
+                    if let Some(stop) = stop {
+                        stop();
+                    }
+                    break;
+                }
+                match rx_rows.recv_timeout(SEARCH_POLL) {
+                    Ok(rows) => {
+                        if tx_item
+                            .send(rows.into_iter().map(into_skim).collect())
+                            .is_err()
+                        {
+                            break;
+                        }
+                    }
+                    Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {}
+                    // The search is finished, or it panicked.
+                    Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => break,
+                }
+            }
+            // Dropping this is what stops skim's spinner, so it has to happen
+            // before the count drops.
+            drop(tx_item);
+            components_to_stop.fetch_sub(1, Ordering::SeqCst);
+        });
+
+        (rx_item, tx_interrupt)
+    }
+}
+
+/// Select zero or more rows from a list the *query* produces, rather than one
+/// it filters.
+///
+/// The search runs again on every keystroke and its rows replace the list. For
+/// a set too large to hold — every line of every note — where something else
+/// already knows how to search it.
+///
+/// Fuzzy matching is off while this is open, since the query has gone to the
+/// search instead; skim's own `ctrl-q` toggles back to filtering what is on
+/// screen.
+pub fn select_many_searching(
+    search: Search,
+    prompt: &str,
+    query: &str,
+    cfg: &SelectorConfig,
+) -> Result<Vec<String>> {
+    let run = Run {
+        prompt,
+        multi: true,
+        query,
+        reload: None,
+        search: Some(search),
+        actions: &[],
+    };
+    Ok(run_selector(Feed::none(true), run, cfg)?.values)
 }
 
 /// What [`select_one_or_query`] came back with.
@@ -565,6 +748,16 @@ const FEED_BATCH: usize = 512;
 const FEED_INTERVAL: Duration = Duration::from_millis(15);
 
 impl Feed {
+    /// No rows of its own, for a selector fed by something other than a feed.
+    /// `preview` states up front whether a pane is wanted, since there is no
+    /// row yet to ask.
+    fn none(preview: bool) -> Self {
+        Self {
+            rows: Rows::Batch(Vec::new()),
+            preview,
+        }
+    }
+
     fn batch(items: Vec<SelectItem>) -> Self {
         let preview = items.iter().any(|item| item.preview.is_some());
         Self {
@@ -635,6 +828,8 @@ struct Run<'a> {
     query: &'a str,
     /// Given one, [`REFRESH_KEY`] reloads the list through it.
     reload: Option<Reload>,
+    /// Given one, the query box drives this instead of filtering rows.
+    search: Option<Search>,
     /// Keys that close the selector meaning something other than enter.
     actions: &'static [Action],
 }
@@ -646,6 +841,7 @@ impl<'a> Run<'a> {
             multi,
             query: "",
             reload: None,
+            search: None,
             actions: &[],
         }
     }
@@ -708,11 +904,32 @@ fn run_selector(feed: Feed, run: Run, cfg: &SelectorConfig) -> Result<Outcome> {
     }
 
     if !run.query.is_empty() {
-        builder.query(run.query.to_string());
+        // Two different boxes: in a searching selector what is typed is the
+        // search, and skim keeps that under a name of its own.
+        if run.search.is_some() {
+            builder.cmd_query(run.query.to_string());
+        } else {
+            builder.query(run.query.to_string());
+        }
     }
 
     let reloadable = run.reload.is_some();
-    let header = hints(actions, reloadable, multi);
+    let searching = run.search.is_some();
+    let header = hints(actions, reloadable, multi, searching);
+
+    // The query drives the search rather than filtering rows, so skim runs it
+    // through a "command" — `{q}` being skim's own spelling of what was typed.
+    // It arrives shell-quoted; `unquote` is what takes that back off.
+    if let Some(search) = run.search {
+        let collector = SearchCollector {
+            search: Arc::new(Mutex::new(search)),
+        };
+        builder
+            .interactive(true)
+            .cmd("{q}".to_string())
+            .cmd_prompt(format!("{prompt}> "))
+            .cmd_collector(Rc::new(RefCell::new(collector)) as Rc<RefCell<dyn CommandCollector>>);
+    }
 
     // `no_clear_if_empty` keeps a quick reload from flickering; a slow one
     // still empties the list, which is what the busy header is for.
@@ -737,11 +954,18 @@ fn run_selector(feed: Feed, run: Run, cfg: &SelectorConfig) -> Result<Outcome> {
         .build()
         .map_err(|e| anyhow!("configuring selector: {e}"))?;
 
-    let (tx, rx): (SkimItemSender, SkimItemReceiver) = unbounded();
-    feed.send(tx)?;
+    // Nothing is fed to a searching selector: its rows come from the
+    // collector, which skim only reaches for when there is no source.
+    let source = if searching {
+        None
+    } else {
+        let (tx, rx): (SkimItemSender, SkimItemReceiver) = unbounded();
+        feed.send(tx)?;
+        Some(rx)
+    };
 
     let _room = room_for(&cfg.height);
-    let output = Skim::run_with(options, Some(rx)).map_err(|e| anyhow!("running selector: {e}"))?;
+    let output = Skim::run_with(options, source).map_err(|e| anyhow!("running selector: {e}"))?;
 
     if output.is_abort {
         return Err(Cancelled.into());
@@ -784,7 +1008,7 @@ fn acted(output: &SkimOutput, actions: &'static [Action]) -> Option<&'static str
 ///
 /// Nothing at all when there is nothing to say, so a plain list of paths keeps
 /// the row for a path.
-fn hints(actions: &[Action], reloadable: bool, multi: bool) -> String {
+fn hints(actions: &[Action], reloadable: bool, multi: bool, searching: bool) -> String {
     let mut hints: Vec<String> = actions
         .iter()
         .map(|action| format!("{} {}", action.key, action.label))
@@ -794,6 +1018,12 @@ fn hints(actions: &[Action], reloadable: bool, multi: bool) -> String {
     }
     if multi {
         hints.push("tab select".to_string());
+    }
+    // Worth a hint only where the query is not doing what a query usually
+    // does: with the search taking it, `ctrl-q` is how you filter what came
+    // back rather than searching again.
+    if searching {
+        hints.push("ctrl-q filter".to_string());
     }
     hints.join(HINT_SEPARATOR)
 }
@@ -860,6 +1090,138 @@ fn refresh_binds(idle: &str) -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// skim hands a searching collector the query already shell-quoted, as
+    /// though a shell were going to run it. Nothing here runs one, so what
+    /// `quote` puts on has to come back off — exactly, or a search for a word
+    /// with an apostrophe in it looks for `'\\''` instead.
+    #[test]
+    fn what_the_selector_quotes_the_search_unquotes() {
+        for typed in [
+            "plain",
+            "two words",
+            "it's",
+            "'quoted'",
+            "a'b'c",
+            "",
+            "--flag",
+        ] {
+            assert_eq!(unquote(&quote(typed)), typed, "{typed:?}");
+        }
+    }
+
+    /// Nothing quoted it, so nothing should be taken off.
+    #[test]
+    fn an_unquoted_query_is_left_alone() {
+        assert_eq!(unquote("bare"), "bare");
+    }
+
+    /// The searching collector is the one piece of this that no `tests/cli.rs`
+    /// case can reach: driving it for real needs a terminal, which is what a
+    /// skim test would be testing. These drive it directly instead.
+    mod searching {
+        use super::*;
+        use std::sync::atomic::AtomicBool;
+
+        /// Everything the collector is asked to do, run to completion.
+        fn collect(search: Search, quoted: &str) -> (Vec<String>, Arc<AtomicUsize>) {
+            let mut collector = SearchCollector {
+                search: Arc::new(Mutex::new(search)),
+            };
+            let counter = Arc::new(AtomicUsize::new(0));
+            let (rx, _interrupt) = collector.invoke(quoted, Arc::clone(&counter));
+            let mut rows = Vec::new();
+            while let Ok(batch) = rx.recv() {
+                rows.extend(batch.iter().map(|item| item.text().to_string()));
+            }
+            (rows, counter)
+        }
+
+        #[test]
+        fn the_search_sees_what_was_typed_rather_than_what_a_shell_would_get() {
+            let seen = Arc::new(Mutex::new(String::new()));
+            let recorder = Arc::clone(&seen);
+            let search: Search = Box::new(move |query| {
+                *recorder.lock().unwrap() = query.to_string();
+                Searching {
+                    rows: Box::new(std::iter::empty()),
+                    stop: Box::new(|| {}),
+                }
+            });
+
+            collect(search, &quote("it's a match"));
+
+            assert_eq!(seen.lock().unwrap().as_str(), "it's a match");
+        }
+
+        #[test]
+        fn every_row_the_search_produces_reaches_the_selector() {
+            let search: Search = Box::new(|_| Searching {
+                rows: Box::new((0..1000).map(|n| SelectItem::plain(format!("row {n}")))),
+                stop: Box::new(|| {}),
+            });
+
+            let (rows, counter) = collect(search, "'q'");
+
+            assert_eq!(rows.len(), 1000);
+            assert_eq!(rows[0], "row 0");
+            assert_eq!(
+                counter.load(Ordering::SeqCst),
+                0,
+                "a finished search left its thread counted, which is what skim busy-waits on",
+            );
+        }
+
+        /// The reason `stop` exists. skim kills the reader on every keystroke,
+        /// and `ReaderControl::kill` busy-waits on the counter — so a search
+        /// still blocked producing rows has to be called off, not waited for.
+        #[test]
+        fn interrupting_a_search_stops_it_even_while_it_is_blocked() {
+            let stopped = Arc::new(AtomicBool::new(false));
+            let flag = Arc::clone(&stopped);
+            let search: Search = Box::new(move |_| {
+                let ended = Arc::new(AtomicBool::new(false));
+                let watched = Arc::clone(&ended);
+                let flag = Arc::clone(&flag);
+                Searching {
+                    // Never yields until it is called off, the way a ripgrep
+                    // over a large vault does not.
+                    rows: Box::new(std::iter::from_fn(move || {
+                        while !watched.load(Ordering::SeqCst) {
+                            std::thread::sleep(Duration::from_millis(1));
+                        }
+                        None
+                    })),
+                    stop: Box::new(move || {
+                        flag.store(true, Ordering::SeqCst);
+                        ended.store(true, Ordering::SeqCst);
+                    }),
+                }
+            });
+
+            let mut collector = SearchCollector {
+                search: Arc::new(Mutex::new(search)),
+            };
+            let counter = Arc::new(AtomicUsize::new(0));
+            let (_rx, interrupt) = collector.invoke("'q'", Arc::clone(&counter));
+            interrupt.send(1).expect("the collector is listening");
+
+            let deadline = Instant::now() + Duration::from_secs(5);
+            while counter.load(Ordering::SeqCst) != 0 && Instant::now() < deadline {
+                std::thread::sleep(Duration::from_millis(5));
+            }
+
+            assert!(
+                stopped.load(Ordering::SeqCst),
+                "the search was not called off"
+            );
+            assert_eq!(
+                counter.load(Ordering::SeqCst),
+                0,
+                "skim would busy-wait here forever",
+            );
+        }
+    }
 
     /// Render an item the way skim would, with `matches` standing in for a
     /// query that hit the given characters of the *label*.
@@ -1070,6 +1432,7 @@ mod tests {
             &[Action::new("f2", "open"), Action::new("f7", "check out")],
             true,
             true,
+            false,
         );
         for header in [BUSY_HEADER, every_hint.as_str(), HINT_SEPARATOR] {
             assert!(!header.contains(','), "{header:?} would split the binding");
@@ -1079,7 +1442,7 @@ mod tests {
 
     #[test]
     fn the_header_names_every_key_the_selector_answers_to() {
-        let full = hints(&[Action::new("f2", "open")], true, true);
+        let full = hints(&[Action::new("f2", "open")], true, true, false);
         assert_eq!(full, "f2 open · ctrl-r refresh · tab select");
     }
 
@@ -1087,13 +1450,13 @@ mod tests {
     /// path than as an empty hint line.
     #[test]
     fn a_selector_with_nothing_to_offer_draws_no_header() {
-        assert!(hints(&[], false, false).is_empty());
+        assert!(hints(&[], false, false, false).is_empty());
     }
 
     #[test]
     fn each_hint_appears_only_when_its_key_is_bound() {
-        assert_eq!(hints(&[], false, true), "tab select");
-        assert_eq!(hints(&[], true, false), "ctrl-r refresh");
+        assert_eq!(hints(&[], false, true, false), "tab select");
+        assert_eq!(hints(&[], true, false, false), "ctrl-r refresh");
     }
 
     /// skim binds `ctrl-r` to rotating the match mode and `tab` to toggling a
@@ -1104,7 +1467,7 @@ mod tests {
     #[test]
     fn every_key_the_header_names_is_bound() {
         let actions = [Action::new("f2", "open"), Action::new("f7", "check out")];
-        let header = hints(&actions, true, true);
+        let header = hints(&actions, true, true, false);
         let binds = binds(&actions, true, true, &header);
 
         for hint in header.split(HINT_SEPARATOR) {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1624,24 +1624,25 @@ fn mk_note(vault: &Path, rel: &str, body: &str, modified: u64) {
 }
 
 /// A vault of three notes, the newest last in the alphabet so ordering by name
-/// and ordering by date cannot be mistaken for each other.
+/// and ordering by date cannot be mistaken for each other. `archive` carries a
+/// label and `zeta.md` sits at the root, so a listing has one of each.
 fn mk_vault(sandbox: &Sandbox) -> PathBuf {
     let vault = sandbox.home().join("notes");
     mk_note(
         &vault,
         "archive/old.md",
-        "---\ntags: [done]\n---\n\nold\n",
+        "---\ntags: [done]\n---\n\nold\n- [x] finished\n",
         1_000,
     );
     mk_note(
         &vault,
         "inbox.md",
-        "---\ntitle: Inbox\ntags:\n  - todo\n  - work\ncreated: 2024-03-01\n---\n\n# Inbox\n",
+        "---\ntitle: Inbox\ntags:\n  - todo\n  - work\ncreated: 2024-03-01\n---\n\n# Inbox\n\n- [ ] call the bank\n- [x] renew\n",
         3_000,
     );
     mk_note(&vault, "zeta.md", "no front matter\n", 2_000);
     sandbox.write_config(&format!(
-        "[note]\nroot = {:?}\neditor = \"echo\"\n",
+        "[note]\nroot = {:?}\neditor = \"echo\"\nlabels = {{ old = [\"archive\"] }}\n",
         vault.display().to_string()
     ));
     vault
@@ -1699,6 +1700,97 @@ fn note_ls_status_carries_the_tags_and_both_dates() {
     // The front matter's creation date, not the file's: this vault was written
     // moments ago.
     assert!(inbox.ends_with("2024-03-01"), "{inbox}");
+
+    // The label its directory carries, which is the point of configuring one.
+    let old = run
+        .lines()
+        .iter()
+        .find(|l| l.starts_with("archive/old.md"))
+        .expect("the archived note")
+        .to_string();
+    assert!(old.contains("old"), "{old}");
+}
+
+/// A directory nothing labelled still names itself, so a vault with two of five
+/// directories labelled does not show three rows saying nothing.
+#[test]
+fn note_ls_status_names_an_unlabelled_directory_after_itself() {
+    let sandbox = Sandbox::new();
+    let vault = sandbox.home().join("notes");
+    mk_note(&vault, "scratch/idea.md", "idea\n", 1_000);
+    sandbox.write_config(&format!(
+        "[note]\nroot = {:?}\n",
+        vault.display().to_string()
+    ));
+
+    let run = sandbox.run(&["note", "ls", "--status"]);
+    run.ok();
+    assert!(run.stdout.contains("scratch"), "{}", run.stdout);
+}
+
+/// `note new` hands the editor a path nobody had to be asked for, and does not
+/// create the file — an abandoned note is one that never existed.
+#[test]
+fn note_new_opens_a_note_it_named_itself() {
+    let sandbox = Sandbox::new();
+    let vault = mk_vault(&sandbox);
+    let run = sandbox.run(&["note", "new"]);
+    run.ok();
+
+    let opened = run
+        .stdout
+        .trim()
+        .strip_prefix("-- ")
+        .expect("a path")
+        .to_string();
+    assert!(opened.starts_with(vault.to_str().unwrap()), "{opened}");
+    assert!(opened.ends_with(".md"), "{opened}");
+    assert!(
+        !Path::new(&opened).exists(),
+        "note new created the file the editor was going to write: {opened}"
+    );
+}
+
+#[test]
+fn note_new_takes_a_name_and_makes_the_directory_it_asks_for() {
+    let sandbox = Sandbox::new();
+    let vault = mk_vault(&sandbox);
+    let run = sandbox.run(&["note", "new", "journal/today"]);
+    run.ok();
+    assert_eq!(
+        run.stdout.trim(),
+        format!("-- {}", vault.join("journal/today.md").display())
+    );
+    assert!(vault.join("journal").is_dir(), "the directory was not made");
+}
+
+/// Two notes started in the same minute is not an error, and neither is one
+/// name typed twice.
+#[test]
+fn note_new_never_hands_back_a_name_already_in_use() {
+    let sandbox = Sandbox::new();
+    let vault = mk_vault(&sandbox);
+    let run = sandbox.run(&["note", "new", "inbox"]);
+    run.ok();
+    assert_eq!(
+        run.stdout.trim(),
+        format!("-- {}", vault.join("inbox-2.md").display())
+    );
+}
+
+/// The search needs ripgrep, and says so rather than opening an empty selector.
+#[test]
+fn note_rg_without_ripgrep_says_what_is_missing() {
+    let sandbox = Sandbox::new();
+    mk_vault(&sandbox);
+    let empty = sandbox.home().join("empty-path");
+    std::fs::create_dir_all(&empty).unwrap();
+    let run = sandbox.run_with_env(
+        &["note", "rg", "anything"],
+        &[("PATH", empty.to_str().unwrap())],
+    );
+    run.code(1);
+    assert!(run.stderr.contains("ripgrep"), "{}", run.stderr);
 }
 
 #[test]
@@ -1762,4 +1854,6 @@ fn config_check_counts_the_notes_in_the_vault() {
     let run = sandbox.run(&["config", "check"]);
     assert!(run.stdout.contains("3 note(s)"), "{}", run.stdout);
     assert!(run.stdout.contains("note editor"), "{}", run.stdout);
+    // `note rg` shells out to it, so the report says whether it is there.
+    assert!(run.stdout.contains("rg"), "{}", run.stdout);
 }


### PR DESCRIPTION
- `[note] labels` names the directories below the vault root, one label to many — the shape and the colours `[repo] labels` uses.
- A directory nothing labelled names itself rather than showing `-`; a note row carries no path beside the label column the way a repository row does.
- A row now leads with the note's name, then one attribute per colour-coded column: label, folders, tags, open tasks, modified, created.
- The dates and the task count are drawn but never matched — typing `3` finds the note you meant, not every note three days old.
- `SelectItem` gains `suffix`, `prefix`'s mirror, which is what makes that possible.
- A column nothing in the vault fills is not drawn at all.
- `scriv note new` starts a note and opens it, asking nothing; the file is left for the editor to write.
- `scriv note rg` searches inside every note as you type, through ripgrep, rebuilt on each keystroke.
- Selected matches become a quickfix list in a vim; any other editor is handed the files.
- `label_colors` moves to `config.rs`, so `work` is one hue across `repo` and `note`.

Cost: `note rg` spawns a ripgrep per keystroke and kills the previous one. The kill is load-bearing — `ReaderControl::kill` busy-waits on a counter, so the counted thread is never the one blocked reading, and `Searching::stop` ends a blocked read from another thread. Without it a held-down key leaves a ripgrep per keystroke running over the whole vault.

Not covered by `tests/cli.rs`: the searching selector needs a terminal, so the collector is driven directly in `src/select.rs` instead — rows, quoting, and the interrupt-while-blocked case.

New outside dependency: `rg`, with a `config check` row. A warning, not a failure — only `note rg` needs it.

Docs: `src/main.rs` help, README (command table, config, requirements, what a row shows) and `CHANGELOG.md` under `## Unreleased`. `docs/demo.gif` is unchanged: the tape never opens a vault, so nothing it records draws differently.