### PR TITLE
Say what the configuration is, and check it as a checklist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,18 @@ raised, never by hand.
 
 ## Unreleased
 
+### Changed
+
+- `scriv config print` reports every setting there is, including the keys and
+  names `scriv init` binds and the action each one runs. It had drifted to a
+  handful of them, so a table added since — `[worktree]`, `[selector]`,
+  `[shell]` — could not be read back from the tool that claims to print the
+  configuration. Values scriv chose rather than you are marked as defaults.
+- `scriv config check` is a checklist rather than a second report of the
+  configuration. Rows are grouped, a working one is a tick rather than a line
+  of green prose, and the run ends with what is left to look at. What a setting
+  is set to now belongs to `config print` alone.
+
 ## v0.16.0
 
 *Released 2026-08-28*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,7 +98,10 @@ publishes the crate.
    `scriv <group> --help`, its key-binding table `DEFAULT_BINDINGS`, its
    `Install` line the platforms and external tools, and the prose under each
    heading what the code now does; the starter config must describe every
-   setting that exists and none that does not.
+   setting that exists and none that does not. A test holds `scriv config
+   print` to that config, so a setting written in one and not the other fails
+   the build; a setting in neither still slips through, which is what reading
+   both on every change is for.
 
    The README is still a page, not a manual: reading it is what is required on
    every change, not adding to it. A new flag does not belong there; a new
@@ -149,6 +152,16 @@ Rationale for code that does is a doc comment at the site — `ScratchRow`,
 - **A new dependency on the outside world gets a `config check` row** in
   `cmd/config.rs`. `Fail` only when scriv is genuinely broken without it, and
   skip a check that repeats an earlier one.
+- **A new setting gets a `config print` row**, under the table it is written
+  in. That report is the whole configuration — every table, whether the file
+  writes it or not — so a setting missing from it is one nobody can read back,
+  and a table added since the last look at the command is how it goes stale. A
+  test holds the report to the starter config and fails when one names a key
+  the other does not, which is what makes that config the list to keep
+  straight. Keep the two commands apart while you are there: `print` says what
+  a setting is and where the value came from, `check` says whether what it
+  points at is actually there, and a `check` row repeats a value only where
+  repeating it is the way out of a problem.
 - **Spawned children explain themselves.** Return `Reported(code)` so scriv
   exits with the child's status rather than printing a vaguer line over git's.
 - **`NO_COLOR` is deliberately not read** — one switch for every tool, where

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ a skip rather than a failure.
 ```sh
 scriv config init          # write ~/.config/scriv/config.toml, then set `root`
 scriv init fish | source   # helpers, key bindings, completions
+scriv config print         # every setting, and what is in force for it
 scriv config check         # confirm it all resolves
 ```
 
@@ -155,9 +156,10 @@ i  = "project-deps"
 bb = "project-build"   # `b` by default
 ```
 
-`scriv config check` lists what resolves. An action scriv does not define stops
-`scriv init fish` outright rather than emitting a shell where one key silently
-does nothing.
+`scriv config print` lists every key and name with the action it runs and what
+that action does; `scriv config check` says whether they all resolve. An action
+scriv does not define stops `scriv init fish` outright rather than emitting a
+shell where one key silently does nothing.
 
 Inside a selector, `ctrl-v` hides and shows the preview pane and `tab` takes
 several rows where several are allowed. Anything else a selector answers to is

--- a/src/binding.rs
+++ b/src/binding.rs
@@ -223,16 +223,27 @@ pub fn resolve(config: &ShellConfig) -> Result<Integration> {
     })
 }
 
-fn bind(what: &str, table: Option<&Bindings>, defaults: &[(&str, &str)]) -> Result<Vec<Bound>> {
-    let written: Vec<(&str, &str)> = match table {
+/// What a table names, in the order it was written — the defaults when it is
+/// absent.
+///
+/// Unlike [`resolve`], an action nobody defines is kept rather than refused:
+/// `scriv config print` reports a line the file really has, and leaves calling
+/// it broken to `scriv config check`.
+pub fn entries<'a>(
+    table: Option<&'a Bindings>,
+    defaults: &'a [(&'a str, &'a str)],
+) -> Vec<(&'a str, &'a str)> {
+    match table {
         Some(table) => table
             .iter()
             .map(|(trigger, id)| (trigger.as_str(), id.as_str()))
             .collect(),
         None => defaults.to_vec(),
-    };
+    }
+}
 
-    written
+fn bind(what: &str, table: Option<&Bindings>, defaults: &[(&str, &str)]) -> Result<Vec<Bound>> {
+    entries(table, defaults)
         .into_iter()
         .map(|(trigger, id)| match action(id) {
             Some(action) => Ok(Bound {

--- a/src/cmd/config.rs
+++ b/src/cmd/config.rs
@@ -1,4 +1,11 @@
-//! `scriv config` — inspect, generate, and check the configuration file.
+//! `scriv config` — generate, print and check the configuration file.
+//!
+//! `print` and `check` answer different questions and are kept apart on
+//! purpose. `print` is the configuration: every setting there is, what is in
+//! force for it, and whether that came from the file or from scriv. `check` is
+//! a checklist: whether what the settings point at is actually there, and
+//! whether the programs scriv shells out to are installed. A row in `check`
+//! repeats a value only where repeating it is the way out of a problem.
 
 use std::os::unix::fs::DirBuilderExt;
 use std::path::{Path, PathBuf};
@@ -6,7 +13,8 @@ use std::process::{Command, Stdio};
 
 use anyhow::{Context, Result, bail};
 
-use crate::path::expand_home_dir;
+use crate::config::{Bindings, Config, Labels};
+use crate::path::{display_path, expand_home_dir};
 use crate::{Ctx, binding, cmd, files, gh, history, repo, term};
 
 /// A commented starter config. Settings are grouped by the command that reads
@@ -90,8 +98,9 @@ ignore = ["node_modules", "target"]
 #
 # Neither table holds shell code — each names an action scriv defines, so the
 # same configuration serves fish and any shell scriv later learns to write for.
-# Between them the two tables below name every action there is, and `scriv
-# config check` says whether yours resolve.
+# Between them the two tables below name every action there is. `scriv config
+# print` lists the keys and names you have with what each one runs, and `scriv
+# config check` says whether they resolve.
 #
 # A table written here replaces the defaults rather than adding to them, which
 # is how a key is unbound or a name dropped: leave it out. Both tables below are
@@ -172,64 +181,423 @@ pub fn init(ctx: &Ctx, force: bool) -> Result<()> {
     Ok(())
 }
 
