### PR TITLE
Show a note as it is, and let a cleanup list be read down

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,32 @@ raised, never by hand.
 
 ## Unreleased
 
+### Added
+
+- `[selector] preview_theme` picks the `bat` theme every file preview is drawn
+  with, and defaults to Catppuccin Mocha. It is passed as `--theme`, so it wins
+  over `BAT_THEME` and your own `bat` config — a preview pane is scriv's to make
+  legible, and a theme chosen for reading whole files in a pager is not always
+  one. A theme your `bat` does not know draws in its default instead of failing.
+  `config check` now reports whether `bat` is installed at all.
+
+### Changed
+
+- A note preview shows the note. It used to show a summary scriv had assembled
+  — the front matter read out, the body redrawn with headings and tags coloured
+  in — and a preview that has rearranged what it is previewing is a preview of
+  something else. Every note pane is now the file itself, through the same
+  `bat` every other preview in scriv goes through, and a `note rg` hit opens at
+  its line with that line marked.
+- `note cleanup` reads down its list. Candidates are grouped by what is wrong
+  with them — the empty ones first, then the untitled, then the ones with no
+  name — and smallest first within each group, since size is what separates a
+  note that was abandoned from one that was written and never titled. Sizes are
+  right-aligned in one letter, `b`/`k`/`M`, so the units stack into a column
+  instead of wandering with the length of each number.
+- `note cleanup` never offers the scratch note. Being empty is what a scratch
+  note is *for*, so it would have been on the list every single run.
+
 ## v0.11.1
 
 *Released 2026-08-25*

--- a/README.md
+++ b/README.md
@@ -37,8 +37,9 @@ Supported platform: macOS on Apple Silicon. `scriv proc` depends on Darwin's
 signal numbers, and the crate refuses to compile for any other target.
 
 External requirements: `git`, plus `gh` for `pr` and `repo clone`/`open`, `rg`
-for `note rg`, a fish history file for `history`, and `$VISUAL` or `$EDITOR` for
-`edit` — or `[note] editor` for `note`. `scriv config check` reports on each.
+for `note rg`, `bat` for syntax-highlighted previews, a fish history file for
+`history`, and `$VISUAL` or `$EDITOR` for `edit` — or `[note] editor` for
+`note`. `scriv config check` reports on each.
 
 ## Setup
 
@@ -95,6 +96,9 @@ label its directory carries; everything else about it is in the preview pane.
 `note rg` searches inside every note as you type — fuzzily, or exactly on
 `ctrl-x` — and turns what you pick into a quickfix list. `note ls` prints
 absolute paths, one per line, for piping into whatever reads paths.
+
+Every preview pane shows the file as it is on disk, drawn by `bat` in
+`[selector] preview_theme` — Catppuccin Mocha unless you say otherwise.
 
 `ls` prints the set, `sel` fuzzy-selects one entry, and the remaining verbs act
 on the selection. `sel` prints to stdout and composes: `cd (scriv repo sel)`.

--- a/src/cmd/config.rs
+++ b/src/cmd/config.rs
@@ -92,6 +92,13 @@ height = "50%"        # finder height, e.g. "50%" or "20"
 # recent = true        # offer repositories and files you have chosen before first
 # preview = true       # show a preview pane for the highlighted row
 # preview_window = "right:50%" # preview layout: [up|down|left|right][:SIZE][:hidden]
+
+# The `bat` theme every file preview is drawn with. Passed as `--theme`, so it
+# wins over BAT_THEME and your own bat config — a preview pane is scriv's to
+# make legible, and a theme chosen for reading whole files in a pager is not
+# always one. A theme bat does not know is not an error: it draws in its own
+# default instead. Empty hands bat nothing and lets its config decide.
+# preview_theme = "Catppuccin Mocha"
 "#;
 
 /// `scriv config init` — write `config.toml` into the config directory,
@@ -569,6 +576,12 @@ fn collect(ctx: &Ctx) -> Vec<Check> {
         "`branch` and `repo` cannot work without it",
     ));
     checks.push(gh_check());
