### PR TITLE
Fewer columns, a scratch note, and a search that guesses what you meant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,41 @@ raised, never by hand.
 
 ## Unreleased
 
+### Added
+
+- `scriv note scratch` opens the one permanent note that is filed nowhere —
+  somewhere to put a thought without first deciding whether it is worth a note
+  of its own, and somewhere to find it again afterwards. The same file every
+  time: `[note] scratch`, or `scratch/scratch.md`.
+- `scriv note cleanup` goes through the notes that were never really written
+  and deletes the ones you agree about. Three kinds and no more: a note with
+  nothing in it, one still called `Untitled`, and one whose name has no letters
+  in it and whose front matter gives it no title either. Each row says which it
+  is, the preview shows what is in it, `tab` takes several, and what you chose
+  is printed before you are asked — nothing goes without being seen first.
+- `note rg` now matches fuzzily: the letters you typed, in order, anywhere on
+  the line, so `errhand` finds "error handling". `ctrl-x` searches for the query
+  exactly instead — for a phrase, a path, a snippet of code — and `ctrl-f` goes
+  back. The header says which is in force.
+
+### Changed
+
+- A note row is a date and a name again. The day it was created leads it, in
+  its own colour and never searched, and the name follows tinted by the label
+  its directory carries. The columns of tags, folders and task counts are gone
+  from the row and remain in the preview pane, which has the width for them.
+- `scriv note ls` prints absolute paths, one per line, so the listing pipes
+  into whatever reads paths. `--absolute-paths` is gone with nothing left to
+  do, and `--status` — the listing a person reads rather than a pipe — collapses
+  your home directory to `~` instead of repeating it down every row.
+- `scriv note edit` warns when the note you named is not there, rather than
+  letting the editor open a new empty buffer and say nothing about it.
+
+### Fixed
+
+- The preview pane no longer keeps the last match on screen after the query
+  stops matching anything. It described a note that was no longer in the list.
+
 ## v0.10.0
 
 *Released 2026-08-25*

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ ignore = ["node_modules", "target"]
 [note]
 root = "~/notes"    # an Obsidian vault, or any tree of Markdown files
 editor = "nvim"     # what `note` opens one with; unset, $VISUAL / $EDITOR