-/// `scriv config print` — print the resolved paths and ignore list.
+// --- print ------------------------------------------------------------------
+
+/// Grey, for everything on a row that is not the value itself: the key it is
+/// written under, and where the value came from.
+const DIM: u8 = 8;
+
+/// Cyan, for the `[table]` a group of settings is written under.
+const HEADING: u8 = 6;
+
+/// Red, for a value scriv cannot act on.
+const BROKEN: u8 = 1;
+
+/// Shown where a setting has no value and nothing stands in for it.
+const UNSET: &str = "(unset)";
+
+/// Shown where a list is empty.
+const EMPTY: &str = "(none)";
+
+/// What the last column says about a value scriv chose rather than the user.
+const DEFAULT: &str = "default";
+
+/// What is in force for one setting.
+enum Value {
+    /// A value, shown as it stands.
+    Set(String),
+    /// Nothing there, and the placeholder that says so.
+    Missing(&'static str),
+    /// Set to something scriv cannot act on.
+    Broken(String),
+}
+
+/// One line of `config print`.
+enum Row {
+    /// The gap between two groups.
+    Blank,
+    /// The `[table]` a group is written under, and what to know about the
+    /// group as a whole.
+    Heading { title: String, note: String },
+    /// One setting: the key it is written under, what is in force, and where
+    /// that came from.
+    Setting {
+        key: String,
+        value: Value,
+        note: String,
+    },
+}
+
+impl Row {
+    fn heading(title: impl Into<String>, note: impl Into<String>) -> Self {
+        Self::Heading {
+            title: title.into(),
+            note: note.into(),
+        }
+    }
+
+    fn setting(key: impl Into<String>, value: Value, note: impl Into<String>) -> Self {
+        Self::Setting {
+            key: key.into(),
+            value,
+            note: note.into(),
+        }
+    }
+}
+
+impl Value {
+    /// The text as it is drawn, before it is painted.
+    fn text(&self) -> &str {
+        match self {
+            Self::Set(text) | Self::Broken(text) => text.as_str(),
+            Self::Missing(text) => text,
+        }
+    }
+
+    /// The colour it is drawn in, or `None` for the terminal's own foreground —
+    /// which is what a value the user set gets, so the settings are the only
+    /// thing on the report at full contrast.
+    fn color(&self) -> Option<u8> {
+        match self {
+            Self::Set(_) => None,
+            Self::Missing(_) => Some(DIM),
+            Self::Broken(_) => Some(BROKEN),
+        }
+    }
+}
+
+/// A setting the file names, or what happens when it does not.
+fn optional(key: &str, value: Option<&str>, without: &str) -> Row {
+    match value {
+        Some(value) => Row::setting(key, Value::Set(value.to_string()), ""),
+        None => Row::setting(key, Value::Missing(UNSET), without),
+    }
+}
+
+/// A setting that has a value whether the file gives it one or not, marked
+/// where that value is the one scriv ships.
+fn defaulted(key: &str, value: Value, is_default: bool) -> Row {
+    Row::setting(key, value, if is_default { DEFAULT } else { "" })
+}
+
+/// A list of names as one value.
+fn list(items: &[String]) -> Value {
+    if items.is_empty() {
+        Value::Missing(EMPTY)
+    } else {
+        Value::Set(items.join(", "))
+    }
+}
+
+/// One row per label, keyed as the file writes it — `labels.work` — so a set of
+/// owners or directories stays one line each however many labels there are.
+fn label_rows(labels: &Labels) -> Vec<Row> {
+    if labels.is_empty() {
+        return vec![Row::setting("labels", Value::Missing(EMPTY), "")];
+    }
+    labels
+        .iter()
+        .map(|(label, members)| Row::setting(format!("labels.{label}"), list(members), ""))
+        .collect()
+}
+
+/// What a `[shell]` table's heading says: whether the rows under it are the
+/// user's or the ones scriv ships.
+fn table_note(written: bool) -> &'static str {
+    if written { "" } else { DEFAULT }
+}
+
+/// One row per key or name, with the action it runs and what that action does.
+///
+/// An action nobody defines is shown and marked rather than left out: it is a
+/// line the file really has, and a report that silently drops it is a user
+/// hunting for a key that is written right there.
+fn binding_rows(table: Option<&Bindings>, defaults: &[(&str, &str)]) -> Vec<Row> {
+    binding::entries(table, defaults)
+        .into_iter()
+        .map(|(trigger, id)| match binding::action(id) {
+            Some(action) => Row::setting(trigger, Value::Set(id.to_string()), action.description),
+            None => Row::setting(trigger, Value::Broken(id.to_string()), "no such action"),
+        })
+        .collect()
+}
+
+/// What `config print` reports that the config file does not hold: the paths
+/// and the editor [`Ctx`] resolved from the environment. Passed in so building
+/// the report stays pure.
+struct Env<'a> {
+    config_path: String,
+    /// Without a file every value below is a default, which is worth saying
+    /// once at the top rather than on every row.
+    config_exists: bool,
+    history_path: String,
+    /// `$VISUAL`, then `$EDITOR`.
+    editor: Option<&'a str>,
+}
+
+/// The whole report, in the order it is printed: every setting there is, under
+/// the table it is written in, whether the file sets it or not.
+fn report(cfg: &Config, env: &Env) -> Vec<Row> {
+    let default = Config::default();
+    let mut rows = vec![Row::heading(
+        env.config_path.clone(),
+        if env.config_exists {
+            ""
+        } else {
+            "not found — every value below is a default"
+        },
+    )];
+
+    rows.push(Row::Blank);
+    rows.push(Row::heading("[repo]", ""));
+    rows.push(optional(
+        "root",
+        cfg.repo.root.as_deref(),
+        "`repo` and `repo clone` have nowhere to look",
+    ));
+    rows.push(Row::setting("extra", list(&cfg.repo.extra), ""));
+    rows.push(defaulted(
+        "ignore",
+        list(&cfg.repo.ignore),
+        cfg.repo.ignore == default.repo.ignore,
+    ));
+    rows.push(defaulted(
+        "display",
+        Value::Set(cfg.repo.display.as_str().to_string()),
+        cfg.repo.display == default.repo.display,
+    ));
+    rows.extend(label_rows(&cfg.repo.labels));
+
+    rows.push(Row::Blank);
+    rows.push(Row::heading("[worktree]", ""));
+    rows.push(defaulted(
+        "root",
+        Value::Set(cfg.worktree.root.clone()),
+        cfg.worktree.root == default.worktree.root,
+    ));
+
+    rows.push(Row::Blank);
+    rows.push(Row::heading("[note]", ""));
+    rows.push(optional(
+        "root",
+        cfg.note.root.as_deref(),
+        "`scriv note` has nowhere to look",
+    ));
+    rows.extend(label_rows(&cfg.note.labels));
+    rows.push(match cfg.note.scratch.as_deref() {
+        Some(scratch) => Row::setting("scratch", Value::Set(scratch.to_string()), ""),
+        None => Row::setting(
+            "scratch",
+            Value::Set(crate::note::DEFAULT_SCRATCH.to_string()),
+            DEFAULT,
+        ),
+    });
+    rows.push(match (cfg.note.editor.as_deref(), env.editor) {
+        (Some(editor), _) => Row::setting("editor", Value::Set(editor.to_string()), ""),
+        (None, Some(editor)) => Row::setting(
+            "editor",
+            Value::Set(editor.to_string()),
+            "from $VISUAL / $EDITOR",
+        ),
+        (None, None) => Row::setting(
+            "editor",
+            Value::Missing(UNSET),
+            "set `[note] editor`, $VISUAL or $EDITOR",
+        ),
+    });
+
+    rows.push(Row::Blank);
+    rows.push(Row::heading("[history]", ""));
+    rows.push(defaulted(
+        "file",
+        Value::Set(env.history_path.clone()),
+        cfg.history.file.is_none(),
+    ));
+
+    rows.push(Row::Blank);
+    rows.push(Row::heading("[selector]", ""));
+    let (sel, base) = (&cfg.selector, &default.selector);
+    rows.push(defaulted(
+        "height",
+        Value::Set(sel.height.clone()),
+        sel.height == base.height,
+    ));
+    rows.push(defaulted(
+        "preview",
+        Value::Set(sel.preview.to_string()),
+        sel.preview == base.preview,
+    ));
+    rows.push(defaulted(
+        "preview_window",
+        Value::Set(sel.preview_window.clone()),
+        sel.preview_window == base.preview_window,
+    ));
+    rows.push(defaulted(
+        "preview_theme",
+        if sel.preview_theme.is_empty() {
+            Value::Missing("(bat's own)")
+        } else {
+            Value::Set(sel.preview_theme.clone())
+        },
+        sel.preview_theme == base.preview_theme,
+    ));
+    rows.push(defaulted(
+        "recent",
+        Value::Set(sel.recent.to_string()),
+        sel.recent == base.recent,
+    ));
+
+    rows.push(Row::Blank);
+    rows.push(Row::heading(
+        "[shell.bindings]",
+        table_note(cfg.shell.bindings.is_some()),
+    ));
+    rows.extend(binding_rows(
+        cfg.shell.bindings.as_ref(),
+        binding::DEFAULT_BINDINGS,
+    ));
+
+    rows.push(Row::Blank);
+    rows.push(Row::heading(
+        "[shell.aliases]",
+        table_note(cfg.shell.aliases.is_some()),
+    ));
+    rows.extend(binding_rows(
+        cfg.shell.aliases.as_ref(),
+        binding::DEFAULT_ALIASES,
+    ));
+
+    rows.push(Row::Blank);
+    rows.push(Row::heading(
+        "environment",
+        "read by scriv, not written in the file",
+    ));
+    rows.push(match env.editor {
+        Some(editor) => Row::setting(
+            "editor",
+            Value::Set(editor.to_string()),
+            "$VISUAL, then $EDITOR",
+        ),
+        None => Row::setting(
+            "editor",
+            Value::Missing(UNSET),
+            "`scriv edit` has nothing to open files with",
+        ),
+    });
+
+    rows
+}
+
+/// Draw the report.
+///
+/// Keys share one column across the whole report, so every setting starts in
+/// the same place; the notes beside them line up only within their own group,
+/// since a path in one group would otherwise push the word `default` half a
+/// terminal away from the value it describes.
+fn render_report(rows: &[Row], color: bool) -> Vec<String> {
+    let key_width = rows
+        .iter()
+        .filter_map(|row| match row {
+            Row::Setting { key, .. } => Some(key.chars().count()),
+            _ => None,
+        })
+        .max()
+        .unwrap_or(0);
+    let note_columns = note_columns(rows);
+
+    rows.iter()
+        .zip(note_columns)
+        .map(|(row, value_width)| match row {
+            Row::Blank => String::new(),
+            Row::Heading { title, note } => {
+                let mut line = term::paint(title, HEADING, color);
+                if !note.is_empty() {
+                    line.push_str("  ");
+                    line.push_str(&term::paint(note, DIM, color));
+                }
+                line
+            }
+            Row::Setting { key, value, note } => {
+                let mut line = format!("  {}  ", term::paint(&pad(key, key_width), DIM, color));
+                let text = if note.is_empty() {
+                    value.text().to_string()
+                } else {
+                    pad(value.text(), value_width)
+                };
+                line.push_str(&match value.color() {
+                    Some(color_index) => term::paint(&text, color_index, color),
+                    None => text,
+                });
+                if !note.is_empty() {
+                    line.push_str("  ");
+                    line.push_str(&term::paint(note, DIM, color));
+                }
+                line
+            }
+        })
+        .collect()
+}
+
+/// The width each row pads its value to, so the notes in one group line up
+/// with each other and with nothing else. Rows without a note are not measured:
+/// nothing lines up behind them.
+fn note_columns(rows: &[Row]) -> Vec<usize> {
+    let mut widths = vec![0; rows.len()];
+    let mut start = 0;
+    for end in 0..=rows.len() {
+        if end != rows.len() && !matches!(rows[end], Row::Heading { .. }) {
+            continue;
+        }
+        let group = rows[start..end]
+            .iter()
+            .filter_map(|row| match row {
+                Row::Setting { value, note, .. } if !note.is_empty() => {
+                    Some(value.text().chars().count())
+                }
+                _ => None,
+            })
+            .max()
+            .unwrap_or(0);
+        widths[start..end].fill(group);
+        start = end;
+    }
+    widths
+}
+
+/// `text` in a field `width` characters wide, counted in characters rather
+/// than bytes so a label with an accent in it does not shift the column.
+fn pad(text: &str, width: usize) -> String {
+    let mut padded = text.to_string();
+    for _ in text.chars().count()..width {
+        padded.push(' ');
+    }
+    padded
+}
+
+/// `scriv config print` — every setting there is, and what is in force for it.
+///
+/// The settings only: whether the paths they name exist, and whether the tools
+/// scriv shells out to are installed, is `scriv config check`.
 pub fn print(ctx: &Ctx) -> Result<()> {
     ctx.log.info(&format!(
         "printing configuration from {}",
         ctx.config_path.display()
     ));
 
-    let repo = &ctx.config.repo;
-    println!("[repo]");
-    println!("root: {}", repo.root.as_deref().unwrap_or("(unset)"));
-    if !repo.extra.is_empty() {
-        println!("extra: {}", repo.extra.join(", "));
-    }
-    println!("ignore: {}", repo.ignore.join(", "));
-    println!("display: {}", repo.display.as_str());
-    if !repo.labels.is_empty() {
-        println!("labels:");
-        for (label, owners) in &repo.labels {
-            println!("  {label}: {}", owners.join(", "));
+    let env = Env {
+        config_path: display_path(&ctx.config_path.to_string_lossy(), ctx.home_str(), false),
+        config_exists: ctx.config_path.exists(),
+        history_path: display_path(&ctx.history_path.to_string_lossy(), ctx.home_str(), false),
+        editor: ctx.editor_setting(),
+    };
+
+    let mut out = term::Listing::stdout();
+    for line in render_report(&report(&ctx.config, &env), ctx.color()) {
+        if !out.line(&line)? {
+            return Ok(());
         }
     }
-
-    println!();
-    println!("[note]");
-    println!(
-        "root: {}",
-        ctx.config.note.root.as_deref().unwrap_or("(unset)")
-    );
-    if !ctx.config.note.labels.is_empty() {
-        println!("labels:");
-        for (label, dirs) in &ctx.config.note.labels {
-            println!("  {label}: {}", dirs.join(", "));
-        }
-    }
-    println!(
-        "scratch: {}",
-        ctx.config
-            .note
-            .scratch
-            .as_deref()
-            .unwrap_or(crate::note::DEFAULT_SCRATCH)
-    );
-    println!(
-        "editor: {}",
-        ctx.note_editor_setting()
-            .unwrap_or("(unset — set `[note] editor`, $VISUAL or $EDITOR)")
-    );
-
-    println!();
-    println!("[history]");
-    println!("file: {}", ctx.history_path.display());
-
-    println!();
-    println!(
-        "editor: {}",
-        ctx.editor_setting()
-            .unwrap_or("(unset — set $VISUAL or $EDITOR)")
-    );
+    out.finish()?;
     Ok(())
 }
 
@@ -268,6 +636,25 @@ impl Status {
             Self::Fail => 1,
         }
     }
+
+    /// The colour the row's name takes, or `None` for the terminal's own
+    /// foreground. Only a failure is coloured: a report where every name is
+    /// green is one nobody reads for the one that is not.
+    fn name_color(self) -> Option<u8> {
+        match self {
+            Self::Fail => Some(self.color()),
+            _ => None,
+        }
+    }
+
+    /// The colour the row's detail takes. What a working setup found is grey;
+    /// what to do about a broken one carries the status colour.
+    fn detail_color(self) -> u8 {
+        match self {
+            Self::Ok => DIM,
+            other => other.color(),
+        }
+    }
 }
 
 /// One thing that was looked at, and what was found.
