### PR TITLE
Make `-v` the version, and leave `--verbose` its long form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ raised, never by hand.
 
 ## Unreleased
 
+### Changed
+
+- `-v` is `--version`. It was `--verbose`, which now has only its long form, and
+  clap's own `-V` is gone. A `-v` meaning verbosity is a usage error rather than
+  a run that quietly stopped being verbose.
+
 ## v0.15.0
 
 *Released 2026-08-28*

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,11 +56,20 @@ const STYLES: Styles = Styles::styled()
     long_about = LONG_ABOUT,
     after_help = EXAMPLES,
     styles = STYLES,
-    disable_help_subcommand = true
+    disable_help_subcommand = true,
+    disable_version_flag = true
 )]
 struct Cli {
+    // Declared rather than left to clap, whose own version flag is `-V`. `-v`
+    // is what the hand reaches for, and it is taken from `--verbose`, which
+    // keeps only its long form: the version is asked for far more often than
+    // more output is.
+    /// Print version
+    #[arg(short = 'v', long, action = clap::ArgAction::Version)]
+    version: Option<bool>,
+
     /// Verbose output
-    #[arg(short, long, global = true)]
+    #[arg(long, global = true)]
     verbose: bool,
 
     /// Path to the config file

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -2441,3 +2441,28 @@ fn config_check_fails_on_a_binding_nothing_answers_to() {
         run.stdout
     );
 }
+
+/// `-v` is the version, not verbosity: clap's own short is `-V`, and the hand
+/// reaches for the lowercase one.
+#[test]
+fn the_short_version_flag_is_the_lowercase_one() {
+    let sandbox = Sandbox::new();
+
+    let short = sandbox.run(&["-v"]);
+    short.ok();
+    assert_eq!(short.stdout, sandbox.run(&["--version"]).ok().stdout);
+
+    sandbox.run(&["-V"]).code(2);
+}
+
+/// `-v` was `--verbose`'s, and the version flag is not global, so a `-v` left
+/// on the end of a subcommand is a usage error rather than a run that quietly
+/// stopped being verbose.
+#[test]
+fn verbose_keeps_only_its_long_form() {
+    let sandbox = Sandbox::new();
+
+    sandbox.run(&["--verbose", "config", "path"]).ok();
+    sandbox.run(&["config", "--verbose", "path"]).ok();
+    sandbox.run(&["config", "path", "-v"]).code(2);
+}


### PR DESCRIPTION
`scriv -v` prints the version. It was `--verbose`'s short, and clap's own `-V` is gone.

- The version is asked for far more often than more output is, so `--verbose` gives the letter up and keeps only its long form.
- Not global, as clap's own version flag was not: `scriv pr ls -v` is now a usage error rather than a run that quietly stopped being verbose.
- `-V` no longer resolves at all.
- CHANGELOG carries it under Changed; nothing in the README named either flag, and `docs/demo.gif` draws no selector this touches.