+# scratch = "scratch/scratch.md"   # the one note `note scratch` opens
 # labels = { work = ["projects", "clients"], personal = ["journal"] }
 ```
 
@@ -79,7 +80,7 @@ editor = "nvim"     # what `note` opens one with; unset, $VISUAL / $EDITOR
 | --- | --- |
 | `scriv repo` | `ls` `sel` `open` `clone` |
 | `scriv file` | `ls` `sel` `add` `rm` `prune` |
-| `scriv note` | `ls` `sel` `new` `edit` `rg` |
+| `scriv note` | `ls` `sel` `new` `scratch` `edit` `rg` `cleanup` |
 | `scriv branch` | `ls` `sel` `checkout` `rm` |
 | `scriv worktree` | `ls` `sel` `add` `rm` |
 | `scriv pr` | `ls` `sel` `checkout` `open` `merge` |
@@ -89,11 +90,11 @@ editor = "nvim"     # what `note` opens one with; unset, $VISUAL / $EDITOR
 | `scriv config` | `init` `print` `path` `check` |
 | `scriv init` | `fish` and every other shell — see Setup |
 
-A note row leads with what the note calls itself and then says what is true of
-it in a colour-coded column each: the label its directory carries, the folders
-below that, its tags, how many of its tasks are still open, and how long ago it
-was modified and created. `note rg` searches inside every note as you type and
-turns what you pick into a quickfix list.
+A note row is the day it was created and what it calls itself, tinted by the
+label its directory carries; everything else about it is in the preview pane.
+`note rg` searches inside every note as you type — fuzzily, or exactly on
+`ctrl-x` — and turns what you pick into a quickfix list. `note ls` prints
+absolute paths, one per line, for piping into whatever reads paths.
 
 `ls` prints the set, `sel` fuzzy-selects one entry, and the remaining verbs act
 on the selection. `sel` prints to stdout and composes: `cd (scriv repo sel)`.

--- a/src/cmd/config.rs
+++ b/src/cmd/config.rs
@@ -67,6 +67,11 @@ ignore = ["node_modules", "target"]
 # Written inline, on one line, for the reason `[repo] labels` is.
 # labels = { work = ["projects", "clients"], personal = ["journal"] }
 
+# The one permanent note `note scratch` opens — somewhere to put a thought
+# without deciding first whether it is worth a note of its own. A path below
+# the root; its directory is created the first time.
+# scratch = "scratch/scratch.md"
+
 # What `note edit` launches, split on whitespace like $EDITOR. Its own setting
 # because a note is as often read as written — `glow` and `nvim` are both
 # answers. Unset, it is $VISUAL then $EDITOR, as `scriv edit` uses.
@@ -162,6 +167,14 @@ pub fn print(ctx: &Ctx) -> Result<()> {
             println!("  {label}: {}", dirs.join(", "));
         }
     }
+    println!(
+        "scratch: {}",
+        ctx.config
+            .note
+            .scratch
+            .as_deref()
+            .unwrap_or(crate::note::DEFAULT_SCRATCH)
+    );
     println!(
         "editor: {}",
         ctx.note_editor_setting()

--- a/src/cmd/note.rs
+++ b/src/cmd/note.rs
@@ -85,7 +85,8 @@ fn load(ctx: &Ctx) -> Result<Vec<Note>> {
         .info(&format!("{} note(s) under {}", notes.len(), root.display()));
     if notes.is_empty() {
         bail!(
-            "no notes under {} — `scriv note` lists Markdown files",
+            "no notes under {} — `scriv note` reads Markdown files, and \
+             `scriv note new` writes one",
             root.display()
         );
     }
@@ -104,14 +105,10 @@ fn read_note(path: &Path, root: &Path, offset: time::UtcOffset) -> Option<Note> 
     let birth = meta.created().ok().and_then(unix);
 
     let head = read_head(path, HEAD_BYTES).unwrap_or_default();
-    let (block, body) = note::split_front_matter(&head);
+    let (block, _) = note::split_front_matter(&head);
     let front = block.map_or_else(note::Front::default, |block| {
         note::parse_front(block, offset)
     });
-    // Counted from the bytes already read rather than from a second pass: a
-    // note longer than the bound is one whose last checkboxes go uncounted,
-    // which is a number slightly low rather than a vault read twice.
-    let tasks = note::count_tasks(body);
 
     let rel = path
         .strip_prefix(root)
@@ -125,7 +122,6 @@ fn read_note(path: &Path, root: &Path, offset: time::UtcOffset) -> Option<Note> 
         modified,
         created: note::created(front.created, birth, modified),
         front,
-        tasks,
     })
 }
 
@@ -156,18 +152,19 @@ fn unix(time: SystemTime) -> Option<i64> {
 /// Plain, one path below the vault per line, which is the name `note edit`
 /// takes. `--status` adds the tags and both dates; `--absolute-paths` prints
 /// what a pipe can open.
-pub fn ls(ctx: &Ctx, absolute_paths: bool, status: bool) -> Result<()> {
+pub fn ls(ctx: &Ctx, status: bool) -> Result<()> {
     let notes = load(ctx)?;
     let cfg = &ctx.config.note;
-    let widths = Widths::of(&notes, cfg, crate::unix_now());
+    let widths = Widths::of(&notes, cfg, ctx.home_str());
     let offset = ctx.utc_offset();
 
     let mut out = term::Listing::stdout();
     for note in &notes {
-        let row = match (absolute_paths, status) {
-            (true, _) => note.path.display().to_string(),
-            (false, false) => note.rel.clone(),
-            (false, true) => note::status_row(note, cfg, &widths, offset),
+        let row = match status {
+            // Absolute and uncollapsed: the plain listing is what a pipe
+            // reads, and `~` is a thing only a shell expands.
+            false => note.path.to_string_lossy().into_owned(),
+            true => note::status_row(note, cfg, &widths, offset, ctx.home_str()),
         };
         if !out.line(&row)? {
             break;
@@ -197,10 +194,18 @@ pub fn edit(ctx: &Ctx, names: &[String]) -> Result<()> {
         }
     } else {
         let root = vault(ctx)?;
-        names
+        let targets: Vec<String> = names
             .iter()
             .map(|name| resolve(&root, ctx.home(), name))
-            .collect()
+            .collect();
+        // The editor would open a new, empty buffer at a mistyped path and say
+        // nothing about it, which is how a typo becomes a second note.
+        for (name, target) in names.iter().zip(&targets) {
+            if !Path::new(target).exists() {
+                eprintln!("warning: no note called {name} — the editor will open it as a new file");
+            }
+        }
+        targets
     };
 
     if targets.is_empty() {
@@ -230,8 +235,8 @@ fn select_notes(ctx: &Ctx) -> Result<Option<Vec<String>>> {
     }
 }
 
-/// Selector rows: the note's name first, then what is true of it, then the
-/// columns nobody searches for — see [`note::row`] and [`note::suffix`].
+/// Selector rows: the day a note was created, dim and unsearchable, then what
+/// it calls itself — coloured by its label where its directory carries one.
 ///
 /// Every pane is built when its row is highlighted rather than now — see
 /// [`Preview::Deferred`]. A vault read up front is one file read per note for
@@ -239,23 +244,24 @@ fn select_notes(ctx: &Ctx) -> Result<Option<Vec<String>>> {
 fn items(ctx: &Ctx, notes: &[Note]) -> Vec<SelectItem> {
     let now = crate::unix_now();
     let cfg = ctx.config.note.clone();
-    let widths = Widths::of(notes, &cfg, now);
     let offset = ctx.utc_offset();
 
     notes
         .iter()
         .map(|note| {
-            let (label, tints) = note::row(note, &cfg, &widths);
-            let (suffix, suffix_tints) = note::suffix(note, now, &widths);
+            let color = note::row_color(note, &cfg);
             let note = note.clone();
             let cfg = cfg.clone();
-            SelectItem::new(label, note.path.to_string_lossy().into_owned())
-                .tints(tints)
-                .suffix(suffix, suffix_tints)
-                .preview(Preview::Deferred(Box::new(move || {
-                    let text = read_head(&note.path, PREVIEW_BYTES).unwrap_or_default();
-                    note::preview(&note, &cfg, &text, now, offset)
-                })))
+            let item = SelectItem::new(note::row(&note), note.path.to_string_lossy().into_owned())
+                .prefix(note::prefix(&note, offset));
+            let item = match color {
+                Some(color) => item.color(color),
+                None => item,
+            };
+            item.preview(Preview::Deferred(Box::new(move || {
+                let text = read_head(&note.path, PREVIEW_BYTES).unwrap_or_default();
+                note::preview(&note, &cfg, &text, now, offset)
+            })))
         })
         .collect()
 }
@@ -307,6 +313,169 @@ fn with_extension(name: &str) -> String {
     }
 }
 
+/// `scriv note scratch` — open the one note that is filed nowhere.
+///
+/// A single permanent file rather than a new one each time, which is the whole
+/// point: somewhere to put a thought without deciding first whether it is worth
+/// a note, and somewhere to find it again afterwards. `[note] scratch` says
+/// where it lives, `scratch/scratch.md` by default.
+pub fn scratch(ctx: &Ctx) -> Result<()> {
+    let editor = ctx.note_editor()?;
+    let root = vault(ctx)?;
+    let path = root.join(
+        ctx.config
+            .note
+            .scratch
+            .as_deref()
+            .unwrap_or(note::DEFAULT_SCRATCH),
+    );
+
+    if let Some(dir) = path.parent() {
+        std::fs::create_dir_all(dir).with_context(|| format!("creating {}", dir.display()))?;
+    }
+    ctx.log.info(&format!("scratch note at {}", path.display()));
+    cmd::edit::launch(ctx, &editor, &[path.to_string_lossy().into_owned()])
+}
+
+// --- cleanup ----------------------------------------------------------------
+
+/// `scriv note cleanup` — look through the notes that were never really
+/// written, and delete the ones you agree about.
+///
+/// Nothing is deleted without being listed and then agreed to, and the listing
+/// says why each note is on it: three rules, applied without judgement, over a
+/// vault only its owner can actually read.
+pub fn cleanup(ctx: &Ctx, yes: bool) -> Result<()> {
+    let notes = load(ctx)?;
+    let candidates = junk(&notes);
+
+    if candidates.is_empty() {
+        println!(
+            "Nothing to clean up — all {} notes have a name and something in them",
+            notes.len()
+        );
+        return Ok(());
+    }
+    ctx.log.info(&format!(
+        "{} of {} notes are candidates",
+        candidates.len(),
+        notes.len()
+    ));
+
+    let chosen = match select::select_many(
+        junk_items(ctx, &candidates),
+        "Notes to delete (tab to select several)",
+        &ctx.config.selector,
+    ) {
+        Ok(chosen) => chosen,
+        Err(e) if e.is::<select::Cancelled>() => return Ok(()),
+        Err(e) => return Err(e),
+    };
+    if chosen.is_empty() {
+        println!("Nothing selected");
+        return Ok(());
+    }
+
+    // Printed before the question is put: "delete 4 notes?" is answerable only
+    // by someone who has already seen the four.
+    let total: u64 = candidates
+        .iter()
+        .filter(|(note, _, _)| chosen.contains(&note.path.to_string_lossy().into_owned()))
+        .map(|(_, _, bytes)| bytes)
+        .sum();
+    let mut out = term::Listing::stdout();
+    for path in &chosen {
+        if !out.line(&term::paint(path, note::Junk::Empty.color(), ctx.color()))? {
+            return Ok(());
+        }
+    }
+    out.finish()?;
+
+    match term::Confirm::resolve(yes) {
+        term::Confirm::Assumed => {}
+        term::Confirm::Ask => {
+            let question = format!(
+                "Delete {} {} ({})? This cannot be undone",
+                chosen.len(),
+                if chosen.len() == 1 { "note" } else { "notes" },
+                note::size(total),
+            );
+            if !term::confirm(&question)? {
+                println!("Nothing deleted");
+                return Ok(());
+            }
+        }
+        term::Confirm::Impossible => bail!(
+            "no terminal to ask for confirmation on — pass `--yes` to delete without being asked"
+        ),
+    }
+
+    let mut failed = 0;
+    for path in &chosen {
+        match std::fs::remove_file(path) {
+            Ok(()) => println!("Deleted {path}"),
+            Err(err) => {
+                failed += 1;
+                eprintln!("error: {path}: {err}");
+            }
+        }
+    }
+    if failed > 0 {
+        bail!("{failed} of {} could not be deleted", chosen.len());
+    }
+    Ok(())
+}
+
+/// Every note worth offering for deletion, with the reason and its size.
+///
+/// The whole file is read rather than the head bound the listing uses: "empty"
+/// is a claim about all of it, and a note that only looks empty for the first
+/// eight kilobytes is not one.
+fn junk(notes: &[Note]) -> Vec<(Note, note::Junk, u64)> {
+    notes
+        .iter()
+        .filter_map(|note| {
+            let bytes = note.path.metadata().map(|m| m.len()).unwrap_or(0);
+            let text = read_head(&note.path, CLEANUP_BYTES).unwrap_or_default();
+            let (_, body) = note::split_front_matter(&text);
+            note::junk(note, body).map(|reason| (note.clone(), reason, bytes))
+        })
+        .collect()
+}
+
+/// How much of a note is read to decide whether there is anything in it. Well
+/// past [`note::MIN_BODY`], and past any note this could call empty.
+const CLEANUP_BYTES: u64 = 64 * 1024;
+
+fn junk_items(ctx: &Ctx, candidates: &[(Note, note::Junk, u64)]) -> Vec<SelectItem> {
+    let now = crate::unix_now();
+    let cfg = ctx.config.note.clone();
+    let offset = ctx.utc_offset();
+    let widths = Widths::of(
+        &candidates
+            .iter()
+            .map(|(n, _, _)| n.clone())
+            .collect::<Vec<_>>(),
+        &cfg,
+        ctx.home_str(),
+    );
+
+    candidates
+        .iter()
+        .map(|(note, reason, bytes)| {
+            let (label, tints) = note::junk_row(note, *reason, *bytes, &widths);
+            let note = note.clone();
+            let cfg = cfg.clone();
+            SelectItem::new(label, note.path.to_string_lossy().into_owned())
+                .tints(tints)
+                .preview(Preview::Deferred(Box::new(move || {
+                    let text = read_head(&note.path, PREVIEW_BYTES).unwrap_or_default();
+                    note::preview(&note, &cfg, &text, now, offset)
+                })))
+        })
+        .collect()
+}
+
 // --- searching --------------------------------------------------------------
 
 /// The most matches one search hands back.
@@ -340,6 +509,7 @@ pub fn rg(ctx: &Ctx, query: Option<&str>) -> Result<()> {
         searcher(root.clone()),
         "Search notes",
         query.unwrap_or_default(),
+        MODES,
         &ctx.config.selector,
     ) {
         Ok(chosen) => chosen,
@@ -357,10 +527,22 @@ pub fn rg(ctx: &Ctx, query: Option<&str>) -> Result<()> {
     open_matches(ctx, &editor, &matches)
 }
 
+/// How `note rg` reads what is typed, fuzzy first.
+///
+/// Fuzzy is the default because it is what a finder is for: typing `errhand`
+/// should find "error handling", and a search that only matches what was typed
+/// exactly makes the user do the remembering. Exact is the other key for when
+/// the query is a phrase, a path or a snippet of code, where subsequence
+/// matching finds a hundred lines that merely contain the letters.
+const MODES: &[select::Mode] = &[
+    select::Mode::new("ctrl-f", "fuzzy"),
+    select::Mode::new("ctrl-x", "exact"),
+];
+
 /// The closure the selector calls on every keystroke: one ripgrep run per
 /// query, its rows streamed as ripgrep prints them.
 fn searcher(root: PathBuf) -> select::Search {
-    Box::new(move |query: &str| {
+    Box::new(move |query: &str, mode: usize| {
         // An empty pattern matches every line of every note, which is neither
         // an answer nor a cheap question.
         if query.trim().is_empty() {
@@ -369,7 +551,7 @@ fn searcher(root: PathBuf) -> select::Search {
                 stop: Box::new(|| {}),
             };
         }
-        match Search::start(&root, query) {
+        match Search::start(&root, query, Matching::of(mode)) {
             Ok(search) => search.into_searching(),
             // A failed spawn is an empty list: the selector is open and has
             // nowhere to report an error to, and the next keystroke tries
@@ -382,7 +564,61 @@ fn searcher(root: PathBuf) -> select::Search {
     })
 }
 
-/// One ripgrep run, read line by line.
+/// How a query becomes something ripgrep can look for.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Matching {
+    /// The characters of the query, in order, with anything between them.
+    Fuzzy,
+    /// The query, as typed, meaning itself.
+    Exact,
+}
+
+impl Matching {
+    fn of(mode: usize) -> Self {
+        match mode {
+            0 => Self::Fuzzy,
+            _ => Self::Exact,
+        }
+    }
+}
+
+/// The pattern ripgrep is given, and whether it is a regular expression.
+///
+/// Fuzzy is a subsequence: every character of the query, in order, with
+/// anything but a line break allowed between them — which is what a fuzzy
+/// finder means and what ripgrep, having no fuzzy mode of its own, can be asked
+/// for. Whitespace is dropped, so `err hand` and `errhand` look for the same
+/// thing.
+///
+/// Every character is escaped either way. A query is being typed live, so it
+/// spends most of its life as an unfinished regular expression — a lone `(` or
+/// `[` would otherwise make the search fail rather than find nothing.
+fn pattern(query: &str, matching: Matching) -> (String, bool) {
+    match matching {
+        Matching::Exact => (query.to_string(), false),
+        Matching::Fuzzy => {
+            let pattern = query
+                .chars()
+                .filter(|c| !c.is_whitespace())
+                .map(regex_escape)
+                .collect::<Vec<_>>()
+                .join("[^\n]*");
+            (pattern, true)
+        }
+    }
+}
+
+/// One character as a regular expression matching only itself.
+fn regex_escape(c: char) -> String {
+    match c {
+        '.' | '^' | '$' | '*' | '+' | '?' | '(' | ')' | '[' | ']' | '{' | '}' | '|' | '\\' => {
+            format!("\\{c}")
+        }
+        _ => c.to_string(),
+    }
+}
+
+/// One ripgrep run, read line by line./// One ripgrep run, read line by line.
 ///
 /// The child is held behind a mutex the reader never takes, so
 /// [`select::Searching::stop`] can kill it from another thread while this one
@@ -396,7 +632,8 @@ struct Search {
 }
 
 impl Search {
-    fn start(root: &Path, query: &str) -> std::io::Result<Self> {
+    fn start(root: &Path, query: &str, matching: Matching) -> std::io::Result<Self> {
+        let (pattern, is_regex) = pattern(query, matching);
         let mut child = std::process::Command::new("rg")
             .args([
                 "--line-number",
@@ -411,10 +648,17 @@ impl Search {
                 "--glob=*.md",
                 "--glob=*.markdown",
             ])
+            // A fixed string in exact mode, so a query holding `.` or `(`
+            // looks for those characters rather than meaning something by them.
+            .args(if is_regex {
+                &[][..]
+            } else {
+                &["--fixed-strings"][..]
+            })
             // `-e` rather than a bare positional: a query beginning with `-`
             // is a pattern, not a flag, and the user is typing it live.
             .arg("-e")
-            .arg(query)
+            .arg(&pattern)
             .arg("--")
             .arg(root)
             .stdin(std::process::Stdio::null())
@@ -745,5 +989,77 @@ mod tests {
         );
         assert_eq!(resolve(root, home, "/elsewhere/a.md"), "/elsewhere/a.md");
         assert_eq!(resolve(root, home, "~/inbox.md"), "/home/me/inbox.md");
+    }
+}
+
+#[cfg(test)]
+mod search_tests {
+    use super::*;
+
+    /// Typing `errhand` should find "error handling": the letters, in order,
+    /// with anything but a line break between them.
+    #[test]
+    fn a_fuzzy_query_becomes_a_subsequence() {
+        let (pattern, is_regex) = pattern("abc", Matching::Fuzzy);
+        assert_eq!(pattern, "a[^\n]*b[^\n]*c");
+        assert!(is_regex);
+    }
+
+    /// Whitespace is dropped, so `err hand` and `errhand` look for one thing.
+    #[test]
+    fn a_fuzzy_query_ignores_the_spaces_in_it() {
+        assert_eq!(
+            pattern("a b", Matching::Fuzzy).0,
+            pattern("ab", Matching::Fuzzy).0
+        );
+    }
+
+    /// A query is typed live, so it spends most of its life as an unfinished
+    /// regular expression. A lone `(` must find nothing, not fail the search.
+    #[test]
+    fn a_half_typed_query_is_not_a_broken_regex() {
+        for query in ["(", "[a", "a|", "*", "\\"] {
+            let (pattern, _) = pattern(query, Matching::Fuzzy);
+            assert!(
+                regex_is_sane(&pattern),
+                "{query:?} became {pattern:?}, which ripgrep would refuse"
+            );
+        }
+    }
+
+    /// Every metacharacter escaped, and every escape balanced — which is what
+    /// makes the pattern above one ripgrep accepts.
+    fn regex_is_sane(pattern: &str) -> bool {
+        let mut chars = pattern.chars().peekable();
+        let mut depth = 0i32;
+        while let Some(c) = chars.next() {
+            match c {
+                '\\' => {
+                    if chars.next().is_none() {
+                        return false;
+                    }
+                }
+                '[' => depth += 1,
+                ']' => depth -= 1,
+                _ => {}
+            }
+        }
+        depth == 0
+    }
+
+    /// Exact means exact: a query holding `.` or `(` looks for those
+    /// characters rather than meaning something by them.
+    #[test]
+    fn an_exact_query_is_handed_over_untouched() {
+        let (pattern, is_regex) = pattern("a.c(", Matching::Exact);
+        assert_eq!(pattern, "a.c(");
+        assert!(!is_regex, "an exact query would be read as a regex");
+    }
+
+    #[test]
+    fn the_first_mode_is_the_fuzzy_one() {
+        assert_eq!(Matching::of(0), Matching::Fuzzy);
+        assert_eq!(Matching::of(1), Matching::Exact);
+        assert_eq!(MODES[0].label, "fuzzy");
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -205,6 +205,9 @@ pub struct NoteConfig {
     /// Written as an inline table — `labels = { work = ["projects"] }` — for
     /// the reason `[repo] labels` is.
     pub labels: Labels,
+    /// The one permanent note `note scratch` opens, as a path below
+    /// [`Self::root`]. Unset, it is `scratch/scratch.md`.
+    pub scratch: Option<String>,
     /// What `note edit` launches, split on whitespace like `$EDITOR`. Unset, it
     /// is `$VISUAL` then `$EDITOR`.
     ///

--- a/src/main.rs
+++ b/src/main.rs
@@ -376,13 +376,12 @@ impl BranchScope {
 #[derive(Subcommand)]
 enum NoteCmd {
     /// List every note in the vault, most recently modified first
+    ///
+    /// Paths are absolute and one per line, so the listing pipes into whatever
+    /// reads paths — `scriv note ls | xargs grep -l TODO`.
     #[command(visible_alias = "list")]
     Ls {
-        /// Return absolute file paths
-        #[arg(short = 'A', long)]
-        absolute_paths: bool,
-        /// Also show each note's tags, when it was last modified, and when it
-        /// was created
+        /// Also show each note's label, its tags, and both dates
         ///
         /// Modified carries a time of day and created does not: a creation date
         /// may have come from front matter, which names a day.
@@ -407,11 +406,36 @@ enum NoteCmd {
         #[arg(value_name = "NAME")]
         name: Option<String>,
     },
+    /// Open the one permanent scratch note
+    ///
+    /// Somewhere to put a thought without first deciding whether it is worth a
+    /// note of its own, and somewhere to find it again afterwards. The same
+    /// file every time: `[note] scratch`, or `scratch/scratch.md`.
+    Scratch,
+    /// Review the notes that were never really written, and delete them
+    ///
+    /// Offers three kinds and no more: a note with nothing in it, one still
+    /// called `Untitled`, and one whose name has no letters in it and whose
+    /// front matter gives it no title either. Each row says which it is.
+    ///
+    /// Nothing goes without being listed and then agreed to. `tab` selects
+    /// several, the preview shows what is in each, and what you chose is
+    /// printed before the question is asked.
+    Cleanup {
+        /// Delete without asking
+        #[arg(short, long)]
+        yes: bool,
+    },
     /// Search inside every note, as you type
     ///
     /// The query goes to `ripgrep` rather than to the fuzzy matcher, so the
     /// list is every matching *line* in the vault and it is rebuilt on each
     /// keystroke. `ctrl-q` switches to filtering what came back.
+    ///
+    /// Matching is fuzzy — the letters you typed, in order, anywhere on the
+    /// line — so `errhand` finds "error handling". `ctrl-x` searches for the
+    /// query exactly instead, for a phrase or a snippet of code, and `ctrl-f`
+    /// goes back; the header says which is in force.
     ///
     /// `tab` takes several. What you pick opens at its line, and anything else
     /// you picked lands in the quickfix list behind it — which needs a vim; any
@@ -804,14 +828,13 @@ fn run(cli: Cli) -> anyhow::Result<()> {
             EditCmd::Dir { dirs } => cmd::edit::dir(&ctx, &dirs),
         },
         Command::Note { command } => match command {
-            NoteCmd::Ls {
-                absolute_paths,
-                status,
-            } => cmd::note::ls(&ctx, absolute_paths, status),
+            NoteCmd::Ls { status } => cmd::note::ls(&ctx, status),
             NoteCmd::Sel => cmd::note::sel(&ctx),
             NoteCmd::Edit { notes } => cmd::note::edit(&ctx, &notes),
             NoteCmd::New { name } => cmd::note::new(&ctx, name.as_deref()),
             NoteCmd::Rg { query } => cmd::note::rg(&ctx, query.as_deref()),
+            NoteCmd::Scratch => cmd::note::scratch(&ctx),
+            NoteCmd::Cleanup { yes } => cmd::note::cleanup(&ctx, yes),
         },
         Command::Branch { command } => match command {
             BranchCmd::Ls { status, scope } => {

--- a/src/note.rs
+++ b/src/note.rs
@@ -27,11 +27,10 @@ const FOLDER_COLOR: u8 = 4;
 const TAG_COLOR: u8 = 5;
 const OPEN_COLOR: u8 = 3;
 
-/// The task column's two glyphs: how many are left, or that none are. Shapes
-/// rather than colour alone, so the column still says something where the
-/// terminal's palette does not.
-const OPEN_TASK: &str = "\u{2610}";
-const ALL_DONE: &str = "\u{2713}";
+/// The colour of a group that is a bare directory name rather than a configured
+/// label: the terminal's own grey, since an unlabelled directory is context
+/// rather than a statement.
+const UNLABELLED_COLOR: u8 = 8;
 
 /// What a note's front matter said about it.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -63,7 +62,6 @@ pub struct Note {
     /// Created, in Unix seconds. See [`created`].
     pub created: i64,
     pub front: Front,
-    pub tasks: Tasks,
 }
 
 /// The checkboxes in a note's body: how much of what it asked for is done.
@@ -81,15 +79,6 @@ pub struct Tasks {
 impl Tasks {
     pub fn total(self) -> usize {
         self.open + self.done
-    }
-
-    /// The column: how many are left, or a tick once none are.
-    fn column(self) -> String {
-        match (self.open, self.done) {
-            (0, 0) => String::new(),
-            (0, _) => ALL_DONE.to_string(),
-            (open, _) => format!("{open}{OPEN_TASK}"),
-        }
     }
 
     fn color(self) -> u8 {
@@ -188,6 +177,17 @@ impl Note {
             Some(at) => &below[..at],
             None => "",
         }
+    }
+
+    /// The path a *report* shows: absolute, with the home directory collapsed
+    /// to `~`.
+    ///
+    /// `note ls` prints the path itself, uncollapsed, because it is read by
+    /// whatever the listing is piped into. `--status` is read by a person, and
+    /// a vault under `$HOME` repeats the same twenty characters down the left
+    /// of every row otherwise.
+    pub fn shown(&self, home: &str) -> String {
+        crate::path::display_path(&self.path.to_string_lossy(), home, false)
     }
 
     /// The tags column: every tag, `#`-prefixed, space-separated.
@@ -466,162 +466,77 @@ fn local(when: i64, offset: time::UtcOffset) -> Option<time::OffsetDateTime> {
 /// list so the columns line up.
 ///
 /// Counted in characters, not bytes: `{:<width$}` pads by character count, so a
-/// byte length would over-pad a title with an accent in it. A column measuring
-/// zero is one nothing in this vault fills, and is left out of the row rather
-/// than padded — a vault with no labels and no tags spends its width on names.
+/// byte length would over-pad a title with an accent in it.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct Widths {
     pub title: usize,
     pub group: usize,
-    pub folder: usize,
     pub tags: usize,
-    pub tasks: usize,
-    pub modified: usize,
-    pub created: usize,
-    pub rel: usize,
+    pub path: usize,
 }
 
 impl Widths {
-    pub fn of(notes: &[Note], cfg: &crate::config::NoteConfig, now: i64) -> Self {
+    pub fn of(notes: &[Note], cfg: &crate::config::NoteConfig, home: &str) -> Self {
         let widest = |f: &dyn Fn(&Note) -> usize| notes.iter().map(f).max().unwrap_or(0);
         Self {
             title: widest(&|n| n.title().chars().count()),
             group: widest(&|n| n.group(cfg).chars().count()),
-            folder: widest(&|n| n.folder(cfg).chars().count()),
             tags: widest(&|n| n.tag_column().chars().count()),
-            tasks: widest(&|n| n.tasks.column().chars().count()),
-            modified: widest(&|n| age(now, n.modified).chars().count()),
-            created: widest(&|n| age(now, n.created).chars().count()),
-            rel: widest(&|n| n.rel.chars().count()),
+            path: widest(&|n| n.shown(home).chars().count()),
         }
     }
 }
 
-/// One selector row: what the note calls itself first, then what is true of it.
+/// The dim column ahead of a selector row: the day the note was created.
 ///
-/// The name leads because it is what is being looked for and what the query
-/// matches; everything after it is an attribute, in a column of its own, in a
-/// colour that says which attribute it is — the group cyan or green where it is
-/// a configured label and grey where it is a bare directory name, the folder
-/// blue as a path is everywhere, the tags magenta.
-///
-/// The row and its colours are built together because a tint is a character
-/// range into the row, and counting those ranges out a second time is how they
-/// drift.
-///
-/// Not padded to the full width: what follows on the row is
-/// [`suffix`], and a row's trailing columns are only worth aligning when
-/// something is drawn in them.
-pub fn row(note: &Note, cfg: &crate::config::NoteConfig, widths: &Widths) -> (String, Vec<Tint>) {
-    let mut row = String::new();
-    let mut tints = Vec::new();
-    let mut column = |row: &mut String, text: &str, width: usize, color: Option<u8>| {
-        if width == 0 {
-            return;
-        }
-        if !row.is_empty() {
-            row.push_str(COLUMN_GAP);
-        }
-        let at = row.chars().count();
-        push_column(row, text, width);
-        if let Some(color) = color.filter(|_| !text.is_empty()) {
-            tints.push(Tint {
-                range: at..at + text.chars().count(),
-                color,
-            });
-        }
-    };
+/// A [`crate::select::SelectItem::prefix`] rather than part of the label, so it
+/// is drawn in its own colour and — the reason it is not simply a column —
+/// never matched: typed into the search box, `2024` would otherwise rank a
+/// year's worth of notes above the one being looked for.
+pub fn prefix(note: &Note, offset: time::UtcOffset) -> String {
+    format!("{}  ", date(note.created, offset))
+}
 
-    column(&mut row, note.title(), widths.title, None);
-    // A bare directory name is grey and a label is its own colour, so the
-    // column says whether it was configured as well as what it holds.
-    let group_color = note
-        .labelled(cfg)
+/// One selector row: what the note calls itself, and nothing else.
+///
+/// Everything a note *is* — where it is filed, what it is tagged, how much of
+/// it is done — is in the preview pane, which has the width for it and is one
+/// keystroke away. A row is for telling one note from another at a glance, and
+/// six columns of attributes is a worse way to do that than a name and a date.
+///
+/// The row takes its group's colour where it has one, the way a repository row
+/// does, so a label is still read off the list without costing a column.
+pub fn row(note: &Note) -> String {
+    note.title().to_string()
+}
+
+/// The colour the whole row is drawn in: its label's, or the terminal's own
+/// foreground where its directory carries none.
+pub fn row_color(note: &Note, cfg: &crate::config::NoteConfig) -> Option<u8> {
+    note.labelled(cfg)
         .then(|| cfg.color_of(note.group(cfg)))
         .flatten()
-        .or(Some(UNLABELLED_COLOR));
-    column(&mut row, note.group(cfg), widths.group, group_color);
-    column(
-        &mut row,
-        note.folder(cfg),
-        widths.folder,
-        Some(FOLDER_COLOR),
-    );
-    column(&mut row, &note.tag_column(), widths.tags, Some(TAG_COLOR));
-
-    // Deliberately not trimmed: [`suffix`] is drawn straight after this, and a
-    // row whose columns were trimmed away would start its dates wherever its
-    // own text happened to stop.
-    (row, tints)
 }
 
-/// The columns drawn after the label and not matched against: how much of the
-/// note is still owed, then how long ago it was modified and created.
+/// One `note ls --status` row: the note's absolute path, its group, its tags,
+/// and both dates.
 ///
-/// Behind the label rather than ahead of it, because the name is what a note
-/// list is read down. Outside the label because none of it is what anybody
-/// searches for — matched, a query of `3` would rank every note that is three
-/// days old above the one being looked for.
-///
-/// Every row's is the same width, so the columns line up however narrow the
-/// name column turned out.
-pub fn suffix(note: &Note, now: i64, widths: &Widths) -> (String, Vec<Tint>) {
-    let mut suffix = String::new();
-    let mut tints = Vec::new();
-
-    if widths.tasks > 0 {
-        suffix.push_str(COLUMN_GAP);
-        let tasks = note.tasks.column();
-        let at = suffix.chars().count() + widths.tasks - tasks.chars().count();
-        // Right-aligned: the glyph is the fixed part and the count grows to
-        // the left of it.
-        for _ in tasks.chars().count()..widths.tasks {
-            suffix.push(' ');
-        }
-        suffix.push_str(&tasks);
-        if !tasks.is_empty() {
-            tints.push(Tint {
-                range: at..suffix.chars().count(),
-                color: note.tasks.color(),
-            });
-        }
-    }
-
-    suffix.push_str(COLUMN_GAP);
-    push_right(&mut suffix, &age(now, note.modified), widths.modified);
-    suffix.push(' ');
-    push_right(&mut suffix, &age(now, note.created), widths.created);
-
-    (suffix, tints)
-}
-
-/// Between two columns. Two spaces, everywhere, so a row reads as columns
-/// rather than as a sentence.
-const COLUMN_GAP: &str = "  ";
-
-/// The colour of a group column holding a bare directory name: the terminal's
-/// own grey, as [`crate::select::SelectItem::prefix`] uses, since an unlabelled
-/// directory is context rather than a statement.
-const UNLABELLED_COLOR: u8 = 8;
-
-/// One `note ls --status` row: the note's name, its group, its tags, how many
-/// tasks are open, and both dates.
-///
-/// The path comes first, so the plain listing is a prefix of this one. Modified
-/// carries a time of day and created does not: a created date may have come
-/// from front matter, which names a day.
+/// The path comes first, with the home directory collapsed to `~` — this is
+/// the listing a person reads, where `note ls` on its own is the one a pipe
+/// does. Modified carries a time of day and created does not: a created date
+/// may have come from front matter, which names a day.
 pub fn status_row(
     note: &Note,
     cfg: &crate::config::NoteConfig,
     widths: &Widths,
     offset: time::UtcOffset,
+    home: &str,
 ) -> String {
     let mut row = String::new();
-    push_column(&mut row, &note.rel, widths.rel);
+    push_column(&mut row, &note.shown(home), widths.path);
     for (text, width) in [
         (note.group(cfg).to_string(), widths.group),
         (note.tag_column(), widths.tags),
-        (note.tasks.column(), widths.tasks),
     ] {
         if width > 0 {
             row.push_str(COLUMN_GAP);
@@ -635,20 +550,16 @@ pub fn status_row(
     row.trim_end().to_string()
 }
 
+/// Between two columns. Two spaces, everywhere, so a row reads as columns
+/// rather than as a sentence.
+const COLUMN_GAP: &str = "  ";
+
 /// Append `text` and pad it out to `width` characters.
 fn push_column(row: &mut String, text: &str, width: usize) {
     row.push_str(text);
     for _ in text.chars().count()..width {
         row.push(' ');
     }
-}
-
-/// Append `text` padded to `width` characters on its left.
-fn push_right(row: &mut String, text: &str, width: usize) {
-    for _ in text.chars().count()..width {
-        row.push(' ');
-    }
-    row.push_str(text);
 }
 
 /// Order a vault: most recently modified first, then by path so notes written
@@ -721,6 +632,7 @@ pub fn preview(
     out.push_str(&paint(&crate::term::one_row(&note.rel), DIM));
     out.push('\n');
 
+    let (_, body) = split_front_matter(text);
     let group = note.group(cfg);
     let mut facts = Vec::new();
     if !group.is_empty() {
@@ -734,12 +646,13 @@ pub fn preview(
     if !tags.is_empty() {
         facts.push(paint(&crate::term::one_row(&tags), TAG_COLOR));
     }
-    // Spelled out rather than left as the row's glyph and a number, which is
-    // the pane's job: it has the width the column did not.
-    if note.tasks.total() > 0 {
+    // Counted here rather than carried on every note: this is the only place
+    // it is shown, and the text it is counted from has just been read anyway.
+    let tasks = count_tasks(body);
+    if tasks.total() > 0 {
         facts.push(paint(
-            &format!("{} of {} done", note.tasks.done, note.tasks.total()),
-            note.tasks.color(),
+            &format!("{} of {} done", tasks.done, tasks.total()),
+            tasks.color(),
         ));
     }
     if !facts.is_empty() {
@@ -759,7 +672,6 @@ pub fn preview(
     ));
     out.push('\n');
 
-    let (_, body) = split_front_matter(text);
     let mut fenced = false;
     for line in body
         .lines()
@@ -933,7 +845,6 @@ mod tests {
             modified: 0,
             created: 0,
             front,
-            tasks: Tasks::default(),
         }
     }
 
@@ -944,7 +855,7 @@ mod tests {
         crate::config::NoteConfig {
             root: Some("/vault".into()),
             labels,
-            editor: None,
+            ..crate::config::NoteConfig::default()
         }
     }
 
@@ -1166,7 +1077,6 @@ mod tests {
             Note {
                 modified: 3 * DAY,
                 created: 400 * DAY,
-                tasks: Tasks { open: 2, done: 5 },
                 ..note(
                     "work/meetings/standup.md",
                     Front {
@@ -1188,29 +1098,45 @@ mod tests {
         ]
     }
 
-    fn rows(notes: &[Note]) -> Vec<String> {
-        let cfg = config();
-        let widths = Widths::of(notes, &cfg, 0);
-        notes.iter().map(|n| row(n, &cfg, &widths).0).collect()
-    }
-
-    /// The name is what the eye runs down and what the query matches, so it
-    /// leads; everything after it is an attribute in a column of its own.
+    /// A row is a name and nothing else. Everything a note *is* lives in the
+    /// preview pane, which has the width for it.
     #[test]
-    fn a_row_leads_with_the_note_name() {
-        for row in rows(&vault()) {
-            let first = row.split_whitespace().next().unwrap_or_default();
-            assert!(
-                ["standup", "idea", "inbox"].contains(&first),
-                "a row does not open with its name: {row:?}"
-            );
-        }
+    fn a_row_is_what_the_note_calls_itself() {
+        let rows: Vec<String> = vault().iter().map(row).collect();
+        assert_eq!(rows, vec!["standup", "idea", "inbox"]);
     }
 
-    /// A labelled directory shows its label; an unlabelled one shows itself,
-    /// rather than the `-` a repository row would carry. A vault of five
-    /// directories with two labelled would otherwise show three rows saying
-    /// nothing.
+    /// The date is drawn in its own colour ahead of the name, and outside what
+    /// the query matches — typed, `2024` would otherwise rank a year of notes
+    /// above the one being looked for.
+    #[test]
+    fn the_created_date_leads_the_row_without_being_searched() {
+        let notes = vault();
+        assert_eq!(prefix(&notes[0], utc()), "1971-02-05  ");
+        assert!(!row(&notes[0]).contains("1971"));
+    }
+
+    /// Every prefix is the same width, so the names line up under each other.
+    #[test]
+    fn every_date_column_is_the_same_width() {
+        let widths: Vec<usize> = vault()
+            .iter()
+            .map(|n| prefix(n, utc()).chars().count())
+            .collect();
+        assert!(widths.windows(2).all(|w| w[0] == w[1]), "{widths:?}");
+    }
+
+    /// A label still reads off the list without costing a column, the way a
+    /// repository row carries its own.
+    #[test]
+    fn a_labelled_note_takes_its_labels_colour_and_an_unlabelled_one_takes_none() {
+        let cfg = config();
+        let notes = vault();
+        assert_eq!(row_color(&notes[0], &cfg), cfg.color_of("work"));
+        assert_eq!(row_color(&notes[1], &cfg), None);
+        assert_eq!(row_color(&notes[2], &cfg), None);
+    }
+
     #[test]
     fn the_group_column_is_the_label_or_the_directory_that_has_none() {
         let cfg = config();
@@ -1222,39 +1148,17 @@ mod tests {
         assert_eq!(notes[2].group(&cfg), "");
     }
 
-    /// Between them, the group and folder columns spell out a note's path
-    /// exactly once: a label names no directory, so the whole path is still
-    /// news; a bare directory name is already drawn, so only what is below it
-    /// is.
+    /// `ls` is read by other tools, so the path it prints is one they can open.
     #[test]
-    fn the_group_and_folder_columns_spell_the_path_out_once() {
+    fn a_status_row_leads_with_a_readable_path_and_ends_with_both_dates() {
         let cfg = config();
         let notes = vault();
-        // `work` is a label, so the directory it labels is still worth drawing.
-        assert_eq!(notes[0].folder(&cfg), "work/meetings");
-        // `scratch` is the directory itself, one column to the left already.
-        assert_eq!(notes[1].folder(&cfg), "");
-        assert_eq!(notes[2].folder(&cfg), "");
-    }
-
-    /// Columns are the whole point: a name one character longer must not shift
-    /// the group on every other row.
-    #[test]
-    fn the_columns_line_up_across_the_whole_list() {
-        let cfg = config();
-        let notes = vault();
-        let widths = Widths::of(&notes, &cfg, 0);
-        for (row, note) in rows(&notes).iter().zip(&notes) {
-            let group = note.group(&cfg);
-            if group.is_empty() {
-                continue;
-            }
-            let after_name: String = row.chars().skip(widths.title + COLUMN_GAP.len()).collect();
-            assert!(
-                after_name.starts_with(group),
-                "the group column moved: {row:?}"
-            );
-        }
+        let widths = Widths::of(&notes, &cfg, "/vault");
+        let row = status_row(&notes[0], &cfg, &widths, utc(), "/vault");
+        assert!(row.starts_with("~/work/meetings/standup.md"), "{row:?}");
+        assert!(row.contains("work"), "{row:?}");
+        assert!(row.contains("#daily"), "{row:?}");
+        assert!(row.ends_with("1971-02-05"), "{row:?}");
     }
 
     #[test]
@@ -1263,123 +1167,10 @@ mod tests {
             note("café.md", Front::default()),
             note("a.md", Front::default()),
         ];
-        let widths = Widths::of(&notes, &config(), 0);
-        assert_eq!(widths.title, "café".chars().count());
-    }
-
-    /// A column nothing in this vault fills is left out rather than padded, so
-    /// a vault with no labels and no tags spends its width on names.
-    #[test]
-    fn an_empty_column_is_not_drawn_at_all() {
-        let notes = vec![
-            note("a.md", Front::default()),
-            note("b.md", Front::default()),
-        ];
-        let cfg = crate::config::NoteConfig::default();
-        let widths = Widths::of(&notes, &cfg, 0);
-        assert_eq!(widths.group, 0);
-        assert_eq!(widths.tags, 0);
-        assert_eq!(row(&notes[0], &cfg, &widths).0, "a");
-    }
-
-    #[test]
-    fn a_row_tints_each_attribute_and_leaves_the_name_alone() {
-        let cfg = config();
-        let notes = vault();
-        let widths = Widths::of(&notes, &cfg, 0);
-        let (label, tints) = row(&notes[0], &cfg, &widths);
-        let text = |tint: &Tint| -> String {
-            label
-                .chars()
-                .skip(tint.range.start)
-                .take(tint.range.len())
-                .collect()
-        };
-        let drawn: Vec<(String, u8)> = tints.iter().map(|t| (text(t), t.color)).collect();
-        assert_eq!(drawn[0].0, "work");
-        assert_eq!(drawn[1], ("work/meetings".to_string(), FOLDER_COLOR));
-        assert_eq!(drawn[2], ("#daily".to_string(), TAG_COLOR));
-        assert!(
-            !tints.iter().any(|t| t.range.start == 0),
-            "the name is tinted, and skim's match highlight has to win: {drawn:?}"
+        assert_eq!(
+            Widths::of(&notes, &config(), "/vault").title,
+            "café".chars().count()
         );
-    }
-
-    /// An unlabelled directory is context rather than a statement, so it is
-    /// grey where a configured label takes its own hue.
-    #[test]
-    fn a_bare_directory_name_is_not_coloured_like_a_label() {
-        let cfg = config();
-        let notes = vault();
-        let widths = Widths::of(&notes, &cfg, 0);
-        let color_of = |n: &Note| row(n, &cfg, &widths).1.first().map(|t| t.color);
-        assert_eq!(color_of(&notes[1]), Some(UNLABELLED_COLOR));
-        assert_ne!(color_of(&notes[0]), Some(UNLABELLED_COLOR));
-    }
-
-    /// The dates and the task count sit behind the name and outside what the
-    /// query matches — typed, `3` must not rank every three-day-old note above
-    /// the one being looked for.
-    #[test]
-    fn the_suffix_holds_what_nobody_searches_for() {
-        let cfg = config();
-        let notes = vault();
-        let widths = Widths::of(&notes, &cfg, 3 * DAY);
-        let (label, _) = row(&notes[0], &cfg, &widths);
-        let (suffix, _) = suffix(&notes[0], 3 * DAY, &widths);
-        assert!(suffix.contains("now"), "{suffix:?}");
-        assert!(suffix.contains(OPEN_TASK), "{suffix:?}");
-        assert!(!label.contains("now"), "{label:?}");
-        assert!(!label.contains(OPEN_TASK), "{label:?}");
-    }
-
-    #[test]
-    fn every_suffix_is_the_same_width() {
-        let cfg = config();
-        let notes = vault();
-        let widths = Widths::of(&notes, &cfg, 10 * YEAR);
-        let widths_drawn: Vec<usize> = notes
-            .iter()
-            .map(|n| suffix(n, 10 * YEAR, &widths).0.chars().count())
-            .collect();
-        assert!(
-            widths_drawn.windows(2).all(|w| w[0] == w[1]),
-            "{widths_drawn:?}"
-        );
-    }
-
-    #[test]
-    fn a_note_with_tasks_left_reads_differently_from_one_without() {
-        assert_eq!(Tasks { open: 0, done: 0 }.column(), "");
-        assert_eq!(Tasks { open: 0, done: 3 }.column(), ALL_DONE);
-        assert_eq!(Tasks { open: 2, done: 3 }.column(), format!("2{OPEN_TASK}"));
-        assert_eq!(Tasks { open: 0, done: 3 }.color(), DONE_COLOR);
-        assert_eq!(Tasks { open: 2, done: 3 }.color(), OPEN_COLOR);
-    }
-
-    #[test]
-    fn tasks_are_counted_from_the_body() {
-        let counted = count_tasks("- [ ] a\n* [x] b\n  + [X] c\n- not a task\n1. [ ] d\n");
-        assert_eq!(counted, Tasks { open: 2, done: 2 });
-    }
-
-    /// A checkbox inside a fence is an example of one, not one.
-    #[test]
-    fn a_task_in_a_code_fence_is_not_counted() {
-        let counted = count_tasks("- [ ] real\n```md\n- [ ] example\n```\n");
-        assert_eq!(counted, Tasks { open: 1, done: 0 });
-    }
-
-    #[test]
-    fn a_status_row_leads_with_the_path_and_ends_with_both_dates() {
-        let cfg = config();
-        let notes = vault();
-        let widths = Widths::of(&notes, &cfg, 0);
-        let row = status_row(&notes[0], &cfg, &widths, utc());
-        assert!(row.starts_with("work/meetings/standup.md"), "{row:?}");
-        assert!(row.contains("work"), "{row:?}");
-        assert!(row.contains("#daily"), "{row:?}");
-        assert!(row.ends_with("1971-02-05"), "{row:?}");
     }
 
     #[test]
@@ -1397,6 +1188,90 @@ mod tests {
         for name in ["a.png", "a.canvas", "a", "a.md.bak"] {
             assert!(!is_note(Path::new(name)), "{name}");
         }
+    }
+
+    #[test]
+    fn tasks_are_counted_from_the_body() {
+        let counted = count_tasks("- [ ] a\n* [x] b\n  + [X] c\n- not a task\n1. [ ] d\n");
+        assert_eq!(counted, Tasks { open: 2, done: 2 });
+    }
+
+    /// A checkbox inside a fence is an example of one, not one.
+    #[test]
+    fn a_task_in_a_code_fence_is_not_counted() {
+        let counted = count_tasks("- [ ] real\n```md\n- [ ] example\n```\n");
+        assert_eq!(counted, Tasks { open: 1, done: 0 });
+    }
+
+    // --- cleanup ---
+
+    fn body_of(len: usize) -> String {
+        "word ".repeat(len)
+    }
+
+    #[test]
+    fn a_note_with_nothing_in_it_is_a_candidate() {
+        let note = note("thoughts.md", Front::default());
+        assert_eq!(junk(&note, ""), Some(Junk::Empty));
+        assert_eq!(junk(&note, "# Thoughts\n"), Some(Junk::Empty));
+        assert_eq!(junk(&note, &body_of(20)), None);
+    }
+
+    /// What an editor calls a file nobody named, and everything it goes on to
+    /// call the next one.
+    #[test]
+    fn an_untitled_note_is_a_candidate_however_it_is_numbered() {
+        for name in [
+            "Untitled.md",
+            "untitled 1.md",
+            "Untitled-2.md",
+            "untitled_3.md",
+        ] {
+            let note = note(name, Front::default());
+            assert_eq!(junk(&note, &body_of(20)), Some(Junk::Untitled), "{name}");
+        }
+        // Not every name that begins with the word.
+        for name in ["Untitled thoughts.md", "untitledness.md"] {
+            let note = note(name, Front::default());
+            assert_eq!(junk(&note, &body_of(20)), None, "{name}");
+        }
+    }
+
+    /// A name with no letters in it is a timestamp somebody meant to replace —
+    /// unless the front matter names the note, in which case it has a name.
+    #[test]
+    fn a_note_named_only_by_numbers_is_a_candidate_unless_it_says_otherwise() {
+        let jotted = note("2026-08-25 1043.md", Front::default());
+        assert_eq!(junk(&jotted, &body_of(20)), Some(Junk::Unnamed));
+
+        let titled = note(
+            "2026-08-25 1043.md",
+            Front {
+                title: Some("Bank call".into()),
+                ..Front::default()
+            },
+        );
+        assert_eq!(junk(&titled, &body_of(20)), None);
+    }
+
+    /// The reason is what the list is read for, so it leads and it is coloured.
+    #[test]
+    fn a_cleanup_row_says_why_the_note_is_on_the_list() {
+        let notes = vault();
+        let widths = Widths::of(&notes, &config(), "/home/me");
+        let (row, tints) = junk_row(&notes[0], Junk::Empty, 0, &widths);
+        assert!(row.starts_with("empty"), "{row:?}");
+        assert!(row.contains("work/meetings/standup.md"), "{row:?}");
+        assert!(row.ends_with("empty"), "{row:?}");
+        assert_eq!(tints[0].range, 0.."empty".len());
+        assert_eq!(tints[0].color, Junk::Empty.color());
+    }
+
+    #[test]
+    fn a_size_is_read_rather_than_counted() {
+        assert_eq!(size(0), "empty");
+        assert_eq!(size(512), "512 B");
+        assert_eq!(size(4096), "4 KB");
     }
 
     // --- preview ---
@@ -1862,3 +1737,127 @@ mod search_tests {
         time::UtcOffset::UTC
     }
 }
+
+// --- cleanup ----------------------------------------------------------------
+
+/// Why a note is worth a second look before it is kept.
+///
+/// The three shapes a note takes when it was never really written: one that was
+/// started and abandoned, one the editor named because nobody did, and one
+/// whose name is a timestamp somebody meant to replace.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Junk {
+    /// Nothing in it, or so little that nothing was said.
+    Empty,
+    /// Called `Untitled`, which is what an editor calls a file nobody named.
+    Untitled,
+    /// Named without a letter in it — a date, a clock reading, a number — and
+    /// carrying no front matter title either.
+    Unnamed,
+}
+
+impl Junk {
+    /// What the row says about it, in a couple of words.
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Empty => "empty",
+            Self::Untitled => "untitled",
+            Self::Unnamed => "no name",
+        }
+    }
+
+    /// Red for a note with nothing in it, yellow for one that has content and
+    /// only wants a name — the second is a judgement and the first is not.
+    pub fn color(self) -> u8 {
+        match self {
+            Self::Empty => 1,
+            Self::Untitled | Self::Unnamed => 3,
+        }
+    }
+}
+
+/// How little a body can hold before there is nothing in the note.
+///
+/// Counted in non-whitespace characters after the front matter, so a note that
+/// is a heading and nothing else — the shape a note takes when it was opened,
+/// titled and abandoned — is under it.
+const MIN_BODY: usize = 24;
+
+/// Whether `note` is worth offering for deletion, and why.
+///
+/// Deliberately three rules and no more. Anything cleverer — a note nothing
+/// links to, a note nothing has opened in a year — is a judgement about what
+/// the vault is *for*, and this is a list to look through rather than a verdict.
+pub fn junk(note: &Note, body: &str) -> Option<Junk> {
+    if body.chars().filter(|c| !c.is_whitespace()).count() < MIN_BODY {
+        return Some(Junk::Empty);
+    }
+    let name = stem(&note.rel);
+    if is_untitled(name) {
+        return Some(Junk::Untitled);
+    }
+    // A front matter title is a name, wherever the file's own name came from.
+    if note.front.title.is_none() && !name.chars().any(char::is_alphabetic) {
+        return Some(Junk::Unnamed);
+    }
+    None
+}
+
+/// Whether a name is the one an editor gives a file nobody named: `Untitled`,
+/// and the `Untitled 1`, `untitled-2` it goes on to.
+fn is_untitled(name: &str) -> bool {
+    let rest = match name.len() >= UNTITLED.len()
+        && name[..UNTITLED.len()].eq_ignore_ascii_case(UNTITLED)
+    {
+        true => &name[UNTITLED.len()..],
+        false => return false,
+    };
+    rest.chars()
+        .all(|c| c.is_ascii_digit() || c == ' ' || c == '-' || c == '_')
+}
+
+const UNTITLED: &str = "untitled";
+
+/// One row of the cleanup selector: why it is here, then where it is.
+///
+/// The reason leads because it is what the list is being read for — the same
+/// three words over and over, which is exactly what makes the odd one out
+/// visible.
+pub fn junk_row(note: &Note, reason: Junk, bytes: u64, widths: &Widths) -> (String, Vec<Tint>) {
+    let label = reason.label();
+    let mut row = String::new();
+    push_column(&mut row, label, JUNK_REASON_WIDTH);
+    row.push_str(COLUMN_GAP);
+    push_column(
+        &mut row,
+        &note.rel,
+        widths.title.max(note.rel.chars().count()),
+    );
+    row.push_str(COLUMN_GAP);
+    row.push_str(&size(bytes));
+
+    let tints = vec![Tint {
+        range: 0..label.chars().count(),
+        color: reason.color(),
+    }];
+    (row.trim_end().to_string(), tints)
+}
+
+/// Wide enough for the longest of [`Junk::label`], so the paths line up.
+const JUNK_REASON_WIDTH: usize = 8;
+
+/// A file size a person reads rather than counts.
+pub fn size(bytes: u64) -> String {
+    match bytes {
+        0 => "empty".to_string(),
+        b if b < 1024 => format!("{b} B"),
+        b => format!("{} KB", b / 1024),
+    }
+}
+
+// --- the scratch note -------------------------------------------------------
+
+/// Where the scratch note lives when nothing says otherwise: its own directory,
+/// so a vault that files everything by folder has somewhere obvious to put the
+/// one note that is filed nowhere.
+pub const DEFAULT_SCRATCH: &str = "scratch/scratch.md";

--- a/src/select.rs
+++ b/src/select.rs
@@ -344,6 +344,7 @@ pub fn select_one_queried(
         query,
         reload: None,
         search: None,
+        modes: &[],
         actions: &[],
     };
     run_selector(Feed::batch(items), run, cfg)?
@@ -417,6 +418,7 @@ pub fn select_one_reloading(
         query: "",
         reload: Some(reload),
         search: None,
+        modes: &[],
         actions,
     };
     chosen(run_selector(Feed::batch(items), run, cfg)?)
@@ -435,6 +437,7 @@ pub fn select_one_acting(
         query: "",
         reload: None,
         search: None,
+        modes: &[],
         actions,
     };
     chosen(run_selector(Feed::batch(items), run, cfg)?)
@@ -520,9 +523,37 @@ pub struct Searching {
     pub stop: Box<dyn Fn() + Send + Sync>,
 }
 
-/// Produces the rows for a query. Called afresh on every keystroke, on a
-/// background thread, so it may block for as long as the search takes.
-pub type Search = Box<dyn FnMut(&str) -> Searching + Send>;
+/// Produces the rows for a query, in the manner `mode` names. Called afresh on
+/// every keystroke, on a background thread, so it may block for as long as the
+/// search takes.
+pub type Search = Box<dyn FnMut(&str, usize) -> Searching + Send>;
+
+/// One way a [`Search`] can read the query, offered on a key of its own.
+///
+/// Two keys rather than one that toggles, because a header cannot be made to
+/// alternate: skim's `set-header` writes a fixed string, and a binding that
+/// rebinds itself to the opposite mode would have to contain its own text.
+/// Deliberate keys also cost the same one keystroke and never leave a doubt
+/// about which mode is in force — which is the thing the header is for.
+pub struct Mode {
+    /// skim's spelling of the key — `ctrl-f`.
+    pub key: &'static str,
+    /// What the header calls it, once chosen.
+    pub label: &'static str,
+}
+
+impl Mode {
+    pub const fn new(key: &'static str, label: &'static str) -> Self {
+        Self { key, label }
+    }
+}
+
+/// The marker a mode key's reload puts in front of the query, so the collector
+/// can tell "search again in mode 2" from "the query changed".
+///
+/// A control character: skim expands the query into this template, and anything
+/// a user could type would be a query somebody means.
+const MODE_MARKER: char = '\u{2}';
 
 /// How many rows to hand skim at once, and how long the counted thread waits
 /// on the producer before looking up to see whether it has been called off.
@@ -548,10 +579,30 @@ fn unquote(quoted: &str) -> String {
     inner.replace(r"'\''", "'")
 }
 
+/// Split a mode marker off the front of what skim handed the collector.
+///
+/// A mode key reloads with `<marker><n><marker>` in front of the query; an
+/// ordinary keystroke reloads with the query alone. Either way what follows is
+/// still shell-quoted — skim expands `{q}` inside the template, not the
+/// template itself — so this runs before [`unquote`], never after.
+fn read_mode(command: &str) -> (Option<usize>, String) {
+    let Some(rest) = command.strip_prefix(MODE_MARKER) else {
+        return (None, command.to_string());
+    };
+    match rest.split_once(MODE_MARKER) {
+        Some((mode, query)) => (mode.parse().ok(), query.to_string()),
+        None => (None, command.to_string()),
+    }
+}
+
 /// The [`CommandCollector`] behind [`select_many_searching`]: skim thinks it is
 /// running a command per keystroke, and it is calling a closure.
 struct SearchCollector {
     search: Arc<Mutex<Search>>,
+    /// Which [`Mode`] the next search reads the query in. Held across
+    /// keystrokes because only the mode *keys* say anything about it: an
+    /// ordinary keystroke re-runs the template, which carries no marker.
+    mode: Arc<AtomicUsize>,
 }
 
 impl CommandCollector for SearchCollector {
@@ -562,7 +613,15 @@ impl CommandCollector for SearchCollector {
     ) -> (SkimItemReceiver, Sender<i32>) {
         let (tx_item, rx_item): (SkimItemSender, SkimItemReceiver) = unbounded();
         let (tx_interrupt, rx_interrupt) = unbounded::<i32>();
-        let query = unquote(cmd);
+        // The marker first, then the quoting: skim quotes only the query it
+        // substituted for `{q}`, so a mode key's marker arrives outside the
+        // quotes rather than inside them.
+        let (mode, quoted) = read_mode(cmd);
+        let query = unquote(&quoted);
+        if let Some(mode) = mode {
+            self.mode.store(mode, Ordering::SeqCst);
+        }
+        let mode = self.mode.load(Ordering::SeqCst);
         let search = Arc::clone(&self.search);
 
         // Counted, and therefore never the thread blocked in the search: as
@@ -574,7 +633,7 @@ impl CommandCollector for SearchCollector {
             let (tx_stop, rx_stop) = std::sync::mpsc::channel::<Box<dyn Fn() + Send + Sync>>();
 
             std::thread::spawn(move || {
-                let mut searching = (search.lock().expect("search closure poisoned"))(&query);
+                let mut searching = (search.lock().expect("search closure poisoned"))(&query, mode);
                 // Handed over before the first row is read, so the thread
                 // below can call it off while this one is still blocked.
                 if tx_stop.send(searching.stop).is_err() {
@@ -649,6 +708,7 @@ pub fn select_many_searching(
     search: Search,
     prompt: &str,
     query: &str,
+    modes: &'static [Mode],
     cfg: &SelectorConfig,
 ) -> Result<Vec<String>> {
     let run = Run {
@@ -657,6 +717,7 @@ pub fn select_many_searching(
         query,
         reload: None,
         search: Some(search),
+        modes,
         actions: &[],
     };
     Ok(run_selector(Feed::none(true), run, cfg)?.values)
@@ -830,6 +891,9 @@ struct Run<'a> {
     reload: Option<Reload>,
     /// Given one, the query box drives this instead of filtering rows.
     search: Option<Search>,
+    /// The ways `search` can read the query, each on a key of its own. The
+    /// first is what the selector opens in.
+    modes: &'static [Mode],
     /// Keys that close the selector meaning something other than enter.
     actions: &'static [Action],
 }
@@ -842,6 +906,7 @@ impl<'a> Run<'a> {
             query: "",
             reload: None,
             search: None,
+            modes: &[],
             actions: &[],
         }
     }
@@ -900,7 +965,18 @@ fn run_selector(feed: Feed, run: Run, cfg: &SelectorConfig) -> Result<Outcome> {
     if previewing {
         builder
             .preview("")
-            .preview_window(cfg.preview_window.as_str());
+            .preview_window(cfg.preview_window.as_str())
+            // What clears the pane when the query stops matching anything.
+            //
+            // skim runs a row's own `preview()` only when a row is highlighted,
+            // and does nothing at all when none is — so the last match's pane
+            // stays on screen after the match itself is gone, describing a note
+            // no longer in the list. This callback is the branch skim takes
+            // instead in exactly that case, and returning nothing from it is
+            // what empties the pane.
+            .preview_fn(PreviewCallback::from(|_: Vec<Arc<dyn SkimItem>>| {
+                Vec::<String>::new()
+            }));
     }
 
     if !run.query.is_empty() {
@@ -915,7 +991,7 @@ fn run_selector(feed: Feed, run: Run, cfg: &SelectorConfig) -> Result<Outcome> {
 
     let reloadable = run.reload.is_some();
     let searching = run.search.is_some();
-    let header = hints(actions, reloadable, multi, searching);
+    let header = hints(actions, reloadable, multi, run.modes);
 
     // The query drives the search rather than filtering rows, so skim runs it
     // through a "command" — `{q}` being skim's own spelling of what was typed.
@@ -923,6 +999,7 @@ fn run_selector(feed: Feed, run: Run, cfg: &SelectorConfig) -> Result<Outcome> {
     if let Some(search) = run.search {
         let collector = SearchCollector {
             search: Arc::new(Mutex::new(search)),
+            mode: Arc::new(AtomicUsize::new(0)),
         };
         builder
             .interactive(true)
@@ -942,10 +1019,16 @@ fn run_selector(feed: Feed, run: Run, cfg: &SelectorConfig) -> Result<Outcome> {
             .cmd_collector(Rc::new(RefCell::new(collector)) as Rc<RefCell<dyn CommandCollector>>);
     }
 
-    if !header.is_empty() {
-        builder.header(header.clone());
+    // A searching selector opens in its first mode, and the header says so
+    // from the outset rather than only after a key is pressed.
+    let opening = match run.modes.first() {
+        Some(_) => mode_header(run.modes, 0, &header),
+        None => header.clone(),
+    };
+    if !opening.is_empty() {
+        builder.header(opening);
     }
-    let binds = binds(actions, reloadable, previewing, &header);
+    let binds = binds(actions, reloadable, previewing, run.modes, &header);
     if !binds.is_empty() {
         builder.bind(binds);
     }
@@ -1008,7 +1091,7 @@ fn acted(output: &SkimOutput, actions: &'static [Action]) -> Option<&'static str
 ///
 /// Nothing at all when there is nothing to say, so a plain list of paths keeps
 /// the row for a path.
-fn hints(actions: &[Action], reloadable: bool, multi: bool, searching: bool) -> String {
+fn hints(actions: &[Action], reloadable: bool, multi: bool, modes: &[Mode]) -> String {
     let mut hints: Vec<String> = actions
         .iter()
         .map(|action| format!("{} {}", action.key, action.label))
@@ -1022,7 +1105,7 @@ fn hints(actions: &[Action], reloadable: bool, multi: bool, searching: bool) -> 
     // Worth a hint only where the query is not doing what a query usually
     // does: with the search taking it, `ctrl-q` is how you filter what came
     // back rather than searching again.
-    if searching {
+    if !modes.is_empty() {
         hints.push("ctrl-q filter".to_string());
     }
     hints.join(HINT_SEPARATOR)
@@ -1036,7 +1119,13 @@ const HINT_SEPARATOR: &str = " · ";
 ///
 /// `header` is what the reload puts back when it finishes, so the hints the
 /// selector opened with survive a refresh.
-fn binds(actions: &[Action], reloadable: bool, previewing: bool, header: &str) -> Vec<String> {
+fn binds(
+    actions: &[Action],
+    reloadable: bool,
+    previewing: bool,
+    modes: &[Mode],
+    header: &str,
+) -> Vec<String> {
     let mut binds: Vec<String> = actions
         .iter()
         .map(|action| format!("{}:accept", action.key))
@@ -1047,7 +1136,34 @@ fn binds(actions: &[Action], reloadable: bool, previewing: bool, header: &str) -
     if reloadable {
         binds.extend(refresh_binds(header));
     }
+    // Each mode key searches again in its own mode and says so in the header,
+    // which is the only place the current one can be read.
+    for (index, mode) in modes.iter().enumerate() {
+        binds.push(format!(
+            "{}:reload({MODE_MARKER}{index}{MODE_MARKER}{{q}})+set-header({})",
+            mode.key,
+            mode_header(modes, index, header),
+        ));
+    }
     binds
+}
+
+/// The header while `chosen` is the mode in force: what the selector could
+/// already do, with the mode named at the front of it.
+fn mode_header(modes: &[Mode], chosen: usize, header: &str) -> String {
+    let mut parts = vec![match modes.get(chosen) {
+        Some(mode) => format!("{} match", mode.label),
+        None => String::new(),
+    }];
+    for (index, mode) in modes.iter().enumerate() {
+        if index != chosen {
+            parts.push(format!("{} {}", mode.key, mode.label));
+        }
+    }
+    if !header.is_empty() {
+        parts.push(header.to_string());
+    }
+    parts.join(HINT_SEPARATOR)
 }
 
 /// The row an inline selector opens on, so it never draws over the prompt.
@@ -1127,6 +1243,7 @@ mod tests {
         fn collect(search: Search, quoted: &str) -> (Vec<String>, Arc<AtomicUsize>) {
             let mut collector = SearchCollector {
                 search: Arc::new(Mutex::new(search)),
+                mode: Arc::new(AtomicUsize::new(0)),
             };
             let counter = Arc::new(AtomicUsize::new(0));
             let (rx, _interrupt) = collector.invoke(quoted, Arc::clone(&counter));
@@ -1137,11 +1254,116 @@ mod tests {
             (rows, counter)
         }
 
+        /// A mode key reloads with a marker in front of the query; an
+        /// ordinary keystroke reloads with the query alone. Telling them apart
+        /// is the whole of how the mode survives typing.
+        #[test]
+        fn a_mode_marker_is_read_off_the_front_and_a_plain_query_is_left_alone() {
+            assert_eq!(read_mode("hello"), (None, "hello".to_string()));
+            assert_eq!(
+                read_mode(&format!("{MODE_MARKER}1{MODE_MARKER}hello")),
+                (Some(1), "hello".to_string())
+            );
+            // A marker with no closing one is not a marker.
+            assert_eq!(
+                read_mode(&format!("{MODE_MARKER}hello")),
+                (None, format!("{MODE_MARKER}hello"))
+            );
+        }
+
+        /// The mode is only ever named by a mode key. Every keystroke after one
+        /// re-runs the template, which carries no marker, so the collector has
+        /// to remember.
+        #[test]
+        fn a_mode_survives_the_keystrokes_that_follow_it() {
+            let seen = Arc::new(Mutex::new(Vec::new()));
+            let recorder = Arc::clone(&seen);
+            let search: Search = Box::new(move |_, mode| {
+                recorder.lock().unwrap().push(mode);
+                Searching {
+                    rows: Box::new(std::iter::empty()),
+                    stop: Box::new(|| {}),
+                }
+            });
+            let mut collector = SearchCollector {
+                search: Arc::new(Mutex::new(search)),
+                mode: Arc::new(AtomicUsize::new(0)),
+            };
+            let drain = |collector: &mut SearchCollector, cmd: &str| {
+                let (rx, _i) = collector.invoke(cmd, Arc::new(AtomicUsize::new(0)));
+                while rx.recv().is_ok() {}
+            };
+
+            // Exactly the shape skim builds: the marker is part of the
+            // template and only the query is quoted.
+            drain(&mut collector, "'a'");
+            drain(
+                &mut collector,
+                &format!("{MODE_MARKER}1{MODE_MARKER}{}", quote("ab")),
+            );
+            drain(&mut collector, "'abc'");
+
+            assert_eq!(*seen.lock().unwrap(), vec![0, 1, 1]);
+        }
+
+        /// skim quotes the query it substitutes for `{q}` and nothing else, so
+        /// a mode key's marker arrives outside the quotes. Reading it off
+        /// after unquoting would leave the query still wearing them.
+        #[test]
+        fn a_mode_key_still_delivers_the_query_unquoted() {
+            let seen = Arc::new(Mutex::new(String::new()));
+            let recorder = Arc::clone(&seen);
+            let search: Search = Box::new(move |query, _| {
+                *recorder.lock().unwrap() = query.to_string();
+                Searching {
+                    rows: Box::new(std::iter::empty()),
+                    stop: Box::new(|| {}),
+                }
+            });
+
+            collect(
+                search,
+                &format!("{MODE_MARKER}1{MODE_MARKER}{}", quote("it's here")),
+            );
+
+            assert_eq!(seen.lock().unwrap().as_str(), "it's here");
+        }
+
+        /// The header is the only place the mode can be read, so a mode key
+        /// names the mode it just chose and offers the other one.
+        #[test]
+        fn a_mode_key_says_which_mode_it_put_the_selector_in() {
+            let modes = [Mode::new("ctrl-f", "fuzzy"), Mode::new("ctrl-x", "exact")];
+            let header = mode_header(&modes, 0, "tab select");
+            assert!(header.starts_with("fuzzy match"), "{header}");
+            assert!(header.contains("ctrl-x exact"), "{header}");
+            assert!(!header.contains("ctrl-f"), "{header}");
+            assert!(header.contains("tab select"), "{header}");
+        }
+
+        #[test]
+        fn every_mode_gets_a_key_that_searches_again_and_sets_the_header() {
+            let modes = [Mode::new("ctrl-f", "fuzzy"), Mode::new("ctrl-x", "exact")];
+            let binds = binds(&[], false, false, &modes, "");
+            assert!(
+                binds.iter().any(|b| b.starts_with("ctrl-f:reload(")),
+                "{binds:?}"
+            );
+            assert!(
+                binds.iter().any(|b| b.starts_with("ctrl-x:reload(")),
+                "{binds:?}"
+            );
+            assert!(
+                binds.iter().all(|b| b.contains("set-header(")),
+                "a mode key that does not say so: {binds:?}"
+            );
+        }
+
         #[test]
         fn the_search_sees_what_was_typed_rather_than_what_a_shell_would_get() {
             let seen = Arc::new(Mutex::new(String::new()));
             let recorder = Arc::clone(&seen);
-            let search: Search = Box::new(move |query| {
+            let search: Search = Box::new(move |query, _mode| {
                 *recorder.lock().unwrap() = query.to_string();
                 Searching {
                     rows: Box::new(std::iter::empty()),
@@ -1156,7 +1378,7 @@ mod tests {
 
         #[test]
         fn every_row_the_search_produces_reaches_the_selector() {
-            let search: Search = Box::new(|_| Searching {
+            let search: Search = Box::new(|_, _| Searching {
                 rows: Box::new((0..1000).map(|n| SelectItem::plain(format!("row {n}")))),
                 stop: Box::new(|| {}),
             });
@@ -1179,7 +1401,7 @@ mod tests {
         fn interrupting_a_search_stops_it_even_while_it_is_blocked() {
             let stopped = Arc::new(AtomicBool::new(false));
             let flag = Arc::clone(&stopped);
-            let search: Search = Box::new(move |_| {
+            let search: Search = Box::new(move |_, _| {
                 let ended = Arc::new(AtomicBool::new(false));
                 let watched = Arc::clone(&ended);
                 let flag = Arc::clone(&flag);
@@ -1201,6 +1423,7 @@ mod tests {
 
             let mut collector = SearchCollector {
                 search: Arc::new(Mutex::new(search)),
+                mode: Arc::new(AtomicUsize::new(0)),
             };
             let counter = Arc::new(AtomicUsize::new(0));
             let (_rx, interrupt) = collector.invoke("'q'", Arc::clone(&counter));
@@ -1432,7 +1655,7 @@ mod tests {
             &[Action::new("f2", "open"), Action::new("f7", "check out")],
             true,
             true,
-            false,
+            &[],
         );
         for header in [BUSY_HEADER, every_hint.as_str(), HINT_SEPARATOR] {
             assert!(!header.contains(','), "{header:?} would split the binding");
@@ -1442,7 +1665,7 @@ mod tests {
 
     #[test]
     fn the_header_names_every_key_the_selector_answers_to() {
-        let full = hints(&[Action::new("f2", "open")], true, true, false);
+        let full = hints(&[Action::new("f2", "open")], true, true, &[]);
         assert_eq!(full, "f2 open · ctrl-r refresh · tab select");
     }
 
@@ -1450,13 +1673,13 @@ mod tests {
     /// path than as an empty hint line.
     #[test]
     fn a_selector_with_nothing_to_offer_draws_no_header() {
-        assert!(hints(&[], false, false, false).is_empty());
+        assert!(hints(&[], false, false, &[]).is_empty());
     }
 
     #[test]
     fn each_hint_appears_only_when_its_key_is_bound() {
-        assert_eq!(hints(&[], false, true, false), "tab select");
-        assert_eq!(hints(&[], true, false, false), "ctrl-r refresh");
+        assert_eq!(hints(&[], false, true, &[]), "tab select");
+        assert_eq!(hints(&[], true, false, &[]), "ctrl-r refresh");
     }
 
     /// skim binds `ctrl-r` to rotating the match mode and `tab` to toggling a
@@ -1467,8 +1690,8 @@ mod tests {
     #[test]
     fn every_key_the_header_names_is_bound() {
         let actions = [Action::new("f2", "open"), Action::new("f7", "check out")];
-        let header = hints(&actions, true, true, false);
-        let binds = binds(&actions, true, true, &header);
+        let header = hints(&actions, true, true, &[]);
+        let binds = binds(&actions, true, true, &[], &header);
 
         for hint in header.split(HINT_SEPARATOR) {
             let key = hint.split(' ').next().expect("a hint with no key");
@@ -1488,7 +1711,7 @@ mod tests {
     #[test]
     fn an_action_key_closes_the_selector_and_the_preview_key_does_not() {
         let actions = [Action::new("f2", "open")];
-        let binds = binds(&actions, false, true, "");
+        let binds = binds(&actions, false, true, &[], "");
         assert!(binds.contains(&"f2:accept".to_string()), "{binds:?}");
         assert!(
             binds.contains(&format!("{PREVIEW_KEY}:toggle-preview")),
@@ -1498,7 +1721,7 @@ mod tests {
 
     #[test]
     fn a_plain_selector_binds_nothing_of_its_own() {
-        assert!(binds(&[], false, false, "").is_empty());
+        assert!(binds(&[], false, false, &[], "").is_empty());
     }
 
     #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1648,13 +1648,22 @@ fn mk_vault(sandbox: &Sandbox) -> PathBuf {
     vault
 }
 
+/// `note ls` is read by other tools, so what it prints is a path they can
+/// open: absolute, one per line, newest first.
 #[test]
-fn note_ls_names_every_note_below_the_vault_newest_first() {
+fn note_ls_prints_absolute_paths_newest_first() {
     let sandbox = Sandbox::new();
-    mk_vault(&sandbox);
+    let vault = mk_vault(&sandbox);
     let run = sandbox.run(&["note", "ls"]);
     run.ok();
-    assert_eq!(run.lines(), vec!["inbox.md", "zeta.md", "archive/old.md"]);
+    assert_eq!(
+        run.lines(),
+        vec![
+            vault.join("inbox.md").to_str().unwrap(),
+            vault.join("zeta.md").to_str().unwrap(),
+            vault.join("archive/old.md").to_str().unwrap(),
+        ]
+    );
 }
 
 /// The vault holds an attachment and an Obsidian settings directory, neither of
@@ -1674,14 +1683,15 @@ fn note_ls_offers_markdown_and_not_the_rest_of_the_vault() {
     assert!(!run.stdout.contains("obsidian"), "{}", run.stdout);
 }
 
+/// Every path the listing prints opens, which is the point of printing them.
 #[test]
-fn note_ls_absolute_paths_are_absolute() {
+fn every_path_note_ls_prints_is_one_that_exists() {
     let sandbox = Sandbox::new();
-    let vault = mk_vault(&sandbox);
-    let run = sandbox.run(&["note", "ls", "--absolute-paths"]);
+    mk_vault(&sandbox);
+    let run = sandbox.run(&["note", "ls"]);
     run.ok();
     for line in run.lines() {
-        assert!(line.starts_with(vault.to_str().unwrap()), "{line}");
+        assert!(Path::new(line).is_file(), "{line}");
     }
 }
 
@@ -1694,8 +1704,10 @@ fn note_ls_status_carries_the_tags_and_both_dates() {
     let run = sandbox.run(&["note", "ls", "--status"]);
     run.ok();
 
+    // `--status` is the listing a person reads, so the home directory it all
+    // sits under is collapsed rather than repeated down every row.
     let inbox = run.lines()[0].to_string();
-    assert!(inbox.starts_with("inbox.md"), "{inbox}");
+    assert!(inbox.starts_with("~/notes/inbox.md"), "{inbox}");
     assert!(inbox.contains("#todo #work"), "{inbox}");
     // The front matter's creation date, not the file's: this vault was written
     // moments ago.
@@ -1705,7 +1717,7 @@ fn note_ls_status_carries_the_tags_and_both_dates() {
     let old = run
         .lines()
         .iter()
-        .find(|l| l.starts_with("archive/old.md"))
+        .find(|l| l.contains("archive/old.md"))
         .expect("the archived note")
         .to_string();
     assert!(old.contains("old"), "{old}");
@@ -1856,4 +1868,126 @@ fn config_check_counts_the_notes_in_the_vault() {
     assert!(run.stdout.contains("note editor"), "{}", run.stdout);
     // `note rg` shells out to it, so the report says whether it is there.
     assert!(run.stdout.contains("rg"), "{}", run.stdout);
+}
+
+/// The scratch note is the same file every time, and its directory is made for
+/// it — otherwise the editor has nowhere to write.
+#[test]
+fn note_scratch_opens_one_permanent_file() {
+    let sandbox = Sandbox::new();
+    let vault = mk_vault(&sandbox);
+
+    let first = sandbox.run(&["note", "scratch"]);
+    first.ok();
+    let second = sandbox.run(&["note", "scratch"]);
+    second.ok();
+
+    assert_eq!(first.stdout, second.stdout, "the scratch note moved");
+    assert_eq!(
+        first.stdout.trim(),
+        format!("-- {}", vault.join("scratch/scratch.md").display())
+    );
+    assert!(vault.join("scratch").is_dir(), "the directory was not made");
+}
+
+#[test]
+fn note_scratch_goes_where_the_config_says() {
+    let sandbox = Sandbox::new();
+    let vault = sandbox.home().join("notes");
+    mk_note(&vault, "a.md", "a\n", 1_000);
+    sandbox.write_config(&format!(
+        "[note]\nroot = {:?}\neditor = \"echo\"\nscratch = \"pad.md\"\n",
+        vault.display().to_string()
+    ));
+
+    let run = sandbox.run(&["note", "scratch"]);
+    run.ok();
+    assert_eq!(
+        run.stdout.trim(),
+        format!("-- {}", vault.join("pad.md").display())
+    );
+}
+
+/// A mistyped name would otherwise open a new, empty buffer and say nothing,
+/// which is how a typo becomes a second note.
+#[test]
+fn note_edit_warns_when_the_note_named_is_not_there() {
+    let sandbox = Sandbox::new();
+    mk_vault(&sandbox);
+    let run = sandbox.run(&["note", "edit", "inbx.md"]);
+    run.ok();
+    assert!(
+        run.stderr.contains("no note called inbx.md"),
+        "{}",
+        run.stderr
+    );
+}
+
+/// A vault where every note has a name and something in it has nothing to
+/// clean up, and says so rather than opening an empty selector.
+#[test]
+fn note_cleanup_says_so_when_there_is_nothing_to_do() {
+    let sandbox = Sandbox::new();
+    let vault = sandbox.home().join("notes");
+    mk_note(
+        &vault,
+        "thoughts.md",
+        "a real note with rather more than a couple of dozen characters in it\n",
+        1_000,
+    );
+    sandbox.write_config(&format!(
+        "[note]\nroot = {:?}\neditor = \"echo\"\n",
+        vault.display().to_string()
+    ));
+
+    let run = sandbox.run(&["note", "cleanup"]);
+    run.ok();
+    assert!(run.stdout.contains("Nothing to clean up"), "{}", run.stdout);
+}
+
+/// The three kinds, and nothing else. Without a terminal the selector cannot
+/// open, so this proves what was classified rather than what was chosen.
+#[test]
+fn note_cleanup_offers_the_three_kinds_and_leaves_real_notes_alone() {
+    let sandbox = Sandbox::new();
+    let vault = sandbox.home().join("notes");
+    mk_note(&vault, "empty.md", "", 1_000);
+    mk_note(
+        &vault,
+        "Untitled 1.md",
+        "this one has plenty of words in it\n",
+        1_000,
+    );
+    mk_note(
+        &vault,
+        "2026-08-25 1043.md",
+        "jotted down in a hurry, no name\n",
+        1_000,
+    );
+    mk_note(
+        &vault,
+        "thoughts.md",
+        "a real note with rather more than a couple of dozen characters\n",
+        1_000,
+    );
+    sandbox.write_config(&format!(
+        "[note]\nroot = {:?}\neditor = \"echo\"\n",
+        vault.display().to_string()
+    ));
+
+    let run = sandbox.run(&["note", "cleanup"]);
+
+    // It got past classification and failed at the selector, which is the only
+    // thing a test without a terminal can reach.
+    run.code(1);
+    assert!(
+        run.stderr.contains("needs a terminal"),
+        "cleanup did not reach the selector: {}",
+        run.stderr
+    );
+    assert!(
+        !run.stdout.contains("Nothing to clean up"),
+        "three candidates were classified as none: {}",
+        run.stdout
+    );
 }


### PR DESCRIPTION
- A note row is the created date and the name again; the attribute columns move back into the preview pane. `SelectItem::suffix` goes with them.
- Fixed: the preview pane kept the last match on screen after the query stopped matching anything. skim runs a row's preview only when a row is highlighted; `preview_fn` is the branch it takes when none is.
- `note ls` prints absolute paths for piping; `--absolute-paths` is gone. `--status` collapses `$HOME` to `~`.
- `note rg` matches fuzzily by default — a subsequence regex, since ripgrep has no fuzzy mode. `ctrl-x` is exact, `ctrl-f` back to fuzzy.
- Every character of a query is escaped, so a half-typed `(` finds nothing rather than failing the search.
- `note scratch` opens one permanent file, at `[note] scratch`.
- `note cleanup` offers empty, `Untitled`, and letterless-and-untitled notes for deletion, saying which rule put each one on the list.
- `note edit` warns when the note named is not there.

Two keys for the search modes rather than one that toggles: `set-header` writes a fixed string, so a self-rebinding toggle would have to contain its own text. Two keys cost the same keystroke and the header never lies about which mode is in force.

A bug I introduced and caught: skim quotes the query it substitutes for `{q}` and nothing else, so a mode marker written into the template arrives *outside* the quotes. Reading it off after unquoting left the query still wearing them. There is a regression test for the exact shape skim builds.

Trade-off worth naming: the row no longer shows tags, folders or task counts, so a vault with two same-named notes in different directories shows two identical rows. The preview pane distinguishes them; the value returned is still the absolute path.

Docs: `src/main.rs` help, README (command table, config, what a row shows) and `CHANGELOG.md` under `## Unreleased`. `docs/demo.gif` is unchanged — the tape never opens a vault.