### PR TITLE
Read a note's name a character at a time, not eight bytes at a time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ raised, never by hand.
 
 ## Unreleased
 
+### Fixed
+
+- `scriv note cleanup` crashed on a vault whose note names are not all English.
+  It compared the first eight *bytes* of a name against `untitled`, and the
+  eighth byte of a name like `Oppgaveøkt` is the middle of the `ø` rather than
+  the end of a letter — which Rust refuses to slice at, taking the whole
+  command down with it. Names are now read a character at a time.
+
 ## v0.11.0
 
 *Released 2026-08-25*

--- a/src/cmd/note.rs
+++ b/src/cmd/note.rs
@@ -899,10 +899,6 @@ mod tests {
         assert_eq!(note.rel, "work/meetings/standup.md");
         assert_eq!(note.title(), "standup");
         assert_eq!(note.dir, "work");
-        assert_eq!(
-            note.folder(&crate::config::NoteConfig::default()),
-            "meetings"
-        );
     }
 
     #[test]

--- a/src/note.rs
+++ b/src/note.rs
@@ -159,26 +159,6 @@ impl Note {
         labels.label_of(&self.dir).is_some()
     }
 
-    /// The directories the note is filed under that the group column has not
-    /// already named.
-    ///
-    /// Which ones those are depends on the group: a *label* is a word of the
-    /// user's own — `work` says nothing about which directory — so the whole
-    /// path below the root is still news. An unlabelled group is the directory
-    /// itself, already drawn one column to the left, so only what sits below it
-    /// is. Between them the two columns spell out the note's path exactly once.
-    pub fn folder<'a>(&'a self, cfg: &'a crate::config::NoteConfig) -> &'a str {
-        let below = match self.labelled(cfg) {
-            true => &self.rel[..],
-            // The separator too, which is why this is not `dir.len()`.
-            false => &self.rel[(self.dir.len() + 1).min(self.rel.len())..],
-        };
-        match below.rfind('/') {
-            Some(at) => &below[..at],
-            None => "",
-        }
-    }
-
     /// The path a *report* shows: absolute, with the home directory collapsed
     /// to `~`.
     ///
@@ -1012,17 +992,6 @@ mod tests {
         );
     }
 
-    /// The folder is what sits between the group's directory and the note, so
-    /// a row never writes the group twice.
-    #[test]
-    fn a_note_at_the_vault_root_is_filed_under_nothing() {
-        let bare = crate::config::NoteConfig::default();
-        assert_eq!(note("inbox.md", Front::default()).folder(&bare), "");
-        assert_eq!(note("a/c.md", Front::default()).folder(&bare), "");
-        assert_eq!(note("a/b/c.md", Front::default()).folder(&bare), "b");
-        assert_eq!(note("a/b/c/d.md", Front::default()).folder(&bare), "b/c");
-    }
-
     /// The filesystem dates a synced or freshly cloned vault the day it
     /// arrived, which is why front matter wins.
     #[test]
@@ -1254,6 +1223,70 @@ mod tests {
         assert_eq!(junk(&titled, &body_of(20)), None);
     }
 