@@ -277,6 +664,8 @@ struct Check {
     name: &'static str,
     status: Status,
     /// What was found, and — when something is wrong — what to do about it.
+    /// Empty where a working setup has nothing to add: the row is a tick, not
+    /// a place to repeat what `config print` already says.
     detail: String,
 }
 
@@ -302,16 +691,69 @@ impl Check {
     }
 }
 
-/// Render one check as its row: glyph, aligned name, detail. `width` is the
-/// widest name in the report, counted in characters.
-fn render(check: &Check, width: usize, color: bool) -> String {
-    let row = format!(
-        "{glyph} {name:<width$}  {detail}",
-        glyph = check.status.glyph(),
-        name = check.name,
-        detail = check.detail,
+/// `count` with the noun it counts, in the number the count calls for.
+fn plural(count: usize, one: &str, many: &str) -> String {
+    format!("{count} {}", if count == 1 { one } else { many })
+}
+
+/// A group of checks, named for what they are about.
+struct Section {
+    title: &'static str,
+    checks: Vec<Check>,
+}
+
+/// Render one check as its row: glyph, name, and what was found. `width` is the
+/// widest name in the report, counted in characters — a row with nothing to add
+/// is not padded to it, since nothing lines up behind it.
+fn render_check(check: &Check, width: usize, color: bool) -> String {
+    let name = if check.detail.is_empty() {
+        check.name.to_string()
+    } else {
+        pad(check.name, width)
+    };
+    let mut row = format!(
+        "  {} {}",
+        term::paint(check.status.glyph(), check.status.color(), color),
+        match check.status.name_color() {
+            Some(tint) => term::paint(&name, tint, color),
+            None => name,
+        },
     );
-    term::paint(row.trim_end(), check.status.color(), color)
+    if !check.detail.is_empty() {
+        row.push_str("  ");
+        row.push_str(&term::paint(
+            &check.detail,
+            check.status.detail_color(),
+            color,
+        ));
+    }
+    row
+}
+
+/// What the report came to, and the colour it is painted in.
+fn summary(checks: &[&Check]) -> (String, u8) {
+    let count = |status| checks.iter().filter(|c| c.status == status).count();
+    let (warned, failed) = (count(Status::Warn), count(Status::Fail));
+
+    let mut parts = vec![format!("{} checks", checks.len())];
+    if failed > 0 {
+        parts.push(format!("{failed} failed"));
+    }
+    if warned > 0 {
+        parts.push(format!("{warned} to look at"));
+    }
+    if failed == 0 && warned == 0 {
+        parts.push("all clear".to_string());
+    }
+
+    let status = if failed > 0 {
+        Status::Fail
+    } else if warned > 0 {
+        Status::Warn
+    } else {
+        Status::Ok
+    };
+    (parts.join(" · "), status.color())
 }
 
 /// How many checks failed. Warnings are not failures: the command exits
@@ -360,10 +802,31 @@ fn version_of(program: &str) -> Option<String> {
     text.lines().next().map(str::trim).map(str::to_string)
 }
 
+/// The version out of a `--version` line — `git version 2.51.0` is `2.51.0`.
+///
+/// The first word that starts with a digit, since every tool here writes its
+/// name before the version and its build details after. A `v` prefix is part of
+/// the spelling, not of the version.
+fn version_number(line: &str) -> Option<&str> {
+    line.split_whitespace()
+        .map(|word| word.strip_prefix('v').unwrap_or(word))
+        .find(|word| word.starts_with(|c: char| c.is_ascii_digit()))
+}
+
+/// What a row says about an installed tool: its version, or that it is there
+/// at all when it will not say.
+fn installed(program: &str) -> String {
+    version_of(program)
+        .as_deref()
+        .and_then(version_number)
+        .unwrap_or("installed")
+        .to_string()
+}
+
 /// Whether a tool scriv shells out to is installed, and which version.
 fn tool_check(name: &'static str, program: &str, required: bool, note: &str) -> Check {
     match on_path(program) {
-        Some(_) => Check::ok(name, version_of(program).unwrap_or_else(|| "found".into())),
+        Some(_) => Check::ok(name, installed(program)),
         None if required => Check::fail(name, format!("not on PATH — {note}")),
         None => Check::warn(name, format!("not on PATH — {note}")),
     }
@@ -393,22 +856,24 @@ fn gh_check() -> Check {
     if on_path("gh").is_none() {
         return Check::warn("gh", format!("not on PATH — {GH_NOTE}"));
     }
-    let version = version_of("gh").unwrap_or_else(|| "found".into());
-    let (status, detail) = gh_state(&version, gh::authenticated());
+    let (status, detail) = gh_state(&installed("gh"), gh::authenticated());
     Check::new("gh", status, detail)
 }
 
-/// The config file itself: whether there is one, and where. Reaching this point
-/// means it parsed, so the only question left is whether one exists — and
-/// absent is a warning, since the known-files commands work without one.
+/// The config file itself: whether there is one. Reaching this point means it
+/// parsed, so the only question left is whether one exists — and absent is a
+/// warning, since the known-files commands work without one. Where it is, is
+/// the first line `config print` draws.
 fn config_check(ctx: &Ctx) -> Check {
-    let path = ctx.config_path.display().to_string();
     if ctx.config_path.exists() {
-        Check::ok("config", path)
+        Check::ok("config file", "")
     } else {
         Check::warn(
-            "config",
-            format!("{path} not found — run `scriv config init`"),
+            "config file",
+            format!(
+                "{} not found — run `scriv config init`",
+                ctx.config_path.display()
+            ),
         )
     }
 }
@@ -430,11 +895,13 @@ fn root_checks(ctx: &Ctx) -> Vec<Check> {
         )),
         Some(root) => {
             let expanded = expand_home_dir(root, ctx.home());
-            let shown = expanded.display();
             checks.push(if expanded.is_dir() {
-                Check::ok("repo root", format!("{shown}"))
+                Check::ok("repo root", "")
             } else {
-                Check::fail("repo root", format!("{shown} is not a directory"))
+                Check::fail(
+                    "repo root",
+                    format!("{} is not a directory", expanded.display()),
+                )
             });
         }
     }
@@ -450,7 +917,7 @@ fn root_checks(ctx: &Ctx) -> Vec<Check> {
             .map(String::as_str)
             .collect();
         checks.push(if missing.is_empty() {
-            Check::ok("repo extra", format!("{total} path(s), all present"))
+            Check::ok("repo extra", plural(total, "path", "paths"))
         } else {
             // Discovery treats a missing search path as a hard error.
             Check::fail("repo extra", format!("missing: {}", missing.join(", ")))
@@ -479,102 +946,114 @@ fn discovery_check(ctx: &Ctx, paths_ok: bool) -> Option<Check> {
     )
 }
 
-/// The editor `scriv edit` will launch, and whether it is actually there.
-fn editor_check(ctx: &Ctx) -> Check {
-    let Some(setting) = ctx.editor_setting() else {
-        return Check::warn(
-            "editor",
-            "no $VISUAL or $EDITOR — `scriv edit` has nothing to open files with",
-        );
-    };
-    // The setting may carry arguments (`code -w`); only the program is
-    // looked for, the same split the launch does.
+/// Whether an editor command is a program this machine has. Shared by the
+/// editor `scriv edit` launches and the one `[note] editor` names.
+fn editor_on_path(name: &'static str, setting: &str) -> Check {
+    // The setting may carry arguments (`code -w`); only the program is looked
+    // for, the same split the launch does.
     let program = setting.split_whitespace().next().unwrap_or(setting);
     match on_path(program) {
-        Some(found) => Check::ok("editor", format!("{setting} ({})", found.display())),
-        None => Check::fail("editor", format!("{setting} — `{program}` is not on PATH")),
+        Some(found) => Check::ok(name, found.display().to_string()),
+        None => Check::fail(name, format!("`{program}` is not on PATH")),
     }
 }
 
-/// The notes vault: where it is, and how many notes are in it.
-///
-/// One row rather than two — a root that resolves and a count of what is under
-/// it are the same question — and a warning rather than a failure when it is
-/// unset, since every other group works without one.
-fn note_checks(ctx: &Ctx) -> Vec<Check> {
-    let mut checks = Vec::new();
+/// The editor `scriv edit` will launch, and whether it is actually there.
+fn editor_check(ctx: &Ctx) -> Check {
+    match ctx.editor_setting() {
+        Some(setting) => editor_on_path("editor", setting),
+        None => Check::warn(
+            "editor",
+            "no $VISUAL or $EDITOR — `scriv edit` has nothing to open files with",
+        ),
+    }
+}
 
+/// The editor `note edit` will launch, when `[note] editor` names one of its
+/// own. Unset, it is the editor the row above already reported, and a second
+/// row saying so is a second row saying so.
+fn note_editor_check(ctx: &Ctx) -> Option<Check> {
+    ctx.config
+        .note
+        .editor
+        .as_deref()
+        .map(|setting| editor_on_path("note editor", setting))
+}
+
+/// The notes vault: whether it resolves, and how many notes are under it.
+///
+/// A warning rather than a failure when it is unset, since every other group
+/// works without one.
+fn note_vault_check(ctx: &Ctx) -> Check {
     if ctx.config.note.root.is_none() {
-        checks.push(Check::warn(
+        return Check::warn(
             "note vault",
             "`[note] root` not set — `scriv note` has nowhere to look",
-        ));
-    } else {
-        checks.push(match cmd::note::vault_summary(ctx) {
-            Err(err) => Check::fail("note vault", format!("{err:#}")),
-            Ok((root, 0)) => Check::warn(
-                "note vault",
-                format!("{} holds no Markdown files", root.display()),
-            ),
-            Ok((root, count)) => Check::ok(
-                "note vault",
-                format!("{count} note(s) in {}", root.display()),
-            ),
-        });
+        );
     }
-
-    // Only when it is set: unset, it is the editor the row above already
-    // reported, and a second row saying so is a second row saying so.
-    if let Some(setting) = ctx.config.note.editor.as_deref() {
-        let program = setting.split_whitespace().next().unwrap_or(setting);
-        checks.push(match on_path(program) {
-            Some(found) => Check::ok("note editor", format!("{setting} ({})", found.display())),
-            None => Check::fail(
-                "note editor",
-                format!("{setting} — `{program}` is not on PATH"),
-            ),
-        });
+    match cmd::note::vault_summary(ctx) {
+        Err(err) => Check::fail("note vault", format!("{err:#}")),
+        Ok((root, 0)) => Check::warn(
+            "note vault",
+            format!("{} holds no Markdown files", root.display()),
+        ),
+        Ok((_, count)) => Check::ok("note vault", plural(count, "note", "notes")),
     }
-
-    checks
 }
 
-/// `[shell]`: whether the bindings and aliases resolve to actions that exist.
+/// `[shell]`: whether every key and name resolves to an action that exists.
 ///
 /// A failure here is `scriv init fish` refusing to emit anything, which takes
 /// the whole shell integration with it — so it is a failure rather than a
 /// warning, and this is where it should be found rather than at the next new
-/// shell.
-fn shell_check(ctx: &Ctx) -> Check {
-    match binding::resolve(&ctx.config.shell) {
-        Err(err) => Check::fail("shell integration", format!("{err:#}")),
-        Ok(integration) => Check::ok(
+/// shell. Which key runs what is `config print`; this counts them and says
+/// whether they resolve.
+fn shell_check(cfg: &Config) -> Check {
+    let bindings = binding::entries(cfg.shell.bindings.as_ref(), binding::DEFAULT_BINDINGS);
+    let aliases = binding::entries(cfg.shell.aliases.as_ref(), binding::DEFAULT_ALIASES);
+
+    let unknown: Vec<String> = bindings
+        .iter()
+        .chain(&aliases)
+        .filter(|(_, id)| binding::action(id).is_none())
+        .map(|(trigger, id)| format!("`{trigger}` names `{id}`"))
+        .collect();
+
+    if unknown.is_empty() {
+        Check::ok(
             "shell integration",
             format!(
-                "{} key binding(s), {} alias(es) — {}",
-                integration.bindings.len(),
-                integration.aliases.len(),
-                integration
-                    .aliases
-                    .iter()
-                    .map(|alias| alias.trigger.as_str())
-                    .collect::<Vec<_>>()
-                    .join(" ")
+                "{}, {}",
+                plural(bindings.len(), "key binding", "key bindings"),
+                plural(aliases.len(), "alias", "aliases"),
             ),
-        ),
+        )
+    } else {
+        Check::fail(
+            "shell integration",
+            format!(
+                "{} — no such action, and `scriv init` refuses until there is",
+                unknown.join(", ")
+            ),
+        )
     }
 }
 
 /// fish's history file: whether it is where scriv looked, and how much is in
 /// it.
 fn history_check(ctx: &Ctx) -> Check {
-    let shown = ctx.history_path.display().to_string();
     match std::fs::read(&ctx.history_path) {
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => Check::warn(
             "fish history",
-            format!("{shown} not found — set `[history] file` if yours is elsewhere"),
+            format!(
+                "{} not found — set `[history] file` if yours is elsewhere",
+                ctx.history_path.display()
+            ),
         ),
-        Err(e) => Check::fail("fish history", format!("{shown}: {e}")),
+        Err(e) => Check::fail(
+            "fish history",
+            format!("{}: {e}", ctx.history_path.display()),
+        ),
         Ok(data) => {
             // The same list `history sel` offers, so the count is the one the
             // selector will show rather than one that counts key presses.
@@ -583,7 +1062,7 @@ fn history_check(ctx: &Ctx) -> Check {
             )));
             Check::ok(
                 "fish history",
-                format!("{} unique command(s) in {shown}", entries.len()),
+                plural(entries.len(), "unique command", "unique commands"),
             )
         }
     }
@@ -616,31 +1095,33 @@ fn files_check(ctx: &Ctx) -> Check {
     }
 }
 
-/// Everything `config check` looks at, in the order it is reported: the config
-/// first, then what it points at, then the tools scriv shells out to.
-fn collect(ctx: &Ctx) -> Vec<Check> {
-    let mut checks = vec![config_check(ctx)];
-
+/// Everything `config check` looks at, in the order it is reported: what the
+/// configuration points at, then the programs scriv shells out to, then the
+/// files it keeps.
+fn collect(ctx: &Ctx) -> Vec<Section> {
+    let mut settings = vec![config_check(ctx)];
     let paths = root_checks(ctx);
     let paths_ok = failures(&paths) == 0;
-    checks.extend(paths);
-    checks.extend(discovery_check(ctx, paths_ok));
+    settings.extend(paths);
+    settings.extend(discovery_check(ctx, paths_ok));
+    settings.push(shell_check(&ctx.config));
 
-    checks.push(editor_check(ctx));
-    checks.push(tool_check(
+    let mut tools = vec![editor_check(ctx)];
+    tools.extend(note_editor_check(ctx));
+    tools.push(tool_check(
         "git",
         "git",
         true,
         "`branch` and `repo` cannot work without it",
     ));
-    checks.push(gh_check());
-    checks.push(tool_check(
+    tools.push(gh_check());
+    tools.push(tool_check(
         "bat",
         "bat",
         false,
         "previews fall back to `head`, without highlighting or a theme",
     ));
-    checks.push(tool_check(
+    tools.push(tool_check(
         "rg",
         "rg",
         false,
@@ -648,7 +1129,7 @@ fn collect(ctx: &Ctx) -> Vec<Check> {
     ));
     // `kill` and `lsof` get no row: both ship in the same base system `ps`
     // does, and a report of three lines saying the same thing is one line.
-    checks.push(tool_check(
+    tools.push(tool_check(
         "ps",
         "ps",
         true,
@@ -657,42 +1138,71 @@ fn collect(ctx: &Ctx) -> Vec<Check> {
     // The one row `project` earns: everything else it runs is whatever the
     // project in front of it asks for, and a missing one of those is already
     // reported where it is skipped.
-    checks.push(tool_check(
+    tools.push(tool_check(
         "mise",
         "mise",
         false,
         "`project` runs a project's own tools through it (https://mise.jdx.dev)",
     ));
-    checks.push(shell_check(ctx));
-    checks.push(history_check(ctx));
-    checks.push(files_check(ctx));
-    checks.extend(note_checks(ctx));
-    checks
+
+    let content = vec![history_check(ctx), files_check(ctx), note_vault_check(ctx)];
+
+    vec![
+        Section {
+            title: "configuration",
+            checks: settings,
+        },
+        Section {
+            title: "tools",
+            checks: tools,
+        },
+        Section {
+            title: "content",
+            checks: content,
+        },
+    ]
 }
 
 /// `scriv config check` — look at everything scriv depends on in one go and say
 /// what is wrong with it. The exit status is non-zero only when something is
 /// genuinely broken, so it is worth putting in a setup script.
+///
+/// A checklist, not a report of the configuration: what each setting is set to
+/// is `scriv config print`, and a row here repeats it only where repeating it
+/// is the way out of a problem.
 pub fn check(ctx: &Ctx) -> Result<()> {
-    let checks = collect(ctx);
+    let sections = collect(ctx);
     let color = ctx.color();
-    let width = checks
+    let all: Vec<&Check> = sections.iter().flat_map(|s| &s.checks).collect();
+    let width = all
         .iter()
         .map(|c| c.name.chars().count())
         .max()
         .unwrap_or(0);
 
     let mut out = term::Listing::stdout();
-    for check in &checks {
-        if !out.line(&render(check, width, color))? {
+    for (index, section) in sections.iter().enumerate() {
+        if index > 0 && !out.line("")? {
             return Ok(());
         }
+        if !out.line(&term::paint(section.title, HEADING, color))? {
+            return Ok(());
+        }
+        for check in &section.checks {
+            if !out.line(&render_check(check, width, color))? {
+                return Ok(());
+            }
+        }
+    }
+    let (summary, tint) = summary(&all);
+    if !out.line("")? || !out.line(&term::paint(&summary, tint, color))? {
+        return Ok(());
     }
     out.finish()?;
 
-    let failed = failures(&checks);
+    let failed = all.iter().filter(|c| c.status == Status::Fail).count();
     if failed > 0 {
-        bail!("{failed} of {} checks failed", checks.len());
+        bail!("{failed} of {} checks failed", all.len());
     }
     Ok(())
 }
@@ -784,15 +1294,10 @@ mod tests {
 
     #[test]
     fn the_templates_commented_keys_parse_when_uncommented() {
-        let is_key = |line: &str| {
-            line.split_once(" = ").is_some_and(|(name, _)| {
-                !name.is_empty() && name.chars().all(|c| c.is_ascii_lowercase() || c == '_')
-            })
-        };
         let uncommented: String = TEMPLATE
             .lines()
             .map(|line| match line.strip_prefix("# ") {
-                Some(rest) if is_key(rest) => rest,
+                Some(rest) if template_key(rest).is_some() => rest,
                 _ => line,
             })
             .collect::<Vec<_>>()
@@ -809,6 +1314,158 @@ mod tests {
         assert_eq!(cfg.repo.display, RepoDisplay::Relative);
         assert_eq!(cfg.repo.label_of("acme"), Some("work"));
         assert!(!cfg.selector.preview_window.is_empty());
+    }
+
+    // --- print ---
+
+    /// The key `line` sets, if it sets one: `root = "~/dev"` is `root`.
+    fn template_key(line: &str) -> Option<&str> {
+        line.split_once(" = ").map(|(name, _)| name).filter(|name| {
+            !name.is_empty() && name.chars().all(|c| c.is_ascii_lowercase() || c == '_')
+        })
+    }
+
+    fn env() -> Env<'static> {
+        Env {
+            config_path: "~/.config/scriv/config.toml".to_string(),
+            config_exists: true,
+            history_path: "~/.local/share/fish/fish_history".to_string(),
+            editor: Some("nvim"),
+        }
+    }
+
+    fn keys(rows: &[Row]) -> Vec<&str> {
+        rows.iter()
+            .filter_map(|row| match row {
+                Row::Setting { key, .. } => Some(key.as_str()),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// The starter config describes every setting there is, so it is the list
+    /// `config print` has to cover. A setting added to one and not the other
+    /// is a configuration file that cannot be read back.
+    #[test]
+    fn every_setting_the_starter_config_names_is_printed() {
+        let rows = report(&Config::default(), &env());
+        let printed = keys(&rows);
+
+        for line in TEMPLATE.lines() {
+            let Some(key) = template_key(line.strip_prefix("# ").unwrap_or(line)) else {
+                continue;
+            };
+            assert!(
+                printed
+                    .iter()
+                    .any(|shown| *shown == key || shown.starts_with(&format!("{key}."))),
+                "`{key}` is in the starter config but not in `config print`: {printed:?}"
+            );
+        }
+    }
+
+    /// The keys a shell binds are configuration like any other setting, and
+    /// the report is where you look to find out which ones you have.
+    #[test]
+    fn the_default_key_bindings_and_aliases_are_printed() {
+        let rows = report(&Config::default(), &env());
+        let printed = keys(&rows);
+
+        for (trigger, _) in binding::DEFAULT_BINDINGS
+            .iter()
+            .chain(binding::DEFAULT_ALIASES)
+        {
+            assert!(
+                printed.contains(trigger),
+                "`{trigger}` is not in {printed:?}"
+            );
+        }
+        let lines = render_report(&rows, false).join("\n");
+        assert!(
+            lines.contains("Select a repository and cd into it"),
+            "a binding was printed without saying what it does:\n{lines}"
+        );
+    }
+
+    /// A binding naming an action scriv does not define stops `scriv init`
+    /// outright. The report still shows the line, since it is one the file
+    /// really has, and says what is wrong with it.
+    #[test]
+    fn a_binding_that_names_nothing_is_shown_and_marked() {
+        let rows = binding_rows(
+            Some(
+                &[("f6".to_string(), "repo-jump".to_string())]
+                    .into_iter()
+                    .collect(),
+            ),
+            binding::DEFAULT_BINDINGS,
+        );
+
+        let line = &render_report(&rows, false)[0];
+        assert!(line.contains("f6"), "{line}");
+        assert!(line.contains("repo-jump"), "{line}");
+        assert!(line.contains("no such action"), "{line}");
+    }
+
+    /// Which values are scriv's own rather than the user's is most of what the
+    /// report is for: a setting nobody chose reads differently from one
+    /// somebody did.
+    #[test]
+    fn a_value_scriv_chose_is_marked_and_one_the_user_chose_is_not() {
+        let mut cfg = Config::default();
+        cfg.selector.height = "20".to_string();
+        let lines = render_report(&report(&cfg, &env()), false);
+
+        let row = |key: &str| {
+            lines
+                .iter()
+                .find(|line| line.trim_start().starts_with(key))
+                .unwrap_or_else(|| panic!("no `{key}` row in {lines:#?}"))
+                .clone()
+        };
+        assert!(!row("height").contains(DEFAULT), "{}", row("height"));
+        assert!(row("recent").contains(DEFAULT), "{}", row("recent"));
+    }
+
+    #[test]
+    fn a_missing_config_file_says_so_once_rather_than_on_every_row() {
+        let lines = render_report(
+            &report(
+                &Config::default(),
+                &Env {
+                    config_exists: false,
+                    ..env()
+                },
+            ),
+            false,
+        );
+
+        assert!(lines[0].contains("not found"), "{:?}", lines[0]);
+        assert_eq!(
+            lines.iter().filter(|l| l.contains("not found")).count(),
+            1,
+            "{lines:#?}"
+        );
+    }
+
+    #[test]
+    fn keys_line_up_in_one_column_and_carry_no_colour_when_it_is_off() {
+        let lines = render_report(&report(&Config::default(), &env()), false);
+        let settings: Vec<&String> = lines.iter().filter(|line| line.starts_with("  ")).collect();
+
+        // The value starts after the first gap wide enough to be a column break.
+        let value_column = |line: &str| {
+            let rest = &line[2..];
+            let gap = rest.find("  ")?;
+            let padded = &rest[gap..];
+            Some(2 + gap + padded.len() - padded.trim_start().len())
+        };
+        let first = value_column(settings[0]);
+        assert!(first.is_some(), "{:?}", settings[0]);
+        for line in &settings {
+            assert_eq!(value_column(line), first, "{line}");
+            assert!(!line.contains('\x1b'), "colour leaked into a plain report");
+        }
     }
 
     // --- check ---
@@ -836,24 +1493,70 @@ mod tests {
         unique.dedup();
         assert_eq!(unique.len(), glyphs.len(), "two statuses look alike");
 
-        let plain = render(&Check::fail("repo root", "not set"), 9, false);
-        assert_eq!(plain, "✗ repo root  not set");
+        let plain = render_check(&Check::fail("repo root", "not set"), 9, false);
+        assert_eq!(plain, "  ✗ repo root  not set");
         assert!(!plain.contains('\x1b'), "colour leaked into a plain report");
     }
 
     #[test]
     fn names_are_padded_into_one_column() {
         let rows = [
-            render(&Check::ok("gh", "found"), 9, false),
-            render(&Check::ok("repo root", "/tmp"), 9, false),
+            render_check(&Check::ok("gh", "found"), 9, false),
+            render_check(&Check::ok("repo root", "/tmp"), 9, false),
         ];
         let column = |row: &str| row.rfind("  ").map(|i| i + 2);
         assert_eq!(column(&rows[0]), column(&rows[1]), "{rows:?}");
     }
 
+    /// A row with nothing to add is the tick alone: `config print` is where
+    /// the value it would have repeated is written.
+    #[test]
+    fn a_check_with_nothing_to_add_is_the_tick_and_the_name() {
+        let row = render_check(&Check::ok("config file", ""), 9, false);
+        assert_eq!(row, "  ✓ config file");
+    }
+
+    #[test]
+    fn the_summary_counts_what_is_left_to_do() {
+        let clear = [Check::ok("git", ""), Check::ok("gh", "")];
+        let (line, tint) = summary(&clear.iter().collect::<Vec<_>>());
+        assert_eq!(line, "2 checks · all clear");
+        assert_eq!(tint, Status::Ok.color());
+
+        let mixed = [
+            Check::ok("git", ""),
+            Check::warn("gh", "not on PATH"),
+            Check::fail("repo root", "not set"),
+        ];
+        let (line, tint) = summary(&mixed.iter().collect::<Vec<_>>());
+        assert_eq!(line, "3 checks · 1 failed · 1 to look at");
+        assert_eq!(tint, Status::Fail.color());
+    }
+
+    /// The row names the key that is wrong, since the report is where the
+    /// user finds out before `scriv init` does.
+    #[test]
+    fn a_binding_that_names_nothing_fails_the_shell_row() {
+        let mut broken_config = Config::default();
+        broken_config.shell.bindings = Some(
+            [("f6".to_string(), "repo-jump".to_string())]
+                .into_iter()
+                .collect(),
+        );
+
+        let sound = shell_check(&Config::default());
+        assert_eq!(sound.status, Status::Ok);
+        assert!(sound.detail.contains("10 key bindings"), "{}", sound.detail);
+
+        let broken = shell_check(&broken_config);
+        assert_eq!(broken.status, Status::Fail);
+        assert!(broken.detail.contains("f6"), "{}", broken.detail);
+        assert!(broken.detail.contains("repo-jump"), "{}", broken.detail);
+    }
+
     #[test]
     fn an_unauthenticated_gh_is_a_warning_that_names_the_way_out() {
-        let (status, detail) = gh_state("gh version 2.97.0", false);
+        let (status, detail) = gh_state("2.97.0", false);
         assert_eq!(status, Status::Warn, "a login nobody has is not fatal");
         assert!(detail.contains("gh auth login"), "{detail}");
         assert!(
@@ -861,9 +1564,27 @@ mod tests {
             "the version went missing: {detail}"
         );
 
-        let (status, detail) = gh_state("gh version 2.97.0", true);
+        let (status, detail) = gh_state("2.97.0", true);
         assert_eq!(status, Status::Ok);
         assert!(!detail.contains("gh auth login"), "{detail}");
+    }
+
+    /// Every tool here writes its version differently, and a checklist that
+    /// repeats each one's whole banner is a checklist nobody scans.
+    #[test]
+    fn a_version_line_is_reported_as_the_version() {
+        assert_eq!(version_number("git version 2.51.0"), Some("2.51.0"));
+        assert_eq!(version_number("bat 0.26.1"), Some("0.26.1"));
+        assert_eq!(
+            version_number("gh version 2.97.0 (2026-07-31)"),
+            Some("2.97.0")
+        );
+        assert_eq!(
+            version_number("2026.8.3 macos-arm64 (2026-08-07)"),
+            Some("2026.8.3")
+        );
+        assert_eq!(version_number("ripgrep v15.2.0"), Some("15.2.0"));
+        assert_eq!(version_number("usage: ps [-AaCcEefhjlMmrSTvwXx]"), None);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -821,18 +821,29 @@ enum ConfigCmd {
         #[arg(short, long)]
         force: bool,
     },
-    /// Print the resolved configuration
+    /// Print every setting and what is in force for it
+    ///
+    /// Every table the config file can hold, whether the file writes that table
+    /// or not: the value in force, and — where that value is scriv's rather
+    /// than yours — that it is a default. The keys `scriv init` binds and the
+    /// names it defines are settings like any other, listed with the action
+    /// each one runs and what that action does.
+    ///
+    /// Whether what the settings point at is actually there is `config check`.
     Print,
     /// Print the configuration file path
     Path,
     /// Check everything scriv depends on and report what is wrong
     ///
-    /// Looks at the config file, the paths it names, the repositories
+    /// A checklist: the config file, the paths it names, the repositories
     /// discovery actually finds, your editor, `git`, `gh` and whether it is
-    /// still logged in, fish's history file and the tracked-file list — all in
-    /// one pass, each with what to do about it. Exits non-zero only when
-    /// something is genuinely broken, so it is worth putting in a setup script;
-    /// a warning still leaves scriv working.
+    /// still logged in, fish's history file, the tracked-file list and the
+    /// notes vault — each a line, with what to do about the ones that are
+    /// wrong. Exits non-zero only when something is genuinely broken, so it is
+    /// worth putting in a setup script; a warning still leaves scriv working.
+    ///
+    /// What each setting is set to is `config print`; a row here repeats a
+    /// value only where repeating it is the way out of a problem.
     ///
     /// The login is asked of GitHub, so this is the one command here that waits
     /// on the network.

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -416,7 +416,34 @@ fn config_init_writes_a_config_the_next_command_accepts() {
     let print = sandbox.run(&["config", "print"]);
     print.ok();
     assert!(print.stdout.contains("[repo]"), "{}", print.stdout);
-    assert!(print.stdout.contains("root:"), "{}", print.stdout);
+    assert!(
+        print.stdout.contains("~/dev/github.com"),
+        "the root the starter config sets is not in the report: {}",
+        print.stdout
+    );
+}
+
+/// The report is what the settings actually are, so every table the file can
+/// hold is in it whether the file writes that table or not.
+#[test]
+fn config_print_covers_every_table_and_the_keys_a_shell_binds() {
+    let sandbox = Sandbox::new();
+    sandbox.write_config("[repo]\nroot = \"~/dev/github.com\"\n");
+
+    let run = sandbox.run(&["config", "print"]);
+    run.ok();
+    for table in ["[repo]", "[worktree]", "[note]", "[history]", "[selector]"] {
+        assert!(run.stdout.contains(table), "no {table} in:\n{}", run.stdout);
+    }
+    // The keys a shell binds are configuration, and this is where they are read
+    // back: the key, what it runs, and what that does.
+    assert!(run.stdout.contains("ctrl-o"), "{}", run.stdout);
+    assert!(run.stdout.contains("repo-cd"), "{}", run.stdout);
+    assert!(
+        run.stdout.contains("Select a repository and cd into it"),
+        "{}",
+        run.stdout
+    );
 }
 
 #[test]
@@ -520,7 +547,7 @@ fn config_check_fails_on_a_missing_root() {
     assert!(
         run.stdout
             .lines()
-            .any(|l| l.starts_with('✗') && l.contains("repo root")),
+            .any(|l| l.trim_start().starts_with('✗') && l.contains("repo root")),
         "{}",
         run.stdout
     );
@@ -552,7 +579,10 @@ fn config_check_does_not_report_one_problem_twice() {
     let run = sandbox.run(&["config", "check"]);
     run.code(1);
     assert_eq!(
-        run.stdout.lines().filter(|l| l.starts_with('✗')).count(),
+        run.stdout
+            .lines()
+            .filter(|l| l.trim_start().starts_with('✗'))
+            .count(),
         1,
         "{}",
         run.stdout
@@ -1883,7 +1913,7 @@ fn config_check_counts_the_notes_in_the_vault() {
     let sandbox = Sandbox::new();
     mk_vault(&sandbox);
     let run = sandbox.run(&["config", "check"]);
-    assert!(run.stdout.contains("3 note(s)"), "{}", run.stdout);
+    assert!(run.stdout.contains("3 notes"), "{}", run.stdout);
     assert!(run.stdout.contains("note editor"), "{}", run.stdout);
     // `note rg` shells out to it, so the report says whether it is there.
     assert!(run.stdout.contains("rg"), "{}", run.stdout);
@@ -2412,20 +2442,29 @@ fn an_action_scriv_does_not_define_stops_init_rather_than_thinning_it() {
     assert!(run.stderr.contains("repo-cd"), "{}", run.stderr);
 }
 
+/// The two commands split this between them: `check` says the integration
+/// resolves, `print` says what it resolves to.
 #[test]
-fn config_check_reports_on_the_shell_integration() {
+fn the_shell_integration_is_counted_by_check_and_named_by_print() {
     let sandbox = Sandbox::new();
     sandbox.write_config("[shell.aliases]\nbuild = \"project-build\"\n");
 
-    let run = sandbox.run(&["config", "check"]);
-    let row = run
+    let check = sandbox.run(&["config", "check"]);
+    let row = check
         .lines()
         .into_iter()
         .find(|line| line.contains("shell integration"))
-        .unwrap_or_else(|| panic!("no shell row:\n{}", run.stdout));
+        .unwrap_or_else(|| panic!("no shell row:\n{}", check.stdout));
+    assert!(row.trim_start().starts_with('✓'), "{row}");
+    assert!(row.contains("1 alias"), "{row}");
+    assert!(
+        !row.contains("build"),
+        "the checklist repeated what `config print` is for: {row}"
+    );
 
-    assert!(row.starts_with('✓'), "{row}");
-    assert!(row.contains("build"), "{row}");
+    let print = sandbox.run(&["config", "print"]);
+    print.ok();
+    assert!(print.stdout.contains("build"), "{}", print.stdout);
 }
 
 #[test]


### PR DESCRIPTION
`scriv config print` and `scriv config check` were converging on the same
report. They now answer different questions.

### print — what the configuration is

- Every table the file can hold, whether the file writes it or not.
- Values scriv chose rather than the user are marked as defaults.
- The keys and names `scriv init` binds are settings like any other, listed
  with the action each one runs and what that action does.
- A test holds the report to the starter config, so a setting written in one
  and not the other fails the build.

### check — whether it works

- Rows grouped, with a summary of what is left to look at.
- A working row is its tick and its version or count; colour is spent on what
  is wrong.
- Values it used to repeat now belong to `print` alone.

### Docs

- README, `--help` and the starter config say which command answers what.
- CLAUDE.md gains the rule that keeps `print` from drifting again.
- `docs/demo.gif` is unchanged: no selector draws differently.

https://claude.ai/code/session_01KPBL2JHti6z3MSPQPiSh4C