### PR TITLE
chore: release v0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ raised, never by hand.
 
 ## Unreleased
 
+## v0.14.0
+
+*Released 2026-08-28*
+
 ### Added
 
 - `scriv project` builds and installs the directory you are standing in without

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1621,7 +1621,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scriv"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scriv"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2024"
 description = "Provides fuzzy-completion for various local and remote resources."
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `scriv`: 0.13.0 -> 0.14.0

<details><summary><i><b>Changelog</b></i></summary><p>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).