+    /// A name is whatever the writer typed, and this repository's owner writes
+    /// Norwegian. Every one of these panicked when a byte offset — the length
+    /// of `untitled`, or the length of a directory plus one — landed inside a
+    /// character rather than between two.
+    ///
+    /// Byte offsets into a name are the bug, not any one name: `&s[..8]` is a
+    /// panic waiting for the eighth byte to be the middle of `ø`. These are the
+    /// shapes that reach a byte offset, so this is where they are held.
+    #[test]
+    fn a_name_that_is_not_ascii_does_not_panic_anywhere() {
+        let names = [
+            "Løsninger",
+            "Møtereferat",
+            "Størrelsesorden",
+            "ø",
+            "Untitled ø",
+            "Untitledø",
+            "ÅRSMØTE",
+            "日本語のノート",
+            "café",
+            "naïveté",
+            "emoji 🎉 note",
+            "Prosjektø",
+        ];
+        let cfg = config();
+        for name in names {
+            for rel in [
+                format!("{name}.md"),
+                format!("{name}/{name}.md"),
+                format!("work/{name}.md"),
+                format!("{name}/deeper/{name}.md"),
+            ] {
+                let note = note(&rel, Front::default());
+                // Every accessor a row, a report or the cleanup list reaches
+                // for. A panic in any is the bug this is here for.
+                let _ = note.title();
+                let _ = note.group(&cfg);
+                let _ = note.tag_column();
+                let _ = note.shown("/home/me");
+                let _ = row(&note);
+                let _ = prefix(&note, utc());
+                let _ = junk(&note, "");
+                let _ = junk(&note, &"word ".repeat(20));
+                let widths = Widths::of(std::slice::from_ref(&note), &cfg, "/home/me");
+                let _ = status_row(&note, &cfg, &widths, utc(), "/home/me");
+                let _ = junk_row(&note, Junk::Untitled, 10, &widths);
+            }
+        }
+    }
+
+    /// The name that crashed it: `untitled` is eight bytes, and the eighth byte
+    /// of a Norwegian filename is as likely as not to be half of an `ø`.
+    #[test]
+    fn a_name_whose_eighth_byte_is_inside_a_character_is_not_untitled() {
+        for name in ["Prosjektø", "Løsningø", "abcdefgø", "Størrelse"] {
+            let note = note(&format!("{name}.md"), Front::default());
+            assert_ne!(
+                junk(&note, &"word ".repeat(20)),
+                Some(Junk::Untitled),
+                "{name}"
+            );
+        }
+    }
+
     /// The reason is what the list is read for, so it leads and it is coloured.
     #[test]
     fn a_cleanup_row_says_why_the_note_is_on_the_list() {
@@ -1322,6 +1355,54 @@ mod tests {
 
     fn drawn(line: &str) -> String {
         markdown_line(line, &mut false)
+    }
+
+    /// The renderer scans a line by byte offset — advancing a cursor, slicing
+    /// out a wikilink, measuring a tag. Every one of those is the same class of
+    /// bug as the one that crashed `note cleanup`, so every one is held here.
+    #[test]
+    fn a_body_that_is_not_ascii_renders_without_panicking() {
+        let lines = [
+            "# Størrelsesorden",
+            "møte med Kjærsti om løsningen",
+            "- [ ] ærlig talt",
+            "- [x] åpne saker",
+            "> sitat på norsk",
+            "se [[nøtter/møter]] og #løsning",
+            "#ø",
+            "ø",
+            "日本語 [[ノート]] #タグ",
+            "🎉 [[emoji]] #party 🎉",
+            "  - [[øy]]",
+            "1. tåler dette",
+            "---",
+            "```rust",
+            "let x = \"ø\";",
+            "```",
+        ];
+        let mut fenced = false;
+        for line in lines {
+            let _ = markdown_line(line, &mut fenced);
+        }
+
+        let text = format!(
+            "---\ntitle: Årsmøte\ntags: [løsning, ærlig]\n---\n{}",
+            lines.join("\n")
+        );
+        let note = note("nøtter/møte.md", front(&text));
+        let rendered = preview(&note, &config(), &text, 0, utc());
+        assert!(rendered.contains("Årsmøte"), "{rendered}");
+        assert!(rendered.contains("#løsning #ærlig"), "{rendered}");
+        assert!(rendered.contains("Størrelsesorden"), "{rendered}");
+    }
+
+    /// Front matter is read character by character too, and a Norwegian tag is
+    /// exactly as valid as an English one.
+    #[test]
+    fn front_matter_that_is_not_ascii_parses() {
+        let parsed = front("---\ntitle: Årsmøte\ntags: [løsning, ærlig, 日本語]\n---\n");
+        assert_eq!(parsed.title.as_deref(), Some("Årsmøte"));
+        assert_eq!(parsed.tags, vec!["løsning", "ærlig", "日本語"]);
     }
 
     #[test]
@@ -1644,6 +1725,32 @@ mod search_tests {
         assert_eq!(found.line, 7);
     }
 
+    /// A search row is built by slicing a ripgrep line at byte offsets, and a
+    /// vault's paths and prose are as Norwegian as its names.
+    #[test]
+    fn a_match_in_a_norwegian_note_parses_and_draws() {
+        let found =
+            parse_match("/vault/nøtter/møte.md:12:5:ærlig talt, en løsning", &root()).unwrap();
+        assert_eq!(found.rel, "nøtter/møte.md");
+        assert_eq!((found.line, found.column), (12, 5));
+        assert_eq!(found.text, "ærlig talt, en løsning");
+
+        let (row, tints) = match_row(&found, 40);
+        assert!(row.contains("nøtter/møte.md"), "{row:?}");
+        // Tints are character ranges, so they must land on characters.
+        for tint in &tints {
+            assert!(
+                row.chars().count() >= tint.range.end,
+                "a tint ran past the row: {tint:?} in {row:?}"
+            );
+        }
+        let back = decode_match(&encode_match(&found), &root()).unwrap();
+        assert_eq!(back.rel, found.rel);
+
+        let rendered = match_preview(&found, "første\nandre\nærlig talt, en løsning\n");
+        assert!(rendered.contains("løsning"), "{rendered}");
+    }
+
     #[test]
     fn a_line_that_is_not_a_match_is_not_one() {
         for line in ["", "no colons at all", "/vault/a.md:not:a:number"] {
@@ -1806,14 +1913,20 @@ pub fn junk(note: &Note, body: &str) -> Option<Junk> {
 /// Whether a name is the one an editor gives a file nobody named: `Untitled`,
 /// and the `Untitled 1`, `untitled-2` it goes on to.
 fn is_untitled(name: &str) -> bool {
-    let rest = match name.len() >= UNTITLED.len()
-        && name[..UNTITLED.len()].eq_ignore_ascii_case(UNTITLED)
-    {
-        true => &name[UNTITLED.len()..],
-        false => return false,
-    };
-    rest.chars()
-        .all(|c| c.is_ascii_digit() || c == ' ' || c == '-' || c == '_')
+    // Character by character, never `name[..UNTITLED.len()]`. A name is
+    // whatever its writer typed, and a byte offset into one is a panic waiting
+    // for that byte to be the middle of a character rather than the start of
+    // it — `untitled` is eight bytes, and the eighth byte of a name like
+    // `Oppgaveøkt` is half of the `ø`.
+    let mut rest = name.chars();
+    let matched = UNTITLED.chars().all(|want| {
+        rest.next()
+            .is_some_and(|got| got.eq_ignore_ascii_case(&want))
+    });
+    if !matched {
+        return false;
+    }
+    rest.all(|c| c.is_ascii_digit() || c == ' ' || c == '-' || c == '_')
 }
 
 const UNTITLED: &str = "untitled";

--- a/src/select.rs
+++ b/src/select.rs
@@ -115,6 +115,7 @@ fn file_preview_cmd(path: &str) -> String {
 /// Where [`SelectItem::color`] says something about the whole row, a tint says
 /// something about one column of it — so a row can carry two facts that are
 /// true of different parts of it without either claiming the line.
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Tint {
     pub range: Range<usize>,
     pub color: u8,

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1991,3 +1991,125 @@ fn note_cleanup_offers_the_three_kinds_and_leaves_real_notes_alone() {
         run.stdout
     );
 }
+
+/// A vault is named by whoever writes in it, and this one's owner writes
+/// Norwegian. `note cleanup` panicked on `Prosjektø` — the eighth byte of the
+/// name is half an `ø`, and `untitled` is eight bytes long — so every note verb
+/// a script can reach is run over a vault full of characters that are not
+/// ASCII. A panic anywhere is the bug this is here for.
+#[test]
+fn every_note_command_survives_a_vault_that_is_not_ascii() {
+    let sandbox = Sandbox::new();
+    let vault = sandbox.home().join("notater");
+
+    // The shape that crashed it, and the only one that does: `untitled` is
+    // eight bytes, so the name must have a character *straddling* its eighth —
+    // seven ASCII bytes and then a two-byte `ø`. `Prosjektø` has eight before
+    // the `ø` and is therefore fine, which is what makes this so easy to miss.
+    mk_note(
+        &vault,
+        "Oppgaveøkt.md",
+        "en økt med ganske mange ord i seg\n",
+        5_000,
+    );
+    mk_note(
+        &vault,
+        "Notater—2024.md",
+        "notater fra hele året, ganske mange\n",
+        4_500,
+    );
+    // The near misses, kept so the test covers both sides of the boundary.
+    mk_note(
+        &vault,
+        "Prosjektø.md",
+        "et prosjekt med mange ord i seg\n",
+        4_200,
+    );
+    mk_note(
+        &vault,
+        "øvelser.md",
+        "øvelser og løsninger, ganske mange\n",
+        4_000,
+    );
+    // Non-ASCII directories, front matter, tags and body.
+    mk_note(
+        &vault,
+        "møter/årsmøte.md",
+        "---\ntitle: Årsmøte\ntags: [løsning, ærlig]\ncreated: 2024-03-01\n---\n\n# Årsmøte\n\n- [ ] følge opp\nse [[nøtter/møte]] og #løsning\n",
+        3_000,
+    );
+    // The three cleanup shapes, in Norwegian and beyond it.
+    mk_note(&vault, "Untitled ø.md", "", 2_000);
+    mk_note(
+        &vault,
+        "日本語/ノート.md",
+        "日本語のノートです、かなり長い文章\n",
+        1_000,
+    );
+    mk_note(
+        &vault,
+        "2026-08-25 1043.md",
+        "notert i all hast, uten navn\n",
+        900,
+    );
+
+    sandbox.write_config(&format!(
+        "[note]\nroot = {:?}\neditor = \"echo\"\nlabels = {{ arbeid = [\"møter\"] }}\n",
+        vault.display().to_string()
+    ));
+
+    sandbox.run(&["note", "ls"]).ok();
+    sandbox.run(&["note", "ls", "--status"]).ok();
+    sandbox.run(&["note", "edit", "øvelser.md"]).ok();
+    sandbox.run(&["note", "new", "Løsningsforslag"]).ok();
+    sandbox.run(&["note", "scratch"]).ok();
+    sandbox.run(&["config", "check"]);
+
+    // The one that crashed. Without a terminal it stops at the selector, which
+    // is past every byte offset that was the bug.
+    let cleanup = sandbox.run(&["note", "cleanup"]);
+    assert_eq!(
+        cleanup.code,
+        Some(1),
+        "note cleanup did not reach the selector\n--- stdout ---\n{}\n--- stderr ---\n{}",
+        cleanup.stdout,
+        cleanup.stderr,
+    );
+    assert!(
+        cleanup.stderr.contains("needs a terminal"),
+        "note cleanup failed before the selector: {}",
+        cleanup.stderr,
+    );
+    assert!(
+        !cleanup.stderr.contains("panicked"),
+        "note cleanup panicked: {}",
+        cleanup.stderr,
+    );
+}
+
+/// The label, the folder and the name all come off one path by cutting it up,
+/// and a Norwegian directory makes every one of those cuts land differently.
+#[test]
+fn note_ls_status_reads_a_norwegian_vault_correctly() {
+    let sandbox = Sandbox::new();
+    let vault = sandbox.home().join("notater");
+    mk_note(
+        &vault,
+        "møter/årsmøte.md",
+        "---\ntags: [løsning]\ncreated: 2024-03-01\n---\n\nærlig talt\n",
+        1_000,
+    );
+    sandbox.write_config(&format!(
+        "[note]\nroot = {:?}\neditor = \"echo\"\nlabels = {{ arbeid = [\"møter\"] }}\n",
+        vault.display().to_string()
+    ));
+
+    let run = sandbox.run(&["note", "ls", "--status"]);
+    run.ok();
+
+    let row = run.lines()[0].to_string();
+    assert!(row.starts_with("~/notater/møter/årsmøte.md"), "{row}");
+    assert!(row.contains("arbeid"), "{row}");
+    assert!(row.contains("#løsning"), "{row}");
+    assert!(row.ends_with("2024-03-01"), "{row}");
+}


### PR DESCRIPTION
Fixes the `note cleanup` panic: `end byte index 8 is not a char boundary; it is inside 'ø'`.

- `is_untitled` sliced the first eight *bytes* of a name to compare against `untitled`. Rust refuses to slice between two halves of a character, so any name with one straddling byte eight took the command down.
- `Note::folder` had the same arithmetic — a directory's length plus one, which for a root note is byte one of its own name. It was dead code since the row lost its folder column, so it is removed rather than fixed.
- Every remaining byte slice in the crate was audited: each is an offset `str::find` returned or a count of ASCII characters just matched, and neither can land inside a character.

The near miss is why this is easy to miss and why the first fixture did not reproduce it: `Prosjektø` has eight bytes *before* its `ø`, so that slice is fine. Only a character straddling byte eight fails. Both sides are in the tests now.

Tests, all watched failing against the bug first:

- a sweep over every accessor a row, a report or the cleanup list reaches for, across Norwegian, Japanese, French and emoji names in four path shapes
- a targeted case for the byte-eight straddle
- the markdown renderer, the front matter reader and the search-match parser, which each scan by byte offset
- two `tests/cli.rs` cases running the real binary over a Norwegian vault, one of which reproduces the reported panic exactly

Not done: `clippy::string_slice` would forbid the whole class at compile time, but it is a restriction lint that would flag roughly twenty legitimate `find`-derived slices and need an `allow` on each. Say the word if the noise is worth the guarantee.

No demo change and no `Release:` marker — this is a patch.