+    checks.push(tool_check(
+        "bat",
+        "bat",
+        false,
+        "previews fall back to `head`, without highlighting or a theme",
+    ));
     checks.push(tool_check(
         "rg",
         "rg",

--- a/src/cmd/note.rs
+++ b/src/cmd/note.rs
@@ -25,10 +25,6 @@ use crate::{Ctx, cmd, select, term};
 /// note is listed by its filename as though it had none.
 const HEAD_BYTES: u64 = 8 * 1024;
 
-/// How much of a note the preview pane reads. Bounded for the same reason a
-/// `Preview::Command` is: skim runs one on every move through the list.
-const PREVIEW_BYTES: u64 = 128 * 1024;
-
 /// The vault, expanded — the one directory `note` looks in.
 fn vault(ctx: &Ctx) -> Result<PathBuf> {
     let root = ctx.config.note.root.as_deref().ok_or_else(|| {
@@ -242,26 +238,19 @@ fn select_notes(ctx: &Ctx) -> Result<Option<Vec<String>>> {
 /// [`Preview::Deferred`]. A vault read up front is one file read per note for
 /// panes the user scrolls past.
 fn items(ctx: &Ctx, notes: &[Note]) -> Vec<SelectItem> {
-    let now = crate::unix_now();
     let cfg = ctx.config.note.clone();
     let offset = ctx.utc_offset();
 
     notes
         .iter()
         .map(|note| {
-            let color = note::row_color(note, &cfg);
-            let note = note.clone();
-            let cfg = cfg.clone();
-            let item = SelectItem::new(note::row(&note), note.path.to_string_lossy().into_owned())
-                .prefix(note::prefix(&note, offset));
-            let item = match color {
+            let item = SelectItem::new(note::row(note), note.path.to_string_lossy().into_owned())
+                .prefix(note::prefix(note, offset))
+                .preview(Preview::File);
+            match note::row_color(note, &cfg) {
                 Some(color) => item.color(color),
                 None => item,
-            };
-            item.preview(Preview::Deferred(Box::new(move || {
-                let text = read_head(&note.path, PREVIEW_BYTES).unwrap_or_default();
-                note::preview(&note, &cfg, &text, now, offset)
-            })))
+            }
         })
         .collect()
 }
@@ -322,19 +311,26 @@ fn with_extension(name: &str) -> String {
 pub fn scratch(ctx: &Ctx) -> Result<()> {
     let editor = ctx.note_editor()?;
     let root = vault(ctx)?;
-    let path = root.join(
-        ctx.config
-            .note
-            .scratch
-            .as_deref()
-            .unwrap_or(note::DEFAULT_SCRATCH),
-    );
+    let path = scratch_path(ctx, &root);
 
     if let Some(dir) = path.parent() {
         std::fs::create_dir_all(dir).with_context(|| format!("creating {}", dir.display()))?;
     }
     ctx.log.info(&format!("scratch note at {}", path.display()));
     cmd::edit::launch(ctx, &editor, &[path.to_string_lossy().into_owned()])
+}
+
+/// Where the scratch note lives. One place, because two commands need to agree
+/// about it: the one that opens it and the one that must never offer to delete
+/// it.
+fn scratch_path(ctx: &Ctx, root: &Path) -> PathBuf {
+    root.join(
+        ctx.config
+            .note
+            .scratch
+            .as_deref()
+            .unwrap_or(note::DEFAULT_SCRATCH),
+    )
 }
 
 // --- cleanup ----------------------------------------------------------------
@@ -347,7 +343,7 @@ pub fn scratch(ctx: &Ctx) -> Result<()> {
 /// vault only its owner can actually read.
 pub fn cleanup(ctx: &Ctx, yes: bool) -> Result<()> {
     let notes = load(ctx)?;
-    let candidates = junk(&notes);
+    let candidates = junk(ctx, &notes)?;
 
     if candidates.is_empty() {
         println!(
@@ -431,16 +427,19 @@ pub fn cleanup(ctx: &Ctx, yes: bool) -> Result<()> {
 /// The whole file is read rather than the head bound the listing uses: "empty"
 /// is a claim about all of it, and a note that only looks empty for the first
 /// eight kilobytes is not one.
-fn junk(notes: &[Note]) -> Vec<(Note, note::Junk, u64)> {
-    notes
+fn junk(ctx: &Ctx, notes: &[Note]) -> Result<Vec<(Note, note::Junk, u64)>> {
+    let scratch = scratch_path(ctx, &vault(ctx)?);
+    let mut candidates: Vec<(Note, note::Junk, u64)> = notes
         .iter()
         .filter_map(|note| {
             let bytes = note.path.metadata().map(|m| m.len()).unwrap_or(0);
             let text = read_head(&note.path, CLEANUP_BYTES).unwrap_or_default();
             let (_, body) = note::split_front_matter(&text);
-            note::junk(note, body).map(|reason| (note.clone(), reason, bytes))
+            note::junk(note, body, &scratch).map(|reason| (note.clone(), reason, bytes))
         })
-        .collect()
+        .collect();
+    note::cleanup_order(&mut candidates);
+    Ok(candidates)
 }
 
 /// How much of a note is read to decide whether there is anything in it. Well
@@ -448,30 +447,23 @@ fn junk(notes: &[Note]) -> Vec<(Note, note::Junk, u64)> {
 const CLEANUP_BYTES: u64 = 64 * 1024;
 
 fn junk_items(ctx: &Ctx, candidates: &[(Note, note::Junk, u64)]) -> Vec<SelectItem> {
-    let now = crate::unix_now();
-    let cfg = ctx.config.note.clone();
-    let offset = ctx.utc_offset();
     let widths = Widths::of(
         &candidates
             .iter()
             .map(|(n, _, _)| n.clone())
             .collect::<Vec<_>>(),
-        &cfg,
+        &ctx.config.note,
         ctx.home_str(),
-    );
+    )
+    .with_sizes(candidates.iter().map(|(_, _, bytes)| *bytes));
 
     candidates
         .iter()
         .map(|(note, reason, bytes)| {
             let (label, tints) = note::junk_row(note, *reason, *bytes, &widths);
-            let note = note.clone();
-            let cfg = cfg.clone();
             SelectItem::new(label, note.path.to_string_lossy().into_owned())
                 .tints(tints)
-                .preview(Preview::Deferred(Box::new(move || {
-                    let text = read_head(&note.path, PREVIEW_BYTES).unwrap_or_default();
-                    note::preview(&note, &cfg, &text, now, offset)
-                })))
+                .preview(Preview::File)
         })
         .collect()
 }
@@ -707,24 +699,13 @@ impl Iterator for Search {
             };
             self.found += 1;
             let (label, tints) = note::match_row(&found, MATCH_COLUMN);
-            let path = found.path.clone();
-            let line = found.line;
+            // The pane opens the note at the line that matched, marked, which
+            // is what a row saying `note.md:41` is promising.
+            let preview = select::line_preview(&found.path.to_string_lossy(), found.line);
             return Some(
                 SelectItem::new(label, note::encode_match(&found))
                     .tints(tints)
-                    .preview(Preview::Deferred(Box::new(move || {
-                        let text = read_head(&path, PREVIEW_BYTES).unwrap_or_default();
-                        note::match_preview(
-                            &note::Match {
-                                path: path.clone(),
-                                rel: path.to_string_lossy().into_owned(),
-                                line,
-                                column: 1,
-                                text: String::new(),
-                            },
-                            &text,
-                        )
-                    }))),
+                    .preview(preview),
             );
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -285,6 +285,14 @@ pub struct SelectorConfig {
     /// Off, every such list keeps the order the command built it in, and
     /// nothing is recorded.
     pub recent: bool,
+    /// The `bat` theme every file preview is drawn with, for the panes that
+    /// show a file's contents.
+    ///
+    /// Passed to `bat` as `--theme`, so it overrides `BAT_THEME` and the user's
+    /// own `bat` config — a preview pane is scriv's to make legible, and a
+    /// theme picked for reading whole files in a pager is not always one.
+    /// Empty hands `bat` nothing and lets its own configuration decide.
+    pub preview_theme: String,
 }
 
 /// How `repo ls`/`sel` renders each repository's path.
@@ -319,9 +327,14 @@ impl Default for SelectorConfig {
             preview: true,
             preview_window: "right:50%".to_string(),
             recent: true,
+            preview_theme: DEFAULT_PREVIEW_THEME.to_string(),
         }
     }
 }
+
+/// The theme previews are drawn with when nothing says otherwise. Bundled with
+/// `bat` since 0.25; an older one warns and draws in its own default instead.
+const DEFAULT_PREVIEW_THEME: &str = "Catppuccin Mocha";
 
 /// The serialized shape of `config.toml`. Superseded keys are still spelled
 /// out so an old config is explained rather than half-read — serde ignores what
@@ -359,6 +372,7 @@ struct RawSelector {
     height: Option<String>,
     preview: Option<bool>,
     preview_window: Option<String>,
+    preview_theme: Option<String>,
     recent: Option<bool>,
     /// Superseded by `[repo] display`, present for detection only.
     display: Option<RepoDisplay>,
@@ -371,6 +385,7 @@ impl From<RawSelector> for SelectorConfig {
             height: raw.height.unwrap_or(default.height),
             preview: raw.preview.unwrap_or(default.preview),
             preview_window: raw.preview_window.unwrap_or(default.preview_window),
+            preview_theme: raw.preview_theme.unwrap_or(default.preview_theme),
             recent: raw.recent.unwrap_or(default.recent),
         }
     }

--- a/src/note.rs
+++ b/src/note.rs
@@ -16,22 +16,10 @@ use std::path::{Path, PathBuf};
 
 use crate::select::Tint;
 
-/// How the columns of a note row are coloured — indices into the ANSI
-/// 256-colour table, so they follow the terminal's own theme. Blue for the
-/// folder, as every file listing colours a directory; magenta for tags, which
-/// is the one hue no status in scriv already means something with.
-///
-/// The title carries no colour of its own: it is what the query matches, and
-/// skim's match highlighting has to be the brightest thing on the row.
+/// The colour of a search row's path — an index into the ANSI 256-colour
+/// table, so it follows the terminal's own theme. Blue, as every file listing
+/// colours a path.
 const FOLDER_COLOR: u8 = 4;
-const TAG_COLOR: u8 = 5;
-const OPEN_COLOR: u8 = 3;
-
-/// The colour of a group that is a bare directory name rather than a configured
-/// label: the terminal's own grey, since an unlabelled directory is context
-/// rather than a statement.
-const UNLABELLED_COLOR: u8 = 8;
-
 /// What a note's front matter said about it.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct Front {
@@ -62,72 +50,6 @@ pub struct Note {
     /// Created, in Unix seconds. See [`created`].
     pub created: i64,
     pub front: Front,
-}
-
-/// The checkboxes in a note's body: how much of what it asked for is done.
-///
-/// The one thing a Markdown note says about itself that is neither its name nor
-/// its metadata, and the one worth a column: a vault is full of notes that are
-/// finished and notes that are still owed something, and nothing else on the
-/// row tells them apart.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-pub struct Tasks {
-    pub open: usize,
-    pub done: usize,
-}
-
-impl Tasks {
-    pub fn total(self) -> usize {
-        self.open + self.done
-    }
-
-    fn color(self) -> u8 {
-        if self.open == 0 {
-            DONE_COLOR
-        } else {
-            OPEN_COLOR
-        }
-    }
-}
-
-/// Count the checkboxes in a note's body. A task is a list item whose marker is
-/// followed by `[ ]` or `[x]`, which is the form every Markdown renderer that
-/// draws a checkbox agrees on.
-pub fn count_tasks(body: &str) -> Tasks {
-    let mut tasks = Tasks::default();
-    let mut fenced = false;
-    for line in body.lines() {
-        let trimmed = line.trim_start();
-        if trimmed.starts_with("```") || trimmed.starts_with("~~~") {
-            fenced = !fenced;
-            continue;
-        }
-        // A checkbox inside a fence is an example of one, not one.
-        if fenced {
-            continue;
-        }
-        let Some((_, after)) = bullet(trimmed) else {
-            continue;
-        };
-        match ticked(after) {
-            Some(true) => tasks.done += 1,
-            Some(false) => tasks.open += 1,
-            None => {}
-        }
-    }
-    tasks
-}
-
-/// Whether the text opens with a ticked box, an empty one, or neither.
-fn ticked(text: &str) -> Option<bool> {
-    let mut chars = text.strip_prefix('[')?.chars();
-    let mark = chars.next()?;
-    chars.next().filter(|c| *c == ']')?;
-    match mark {
-        ' ' => Some(false),
-        'x' | 'X' => Some(true),
-        _ => None,
-    }
 }
 
 impl Note {
@@ -453,6 +375,11 @@ pub struct Widths {
     pub group: usize,
     pub tags: usize,
     pub path: usize,
+    /// The vault-relative path, which the cleanup list shows where a report
+    /// shows the whole thing.
+    pub rel: usize,
+    /// The widest rendered [`size`], so the sizes right-align under each other.
+    pub size: usize,
 }
 
 impl Widths {
@@ -463,7 +390,15 @@ impl Widths {
             group: widest(&|n| n.group(cfg).chars().count()),
             tags: widest(&|n| n.tag_column().chars().count()),
             path: widest(&|n| n.shown(home).chars().count()),
+            rel: widest(&|n| n.rel.chars().count()),
+            size: 0,
         }
+    }
+
+    /// The widths a cleanup list needs on top: the sizes it is going to draw.
+    pub fn with_sizes(mut self, sizes: impl Iterator<Item = u64>) -> Self {
+        self.size = sizes.map(|b| size(b).chars().count()).max().unwrap_or(0);
+        self
     }
 }
 
@@ -569,246 +504,6 @@ pub fn is_note(path: &Path) -> bool {
 /// things to hand an editor.
 const NOTE_EXTENSIONS: &[&str] = &["md", "markdown"];
 
-// --- preview ----------------------------------------------------------------
-
-/// Colours the preview pane draws with. Grey for everything that is context
-/// rather than content, cyan for headings, blue for a link, green for a task
-/// that is done.
-const DIM: u8 = 8;
-const HEADING_COLOR: u8 = 6;
-const LINK_COLOR: u8 = 4;
-const DONE_COLOR: u8 = 2;
-
-/// How much of a note the preview pane shows, matching what `bat` is asked for
-/// elsewhere. A pane is thirty rows; anything past this is for the editor.
-const PREVIEW_LINES: usize = 200;
-
-/// The preview pane for a note: what the row could not fit, then the note.
-///
-/// The header is where the two age columns on the row are spelled out — a
-/// column reading `3d  2y` says which is which only once something says it,
-/// and the pane has the width to.
-///
-/// The body is drawn rather than shelled out to `bat`: a vault is thousands of
-/// notes and skim runs a preview on every move through the list, so the pane
-/// that costs nothing to produce is the one that keeps up. Front matter is not
-/// repeated — the header above is what it says, read.
-///
-/// Rendering is line-level. Headings, quotes, list markers, task boxes and code
-/// fences are what a note is made of at a glance; `**bold**` and its friends
-/// are left as the author wrote them, since a pane that hides the markup it
-/// cannot render is lying about the file.
-pub fn preview(
-    note: &Note,
-    cfg: &crate::config::NoteConfig,
-    text: &str,
-    now: i64,
-    offset: time::UtcOffset,
-) -> String {
-    let mut out = String::new();
-
-    out.push_str(&bold(&crate::term::one_row(note.title())));
-    out.push('\n');
-    out.push_str(&paint(&crate::term::one_row(&note.rel), DIM));
-    out.push('\n');
-
-    let (_, body) = split_front_matter(text);
-    let group = note.group(cfg);
-    let mut facts = Vec::new();
-    if !group.is_empty() {
-        let color = match note.labelled(cfg) {
-            true => cfg.color_of(group).unwrap_or(UNLABELLED_COLOR),
-            false => UNLABELLED_COLOR,
-        };
-        facts.push(paint(&crate::term::one_row(group), color));
-    }
-    let tags = note.tag_column();
-    if !tags.is_empty() {
-        facts.push(paint(&crate::term::one_row(&tags), TAG_COLOR));
-    }
-    // Counted here rather than carried on every note: this is the only place
-    // it is shown, and the text it is counted from has just been read anyway.
-    let tasks = count_tasks(body);
-    if tasks.total() > 0 {
-        facts.push(paint(
-            &format!("{} of {} done", tasks.done, tasks.total()),
-            tasks.color(),
-        ));
-    }
-    if !facts.is_empty() {
-        out.push_str(&facts.join(&paint("  \u{b7}  ", DIM)));
-        out.push('\n');
-    }
-
-    out.push_str(&paint(
-        &format!(
-            "modified {} ({})   created {} ({})",
-            timestamp(note.modified, offset),
-            age(now, note.modified),
-            date(note.created, offset),
-            age(now, note.created),
-        ),
-        DIM,
-    ));
-    out.push('\n');
-
-    let mut fenced = false;
-    for line in body
-        .lines()
-        .skip_while(|line| line.trim().is_empty())
-        .take(PREVIEW_LINES)
-    {
-        // Every line reaching the terminal is a note's own bytes, so its
-        // control characters go before anything is drawn: a note holding an
-        // escape sequence would otherwise repaint the pane around it.
-        out.push('\n');
-        out.push_str(&markdown_line(&crate::term::one_row(line), &mut fenced));
-    }
-    out
-}
-
-/// One body line, drawn. `fenced` carries whether the line before it was inside
-/// a fenced code block, which is the only state a line-level renderer needs.
-fn markdown_line(line: &str, fenced: &mut bool) -> String {
-    let trimmed = line.trim_start();
-
-    if trimmed.starts_with("```") || trimmed.starts_with("~~~") {
-        *fenced = !*fenced;
-        return paint(line, DIM);
-    }
-    // Inside a fence every character is the author's, `#` and `[[` included.
-    if *fenced {
-        return line.to_string();
-    }
-
-    if let Some(heading) = heading(trimmed) {
-        return format!("\x1b[1;38;5;{HEADING_COLOR}m{heading}\x1b[0m");
-    }
-    if trimmed.starts_with('>') || is_rule(trimmed) {
-        return paint(line, DIM);
-    }
-    match task_or_bullet(line) {
-        Some((marker, rest)) => format!("{marker}{}", inline(rest)),
-        None => inline(line),
-    }
-}
-
-/// An ATX heading's text, `#` marks and all — kept, because a level is
-/// something a reader counts.
-fn heading(trimmed: &str) -> Option<&str> {
-    let hashes = trimmed.len() - trimmed.trim_start_matches('#').len();
-    ((1..=6).contains(&hashes) && trimmed[hashes..].starts_with(' ')).then_some(trimmed)
-}
-
-/// Whether the line is a thematic break rather than text.
-fn is_rule(trimmed: &str) -> bool {
-    let mark = trimmed.chars().next().filter(|c| "-*_".contains(*c));
-    mark.is_some_and(|mark| {
-        trimmed.chars().filter(|c| *c == mark).count() >= 3
-            && trimmed.chars().all(|c| c == mark || c == ' ')
-    })
-}
-
-/// A list line split into its drawn marker and the text after it: the bullet
-/// dim, a task's box green once it is ticked.
-fn task_or_bullet(line: &str) -> Option<(String, &str)> {
-    let indent = line.len() - line.trim_start().len();
-    let (bullet, after) = bullet(&line[indent..])?;
-    let head = &line[..indent + bullet.len()];
-
-    let Some(box_end) = task_box(after) else {
-        return Some((paint(head, DIM), after));
-    };
-    let (ticked, rest) = after.split_at(box_end);
-    let done = !ticked.contains(|c: char| c == ' ' && ticked.starts_with("[ "));
-    Some((
-        format!(
-            "{}{}",
-            paint(head, DIM),
-            paint(ticked, if done { DONE_COLOR } else { DIM })
-        ),
-        rest,
-    ))
-}
-
-/// The `- `, `* `, `+ ` or `1. ` opening a list item, and what follows it.
-fn bullet(text: &str) -> Option<(&str, &str)> {
-    if let Some(rest) = text
-        .strip_prefix(['-', '*', '+'])
-        .and_then(|r| r.strip_prefix(' '))
-    {
-        return Some((&text[..2], rest));
-    }
-    let digits = text.len() - text.trim_start_matches(|c: char| c.is_ascii_digit()).len();
-    if digits == 0 {
-        return None;
-    }
-    let rest = text[digits..].strip_prefix(['.', ')'])?.strip_prefix(' ')?;
-    Some((&text[..digits + 2], rest))
-}
-
-/// Where a task checkbox ends, when the text opens with one.
-fn task_box(text: &str) -> Option<usize> {
-    let inner = text.strip_prefix('[')?;
-    let mut chars = inner.chars();
-    let mark = chars.next()?;
-    chars.next().filter(|c| *c == ']')?;
-    // `[ ]` and `[x]` and nothing wider: `[2024-01-01]` opens a link, not a
-    // task.
-    (mark == ' ' || !mark.is_whitespace()).then_some(3)
-}
-
-/// Colour what a note's body says about itself: `[[wikilinks]]` and `#tags`.
-fn inline(line: &str) -> String {
-    let mut out = String::with_capacity(line.len());
-    let mut at = 0;
-    // A tag opens a word; `C#` in a sentence and a `#fragment` on a URL do not.
-    let mut boundary = true;
-
-    while at < line.len() {
-        if line[at..].starts_with("[[")
-            && let Some(end) = line[at + 2..].find("]]")
-        {
-            let link = &line[at..at + 2 + end + 2];
-            out.push_str(&paint(link, LINK_COLOR));
-            at += link.len();
-            boundary = false;
-            continue;
-        }
-        if boundary && let Some(tag) = tag_at(&line[at..]) {
-            out.push_str(&paint(tag, TAG_COLOR));
-            at += tag.len();
-            boundary = false;
-            continue;
-        }
-        let ch = line[at..].chars().next().expect("scanning by character");
-        boundary = ch.is_whitespace();
-        out.push(ch);
-        at += ch.len_utf8();
-    }
-    out
-}
-
-/// The tag `text` opens with, if it opens with one. A tag is `#` and at least
-/// one character of `[A-Za-z0-9/_-]`, not all of them digits — Obsidian's own
-/// rule, and what keeps `#1234` an issue number and `#fff` a colour.
-fn tag_at(text: &str) -> Option<&str> {
-    let rest = text.strip_prefix('#')?;
-    let len = rest
-        .find(|c: char| !(c.is_alphanumeric() || "/_-".contains(c)))
-        .unwrap_or(rest.len());
-    let tag = &rest[..len];
-    (!tag.is_empty() && !tag.chars().all(|c| c.is_ascii_digit())).then(|| &text[..len + 1])
-}
-
-fn paint(text: &str, color: u8) -> String {
-    crate::term::paint(text, color, true)
-}
-
-fn bold(text: &str) -> String {
-    format!("\x1b[1m{text}\x1b[0m")
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -826,6 +521,11 @@ mod tests {
             created: 0,
             front,
         }
+    }
+
+    /// The one note a cleanup list never offers, however empty it is.
+    fn scratch() -> &'static Path {
+        Path::new("/vault/scratch/scratch.md")
     }
 
     /// A vault where `work` is labelled and `scratch` is not.
@@ -1159,19 +859,6 @@ mod tests {
         }
     }
 
-    #[test]
-    fn tasks_are_counted_from_the_body() {
-        let counted = count_tasks("- [ ] a\n* [x] b\n  + [X] c\n- not a task\n1. [ ] d\n");
-        assert_eq!(counted, Tasks { open: 2, done: 2 });
-    }
-
-    /// A checkbox inside a fence is an example of one, not one.
-    #[test]
-    fn a_task_in_a_code_fence_is_not_counted() {
-        let counted = count_tasks("- [ ] real\n```md\n- [ ] example\n```\n");
-        assert_eq!(counted, Tasks { open: 1, done: 0 });
-    }
-
     // --- cleanup ---
 
     fn body_of(len: usize) -> String {
@@ -1181,9 +868,9 @@ mod tests {
     #[test]
     fn a_note_with_nothing_in_it_is_a_candidate() {
         let note = note("thoughts.md", Front::default());
-        assert_eq!(junk(&note, ""), Some(Junk::Empty));
-        assert_eq!(junk(&note, "# Thoughts\n"), Some(Junk::Empty));
-        assert_eq!(junk(&note, &body_of(20)), None);
+        assert_eq!(junk(&note, "", scratch()), Some(Junk::Empty));
+        assert_eq!(junk(&note, "# Thoughts\n", scratch()), Some(Junk::Empty));
+        assert_eq!(junk(&note, &body_of(20), scratch()), None);
     }
 
     /// What an editor calls a file nobody named, and everything it goes on to
@@ -1197,12 +884,16 @@ mod tests {
             "untitled_3.md",
         ] {
             let note = note(name, Front::default());
-            assert_eq!(junk(&note, &body_of(20)), Some(Junk::Untitled), "{name}");
+            assert_eq!(
+                junk(&note, &body_of(20), scratch()),
+                Some(Junk::Untitled),
+                "{name}"
+            );
         }
         // Not every name that begins with the word.
         for name in ["Untitled thoughts.md", "untitledness.md"] {
             let note = note(name, Front::default());
-            assert_eq!(junk(&note, &body_of(20)), None, "{name}");
+            assert_eq!(junk(&note, &body_of(20), scratch()), None, "{name}");
         }
     }
 
@@ -1211,7 +902,7 @@ mod tests {
     #[test]
     fn a_note_named_only_by_numbers_is_a_candidate_unless_it_says_otherwise() {
         let jotted = note("2026-08-25 1043.md", Front::default());
-        assert_eq!(junk(&jotted, &body_of(20)), Some(Junk::Unnamed));
+        assert_eq!(junk(&jotted, &body_of(20), scratch()), Some(Junk::Unnamed));
 
         let titled = note(
             "2026-08-25 1043.md",
@@ -1220,7 +911,7 @@ mod tests {
                 ..Front::default()
             },
         );
-        assert_eq!(junk(&titled, &body_of(20)), None);
+        assert_eq!(junk(&titled, &body_of(20), scratch()), None);
     }
 
     /// A name is whatever the writer typed, and this repository's owner writes
@@ -1264,8 +955,8 @@ mod tests {
                 let _ = note.shown("/home/me");
                 let _ = row(&note);
                 let _ = prefix(&note, utc());
-                let _ = junk(&note, "");
-                let _ = junk(&note, &"word ".repeat(20));
+                let _ = junk(&note, "", scratch());
+                let _ = junk(&note, &"word ".repeat(20), scratch());
                 let widths = Widths::of(std::slice::from_ref(&note), &cfg, "/home/me");
                 let _ = status_row(&note, &cfg, &widths, utc(), "/home/me");
                 let _ = junk_row(&note, Junk::Untitled, 10, &widths);
@@ -1280,7 +971,7 @@ mod tests {
         for name in ["Prosjektø", "Løsningø", "abcdefgø", "Størrelse"] {
             let note = note(&format!("{name}.md"), Front::default());
             assert_ne!(
-                junk(&note, &"word ".repeat(20)),
+                junk(&note, &"word ".repeat(20), scratch()),
                 Some(Junk::Untitled),
                 "{name}"
             );
@@ -1291,109 +982,88 @@ mod tests {
     #[test]
     fn a_cleanup_row_says_why_the_note_is_on_the_list() {
         let notes = vault();
-        let widths = Widths::of(&notes, &config(), "/home/me");
+        let widths = Widths::of(&notes, &config(), "/home/me").with_sizes([0].into_iter());
         let (row, tints) = junk_row(&notes[0], Junk::Empty, 0, &widths);
         assert!(row.starts_with("empty"), "{row:?}");
         assert!(row.contains("work/meetings/standup.md"), "{row:?}");
-        assert!(row.ends_with("empty"), "{row:?}");
+        assert!(row.ends_with("0b"), "{row:?}");
         assert_eq!(tints[0].range, 0.."empty".len());
         assert_eq!(tints[0].color, Junk::Empty.color());
     }
 
+    /// One number and one letter, so a column of sizes reads down its last
+    /// character rather than being measured.
     #[test]
-    fn a_size_is_read_rather_than_counted() {
-        assert_eq!(size(0), "empty");
-        assert_eq!(size(512), "512 B");
-        assert_eq!(size(4096), "4 KB");
+    fn a_size_is_one_number_and_one_letter() {
+        assert_eq!(size(0), "0b");
+        assert_eq!(size(512), "512b");
+        assert_eq!(size(1024), "1k");
+        assert_eq!(size(4096), "4k");
+        assert_eq!(size(2 * 1024 * 1024), "2M");
     }
 
-    // --- preview ---
-
-    fn preview_of(text: &str) -> String {
-        preview(
-            &note("work/a.md", Front::default()),
-            &config(),
-            text,
-            0,
-            utc(),
-        )
-    }
-
-    /// The header is where the row's two age columns are named; without it the
-    /// pair reads as two numbers.
+    /// The whole point of right-aligning it: the units stack, so a glance down
+    /// the list tells bytes from kilobytes without reading a single number.
     #[test]
-    fn the_preview_names_both_dates_the_row_only_shows() {
-        let rendered = preview_of("body\n");
-        assert!(rendered.contains("modified "), "{rendered}");
-        assert!(rendered.contains("created "), "{rendered}");
-    }
-
-    /// The header already says everything the block does, spelled out.
-    #[test]
-    fn the_preview_shows_the_body_and_not_the_front_matter() {
-        let rendered = preview_of("---\ntitle: A\ntags: [x]\n---\n\n# Heading\n");
-        assert!(rendered.contains("Heading"), "{rendered}");
-        assert!(!rendered.contains("tags: [x]"), "{rendered}");
-    }
-
-    /// A note is foreign text: an escape sequence in one would otherwise
-    /// repaint the pane around it. Only scriv's own colours survive the body.
-    #[test]
-    fn a_note_cannot_colour_the_pane_with_its_own_escapes() {
-        let rendered = preview_of("plain \x1b[31mred\x1b[0m\n");
-        let body = rendered.split_once("\n\n").expect("a body").1;
-        assert!(body.contains("red"), "{body:?}");
-        assert!(!body.contains('\x1b'), "{body:?}");
-    }
-
-    #[test]
-    fn a_preview_stops_at_the_line_it_is_bounded_to() {
-        let long = "line\n".repeat(PREVIEW_LINES * 2);
-        let rendered = preview_of(&long);
-        assert_eq!(rendered.matches("line").count(), PREVIEW_LINES);
-    }
-
-    fn drawn(line: &str) -> String {
-        markdown_line(line, &mut false)
-    }
-
-    /// The renderer scans a line by byte offset — advancing a cursor, slicing
-    /// out a wikilink, measuring a tag. Every one of those is the same class of
-    /// bug as the one that crashed `note cleanup`, so every one is held here.
-    #[test]
-    fn a_body_that_is_not_ascii_renders_without_panicking() {
-        let lines = [
-            "# Størrelsesorden",
-            "møte med Kjærsti om løsningen",
-            "- [ ] ærlig talt",
-            "- [x] åpne saker",
-            "> sitat på norsk",
-            "se [[nøtter/møter]] og #løsning",
-            "#ø",
-            "ø",
-            "日本語 [[ノート]] #タグ",
-            "🎉 [[emoji]] #party 🎉",
-            "  - [[øy]]",
-            "1. tåler dette",
-            "---",
-            "```rust",
-            "let x = \"ø\";",
-            "```",
-        ];
-        let mut fenced = false;
-        for line in lines {
-            let _ = markdown_line(line, &mut fenced);
-        }
-
-        let text = format!(
-            "---\ntitle: Årsmøte\ntags: [løsning, ærlig]\n---\n{}",
-            lines.join("\n")
+    fn every_size_ends_in_the_same_column() {
+        let notes = vault();
+        let sizes = [0u64, 900, 4096, 5 * 1024 * 1024];
+        let widths = Widths::of(&notes, &config(), "/home/me").with_sizes(sizes.into_iter());
+        let rows: Vec<String> = sizes
+            .iter()
+            .map(|bytes| junk_row(&notes[0], Junk::Empty, *bytes, &widths).0)
+            .collect();
+        let lengths: Vec<usize> = rows.iter().map(|r| r.chars().count()).collect();
+        assert!(
+            lengths.windows(2).all(|w| w[0] == w[1]),
+            "the sizes do not line up: {rows:?}"
         );
-        let note = note("nøtter/møte.md", front(&text));
-        let rendered = preview(&note, &config(), &text, 0, utc());
-        assert!(rendered.contains("Årsmøte"), "{rendered}");
-        assert!(rendered.contains("#løsning #ærlig"), "{rendered}");
-        assert!(rendered.contains("Størrelsesorden"), "{rendered}");
+    }
+
+    /// Grouped by what is wrong, then smallest first — which is what makes a
+    /// cleanup list answerable a group at a time rather than a row at a time.
+    #[test]
+    fn a_cleanup_list_is_grouped_by_reason_and_then_by_size() {
+        let at = |rel: &str| note(rel, Front::default());
+        let mut candidates = vec![
+            (at("d.md"), Junk::Unnamed, 900),
+            (at("a.md"), Junk::Empty, 12),
+            (at("c.md"), Junk::Unnamed, 40),
+            (at("b.md"), Junk::Untitled, 700),
+            (at("e.md"), Junk::Empty, 0),
+        ];
+        cleanup_order(&mut candidates);
+
+        let order: Vec<(&str, Junk, u64)> = candidates
+            .iter()
+            .map(|(n, reason, size)| (n.rel.as_str(), *reason, *size))
+            .collect();
+        assert_eq!(
+            order,
+            vec![
+                ("e.md", Junk::Empty, 0),
+                ("a.md", Junk::Empty, 12),
+                ("b.md", Junk::Untitled, 700),
+                ("c.md", Junk::Unnamed, 40),
+                ("d.md", Junk::Unnamed, 900),
+            ]
+        );
+    }
+
+    /// Being empty is what the scratch note is *for*, so offering to delete it
+    /// would offer that on every run.
+    #[test]
+    fn the_scratch_note_is_never_a_candidate() {
+        let pad = Note {
+            path: scratch().to_path_buf(),
+            ..note("scratch/scratch.md", Front::default())
+        };
+        assert_eq!(junk(&pad, "", scratch()), None);
+        assert_eq!(junk(&pad, "Untitled", scratch()), None);
+
+        // Its neighbours are offered as usual.
+        let other = note("scratch/other.md", Front::default());
+        assert_eq!(junk(&other, "", scratch()), Some(Junk::Empty));
     }
 
     /// Front matter is read character by character too, and a Norwegian tag is
@@ -1403,53 +1073,6 @@ mod tests {
         let parsed = front("---\ntitle: Årsmøte\ntags: [løsning, ærlig, 日本語]\n---\n");
         assert_eq!(parsed.title.as_deref(), Some("Årsmøte"));
         assert_eq!(parsed.tags, vec!["løsning", "ærlig", "日本語"]);
-    }
-
-    #[test]
-    fn a_heading_keeps_its_hashes_so_its_level_is_still_countable() {
-        assert!(drawn("## Notes").contains("## Notes"));
-    }
-
-    #[test]
-    fn a_ticked_task_and_an_open_one_are_not_drawn_alike() {
-        assert_ne!(drawn("- [x] done"), drawn("- [ ] open"));
-        assert!(drawn("- [x] done").contains("done"));
-    }
-
-    #[test]
-    fn a_wikilink_and_a_tag_are_coloured_where_they_appear() {
-        let rendered = drawn("see [[other note]] about #rust");
-        assert!(
-            rendered.contains(&paint("[[other note]]", LINK_COLOR)),
-            "{rendered:?}"
-        );
-        assert!(
-            rendered.contains(&paint("#rust", TAG_COLOR)),
-            "{rendered:?}"
-        );
-    }
-
-    /// A `#` that opens no word is not a tag: `#1234` is an issue number and
-    /// `#fff` a colour, and both sit in the middle of prose.
-    #[test]
-    fn a_hash_that_is_not_a_tag_is_left_alone() {
-        for line in ["issue #1234", "C# is a language", "url#fragment"] {
-            assert_eq!(drawn(line), line, "{line:?}");
-        }
-    }
-
-    /// Inside a fence every character is the author's, `#` and `[[` included.
-    #[test]
-    fn a_fenced_block_is_not_rendered_as_markdown() {
-        let mut fenced = false;
-        markdown_line("```sh", &mut fenced);
-        assert!(fenced);
-        assert_eq!(
-            markdown_line("# not a heading", &mut fenced),
-            "# not a heading"
-        );
-        markdown_line("```", &mut fenced);
-        assert!(!fenced);
     }
 }
 
@@ -1616,39 +1239,6 @@ pub fn match_row(found: &Match, width: usize) -> (String, Vec<Tint>) {
 /// numbers its lines.
 const LINE_COLOR: u8 = 3;
 
-/// How much of a note the search preview shows either side of the match.
-const MATCH_CONTEXT: usize = 12;
-
-/// The preview pane for a search row: the matched line in the note around it,
-/// with the match itself marked.
-pub fn match_preview(found: &Match, text: &str) -> String {
-    let mut out = paint(&crate::term::one_row(&found.rel), DIM);
-    out.push('\n');
-
-    let line = found.line.max(1) as usize;
-    let first = line.saturating_sub(MATCH_CONTEXT).max(1);
-    let number_width = (line + MATCH_CONTEXT).to_string().len();
-
-    for (offset, body) in text
-        .lines()
-        .enumerate()
-        .skip(first - 1)
-        .take(MATCH_CONTEXT * 2 + 1)
-    {
-        let number = offset + 1;
-        let body = crate::term::one_row(body);
-        out.push('\n');
-        out.push_str(&paint(&format!("{number:>number_width$}"), DIM));
-        out.push(' ');
-        if number == line {
-            out.push_str(&format!("\x1b[1;38;5;{LINE_COLOR}m{body}\x1b[0m"));
-        } else {
-            out.push_str(&body);
-        }
-    }
-    out
-}
-
 // --- new notes --------------------------------------------------------------
 
 /// The name a new note takes when the user did not give one: the local date and
@@ -1746,9 +1336,6 @@ mod search_tests {
         }
         let back = decode_match(&encode_match(&found), &root()).unwrap();
         assert_eq!(back.rel, found.rel);
-
-        let rendered = match_preview(&found, "første\nandre\nærlig talt, en løsning\n");
-        assert!(rendered.contains("løsning"), "{rendered}");
     }
 
     #[test]
@@ -1852,7 +1439,11 @@ mod search_tests {
 /// The three shapes a note takes when it was never really written: one that was
 /// started and abandoned, one the editor named because nobody did, and one
 /// whose name is a timestamp somebody meant to replace.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+///
+/// The order the variants are written in is the order a cleanup list is read
+/// in: the notes with nothing in them, which are the easiest call, before the
+/// ones that only want a name.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Junk {
     /// Nothing in it, or so little that nothing was said.
     Empty,
@@ -1895,7 +1486,14 @@ const MIN_BODY: usize = 24;
 /// Deliberately three rules and no more. Anything cleverer — a note nothing
 /// links to, a note nothing has opened in a year — is a judgement about what
 /// the vault is *for*, and this is a list to look through rather than a verdict.
-pub fn junk(note: &Note, body: &str) -> Option<Junk> {
+///
+/// `scratch` is the one note that is never on it, whatever it holds.
+pub fn junk(note: &Note, body: &str, scratch: &Path) -> Option<Junk> {
+    // Being empty is what the scratch note is *for* — it is emptied every time
+    // it is used up — so offering to delete it would offer that on every run.
+    if note.path == scratch {
+        return None;
+    }
     if body.chars().filter(|c| !c.is_whitespace()).count() < MIN_BODY {
         return Some(Junk::Empty);
     }
@@ -1931,40 +1529,68 @@ fn is_untitled(name: &str) -> bool {
 
 const UNTITLED: &str = "untitled";
 
-/// One row of the cleanup selector: why it is here, then where it is.
+/// Order a cleanup list: by what is wrong with each note, then smallest first.
+///
+/// Grouping by reason is what makes the list answerable — the empty ones are
+/// one decision taken together, and the ones that only want a name are another.
+/// Within a group the smallest come first, since size is what separates a note
+/// that was abandoned from one that was written and never titled. Ties go to
+/// the path, so a listing does not shuffle between runs.
+pub fn cleanup_order(candidates: &mut [(Note, Junk, u64)]) {
+    candidates.sort_by(|(a, a_reason, a_size), (b, b_reason, b_size)| {
+        a_reason
+            .cmp(b_reason)
+            .then_with(|| a_size.cmp(b_size))
+            .then_with(|| a.rel.cmp(&b.rel))
+    });
+}
+
+/// One row of the cleanup selector: why it is here, where it is, and how much
+/// of it there is.
 ///
 /// The reason leads because it is what the list is being read for — the same
 /// three words over and over, which is exactly what makes the odd one out
-/// visible.
+/// visible. The size trails, right-aligned, so the units stack into a column
+/// instead of wandering with the length of each number.
 pub fn junk_row(note: &Note, reason: Junk, bytes: u64, widths: &Widths) -> (String, Vec<Tint>) {
     let label = reason.label();
     let mut row = String::new();
     push_column(&mut row, label, JUNK_REASON_WIDTH);
     row.push_str(COLUMN_GAP);
-    push_column(
-        &mut row,
-        &note.rel,
-        widths.title.max(note.rel.chars().count()),
-    );
+    push_column(&mut row, &note.rel, widths.rel);
     row.push_str(COLUMN_GAP);
-    row.push_str(&size(bytes));
+    push_right(&mut row, &size(bytes), widths.size);
 
     let tints = vec![Tint {
         range: 0..label.chars().count(),
         color: reason.color(),
     }];
-    (row.trim_end().to_string(), tints)
+    (row, tints)
+}
+
+/// Append `text` padded to `width` characters on its left.
+fn push_right(row: &mut String, text: &str, width: usize) {
+    for _ in text.chars().count()..width {
+        row.push(' ');
+    }
+    row.push_str(text);
 }
 
 /// Wide enough for the longest of [`Junk::label`], so the paths line up.
 const JUNK_REASON_WIDTH: usize = 8;
 
 /// A file size a person reads rather than counts.
+///
+/// One letter, not two: the unit is the last character of every size, so a
+/// column of them lines up under itself and the eye reads down the letters
+/// rather than hunting for where each number ended.
 pub fn size(bytes: u64) -> String {
+    const K: u64 = 1024;
+    const M: u64 = K * K;
     match bytes {
-        0 => "empty".to_string(),
-        b if b < 1024 => format!("{b} B"),
-        b => format!("{} KB", b / 1024),
+        b if b < K => format!("{b}b"),
+        b if b < M => format!("{}k", b / K),
+        b => format!("{}M", b / M),
     }
 }
 

--- a/src/select.rs
+++ b/src/select.rs
@@ -105,9 +105,59 @@ pub fn checkout_preview(path: &str) -> Preview {
 fn file_preview_cmd(path: &str) -> String {
     let path = quote(path);
     format!(
-        "bat --color=always --style=plain --line-range=:200 -- {path} 2>/dev/null \
-         || head -n 200 -- {path}"
+        "bat --color=always --style=plain {theme} --line-range=:200 -- {path} 2>/dev/null \
+         || head -n 200 -- {path}",
+        theme = theme_flag(),
     )
+}
+
+/// How much of a file the preview shows either side of a line it is opened at.
+const LINE_CONTEXT: u32 = 12;
+
+/// The preview for one *line* of a file: the lines around it, with that one
+/// marked — for a search result, where the answer is a place rather than a file.
+///
+/// Line numbers are drawn here where an ordinary file preview leaves them out:
+/// the row said `note.md:41`, and a pane that cannot show 41 is asking to be
+/// counted down by hand.
+pub fn line_preview(path: &str, line: u32) -> Preview {
+    let quoted = quote(path);
+    let first = line.saturating_sub(LINE_CONTEXT).max(1);
+    let last = line.saturating_add(LINE_CONTEXT);
+    Preview::Command(format!(
+        "bat --color=always --style=numbers {theme} --highlight-line {line} \
+         --line-range={first}:{last} -- {quoted} 2>/dev/null \
+         || sed -n '{first},{last}p' -- {quoted}",
+        theme = theme_flag(),
+    ))
+}
+
+/// The `--theme` bat is given, as a flag ready to drop into a command line, or
+/// nothing when the configuration asked for nothing.
+///
+/// A theme bat does not know is not an error: it warns on stderr — which the
+/// preview command already discards — and falls back to its own default. So an
+/// older bat, or one whose theme set does not include the configured one, keeps
+/// working and simply looks like the user's own `bat` does.
+fn theme_flag() -> String {
+    match preview_theme() {
+        "" => String::new(),
+        theme => format!("--theme={}", quote(theme)),
+    }
+}
+
+/// The preview theme, resolved once from the configuration the first selector
+/// ran with.
+///
+/// Set rather than passed because a [`Preview::File`] builds its command inside
+/// [`SkimItem::preview`], which skim calls on a row long after the row was made
+/// and with no configuration in reach. One process reads one configuration —
+/// [`crate::Ctx`] resolves it once — so a value fixed for the life of the
+/// process is the same value every caller would have been handed.
+static PREVIEW_THEME: std::sync::OnceLock<String> = std::sync::OnceLock::new();
+
+fn preview_theme() -> &'static str {
+    PREVIEW_THEME.get().map(String::as_str).unwrap_or_default()
 }
 
 /// A stretch of a label drawn in its own colour, as a character range.
@@ -952,6 +1002,9 @@ fn run_selector(feed: Feed, run: Run, cfg: &SelectorConfig) -> Result<Outcome> {
     // skim does not stop when its input ends, so a selector whose terminal has
     // gone spins at 100% CPU until something kills the process.
     let _watch = crate::term::watch_for_hangup();
+
+    // Fixed here rather than threaded through every row: see [`PREVIEW_THEME`].
+    let _ = PREVIEW_THEME.set(cfg.preview_theme.clone());
 
     let mut builder = SkimOptionsBuilder::default();
     builder

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1868,6 +1868,8 @@ fn config_check_counts_the_notes_in_the_vault() {
     assert!(run.stdout.contains("note editor"), "{}", run.stdout);
     // `note rg` shells out to it, so the report says whether it is there.
     assert!(run.stdout.contains("rg"), "{}", run.stdout);
+    // So does every preview pane, which is where the theme is applied.
+    assert!(run.stdout.contains("bat"), "{}", run.stdout);
 }
 
 /// The scratch note is the same file every time, and its directory is made for
@@ -2112,4 +2114,54 @@ fn note_ls_status_reads_a_norwegian_vault_correctly() {
     assert!(row.contains("arbeid"), "{row}");
     assert!(row.contains("#løsning"), "{row}");
     assert!(row.ends_with("2024-03-01"), "{row}");
+}
+
+/// The scratch note is empty by design — that is what a scratch note is — so
+/// a cleanup list that offered it would offer it on every single run.
+#[test]
+fn note_cleanup_never_offers_the_scratch_note() {
+    let sandbox = Sandbox::new();
+    let vault = sandbox.home().join("notes");
+    mk_note(&vault, "scratch/scratch.md", "", 1_000);
+    mk_note(
+        &vault,
+        "thoughts.md",
+        "a real note with rather more than a couple of dozen characters in it\n",
+        900,
+    );
+    sandbox.write_config(&format!(
+        "[note]\nroot = {:?}\neditor = \"echo\"\n",
+        vault.display().to_string()
+    ));
+
+    let run = sandbox.run(&["note", "cleanup"]);
+
+    run.ok();
+    assert!(
+        run.stdout.contains("Nothing to clean up"),
+        "the scratch note was offered for deletion: {}",
+        run.stdout
+    );
+}
+
+/// And it is still protected when the config moves it somewhere else.
+#[test]
+fn note_cleanup_protects_the_configured_scratch_note() {
+    let sandbox = Sandbox::new();
+    let vault = sandbox.home().join("notes");
+    mk_note(&vault, "pad.md", "", 1_000);
+    mk_note(
+        &vault,
+        "thoughts.md",
+        "a real note with rather more than a couple of dozen characters in it\n",
+        900,
+    );
+    sandbox.write_config(&format!(
+        "[note]\nroot = {:?}\neditor = \"echo\"\nscratch = \"pad.md\"\n",
+        vault.display().to_string()
+    ));
+
+    let run = sandbox.run(&["note", "cleanup"]);
+    run.ok();
+    assert!(run.stdout.contains("Nothing to clean up"), "{}", run.stdout);
 }


### PR DESCRIPTION
- Note previews show the file itself, through `bat`, instead of a summary scriv assembled from the front matter and a hand-rolled markdown renderer.
- A `note rg` hit opens at its line, with that line marked and line numbers drawn.
- `[selector] preview_theme` themes every file preview in the binary, not only the notes. Catppuccin Mocha by default, passed as `--theme` so it wins over `BAT_THEME`.
- `config check` reports whether `bat` is installed.
- `note cleanup` groups by reason — empty, untitled, no name — and sorts smallest first inside each group.
- Cleanup sizes are right-aligned in one letter, `b`/`k`/`M`, so the units stack into a column.
- `note cleanup` never offers the scratch note; being empty is what it is for.
- About three hundred lines of renderer and its tests deleted.

A theme `bat` does not know is deliberately not handled: it warns on stderr, which the preview command already discards, and falls back to its own default. So an older `bat` keeps working and looks like the user's own.

The theme lives in a `OnceLock` rather than being passed down: a `Preview::File` builds its command inside `SkimItem::preview`, which skim calls long after the row was made and with no configuration in reach. One process reads one configuration, so a value fixed for the process is the value every caller would have been handed.

Cost worth naming: previews now depend on `bat` for highlighting where the note pane used to need nothing. Without it they fall back to `head`/`sed`, unhighlighted and unthemed — which is what the new `config check` row is for.

Verified against a vault of Norwegian and empty notes: the cleanup list groups and aligns as intended, the scratch note is absent, and both preview commands render in Catppuccin Mocha.

Docs: `src/main.rs` help unchanged (no new verb or flag), README (requirements, what a preview shows), the generated `config.toml`, and `CHANGELOG.md` under `## Unreleased`. `docs/demo.gif` is unchanged — the tape never opens a vault, and the selectors it does record draw the same rows.