### PR TITLE
Draw the config report in colours a theme can resolve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ raised, never by hand.
 
 ## Unreleased
 
+### Fixed
+
+- `scriv config print` and `scriv config check` no longer draw half their output
+  in bright black. It is the background colour on a good share of dark themes
+  and barely-there grey on the rest, so the keys, the notes beside a value and
+  everything a passing check found were hard to read. Field names are bold now,
+  and the text beside them takes a colour the terminal resolves from its own
+  theme.
+
 ## v0.16.1
 
 *Released 2026-09-01*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,6 +164,15 @@ Rationale for code that does is a doc comment at the site — `ScratchRow`,
   repeating it is the way out of a problem.
 - **Spawned children explain themselves.** Return `Reported(code)` so scriv
   exits with the child's status rather than printing a vaguer line over git's.
+- **Colour is the low sixteen indices, and never 0, 7, 8 or 15.** Those four are
+  the background in a large share of themes, and a terminal resolves the rest
+  from the theme the user chose rather than from a fixed table. Secondary text
+  — where a value came from, what a check found — takes a hue of its own
+  (magenta), and a heading or a field label takes bold rather than a colour, so
+  the row still reads under `--color never` and on a background nobody
+  predicted. Nothing means anything by colour alone: the glyph or the word says
+  it too. `cmd/config.rs` follows this; `proc.rs`, `select.rs`, `cmd/project.rs`,
+  `project/report.rs` and `project/deps.rs` still hold a `= 8` that predates it.
 - **`NO_COLOR` is deliberately not read** — one switch for every tool, where
   `SCRIV_NO_COLOR` is one for this. Printing reads `ctx.color()`, never the tty.
 - **`repo`/`file`/`branch`/`worktree`/`pr`/`history` are registries; `edit` and

--- a/src/cmd/config.rs
+++ b/src/cmd/config.rs
@@ -183,9 +183,14 @@ pub fn init(ctx: &Ctx, force: bool) -> Result<()> {
 
 // --- print ------------------------------------------------------------------
 
-/// Grey, for everything on a row that is not the value itself: the key it is
-/// written under, and where the value came from.
-const DIM: u8 = 8;
+/// Magenta, for everything on a row that is not the value itself: where the
+/// value came from, and what a check found.
+///
+/// Colour here is the low sixteen indices only, which a terminal resolves from
+/// its own theme. Bright black reads as secondary on a dark theme and as
+/// invisible on the several themes that use it as their background, which is
+/// why a hue carries the secondary text and bold carries the labels.
+const SECONDARY: u8 = 5;
 
 /// Cyan, for the `[table]` a group of settings is written under.
 const HEADING: u8 = 6;
@@ -260,7 +265,7 @@ impl Value {
     fn color(&self) -> Option<u8> {
         match self {
             Self::Set(_) => None,
-            Self::Missing(_) => Some(DIM),
+            Self::Missing(_) => Some(SECONDARY),
             Self::Broken(_) => Some(BROKEN),
         }
     }
@@ -513,12 +518,12 @@ fn render_report(rows: &[Row], color: bool) -> Vec<String> {
                 let mut line = term::paint(title, HEADING, color);
                 if !note.is_empty() {
                     line.push_str("  ");
-                    line.push_str(&term::paint(note, DIM, color));
+                    line.push_str(&term::paint(note, SECONDARY, color));
                 }
                 line
             }
             Row::Setting { key, value, note } => {
-                let mut line = format!("  {}  ", term::paint(&pad(key, key_width), DIM, color));
+                let mut line = format!("  {}  ", term::bold(&pad(key, key_width), color));
                 let text = if note.is_empty() {
                     value.text().to_string()
                 } else {
@@ -530,7 +535,7 @@ fn render_report(rows: &[Row], color: bool) -> Vec<String> {
                 });
                 if !note.is_empty() {
                     line.push_str("  ");
-                    line.push_str(&term::paint(note, DIM, color));
+                    line.push_str(&term::paint(note, SECONDARY, color));
                 }
                 line
             }
@@ -647,11 +652,11 @@ impl Status {
         }
     }
 
-    /// The colour the row's detail takes. What a working setup found is grey;
-    /// what to do about a broken one carries the status colour.
+    /// The colour the row's detail takes. What a working setup found is
+    /// secondary text; what to do about a broken one carries the status colour.
     fn detail_color(self) -> u8 {
         match self {
-            Self::Ok => DIM,
+            Self::Ok => SECONDARY,
             other => other.color(),
         }
     }
@@ -714,10 +719,7 @@ fn render_check(check: &Check, width: usize, color: bool) -> String {
     let mut row = format!(
         "  {} {}",
         term::paint(check.status.glyph(), check.status.color(), color),
-        match check.status.name_color() {
-            Some(tint) => term::paint(&name, tint, color),
-            None => name,
-        },
+        term::style(&name, check.status.name_color(), true, color),
     );
     if !check.detail.is_empty() {
         row.push_str("  ");

--- a/src/term.rs
+++ b/src/term.rs
@@ -313,11 +313,39 @@ fn drop_controls(line: &str) -> String {
 /// Wrap `text` in an ANSI 256-colour sequence when `on`, so the same colour
 /// indices the selector uses also drive plain listings.
 pub fn paint(text: &str, color: u8, on: bool) -> String {
-    if on {
-        format!("\x1b[38;5;{color}m{text}\x1b[0m")
-    } else {
-        text.to_string()
+    style(text, Some(color), false, on)
+}
+
+/// Bold `text` when `on`, without giving it a colour.
+///
+/// What a heading or a field label takes. Bold is an attribute rather than a
+/// hue, so it is the one emphasis that reads the same whatever the terminal's
+/// theme has painted behind it.
+pub fn bold(text: &str, on: bool) -> String {
+    style(text, None, true, on)
+}
+
+/// `text` under an optional foreground colour and an optional bold attribute,
+/// as one sequence — or unchanged when `on` is false.
+///
+/// Colours are the low sixteen indices, which a terminal resolves from its own
+/// theme rather than from a fixed table. Indices outside them are a colour
+/// chosen for somebody else's background.
+pub fn style(text: &str, color: Option<u8>, bold: bool, on: bool) -> String {
+    if !on {
+        return text.to_string();
     }
+    let mut codes = String::new();
+    if bold {
+        codes.push_str("\x1b[1m");
+    }
+    if let Some(color) = color {
+        codes.push_str(&format!("\x1b[38;5;{color}m"));
+    }
+    if codes.is_empty() {
+        return text.to_string();
+    }
+    format!("{codes}{text}\x1b[0m")
 }
 
 /// Paint `text`, then return to `back` rather than to the terminal default —
@@ -722,6 +750,22 @@ mod tests {
     #[test]
     fn paint_wraps_when_on() {
         assert_eq!(paint("main", 2, true), "\x1b[38;5;2mmain\x1b[0m");
+    }
+
+    #[test]
+    fn bold_is_an_attribute_rather_than_a_colour() {
+        assert_eq!(bold("root", true), "\x1b[1mroot\x1b[0m");
+        assert_eq!(bold("root", false), "root");
+    }
+
+    #[test]
+    fn a_style_with_both_writes_both_and_resets_once() {
+        assert_eq!(
+            style("failed", Some(1), true, true),
+            "\x1b[1m\x1b[38;5;1mfailed\x1b[0m"
+        );
+        // Nothing asked for is nothing written, rather than a bare reset.
+        assert_eq!(style("plain", None, false, true), "plain");
     }
 
     #[test]


### PR DESCRIPTION
Half of `config print` and `config check` was bright black — the background
colour on a good share of dark themes, and barely-there grey on the rest.

- Field names and check names are bold rather than coloured: an attribute reads
  the same whatever is behind it.
- The secondary text beside them — where a value came from, what a passing check
  found — takes a hue from the low sixteen indices, which a terminal resolves
  from its own theme.
- Nothing means anything by colour alone; every row still carries its glyph or
  its word.

`proc.rs`, `select.rs`, `cmd/project.rs`, `project/report.rs` and
`project/deps.rs` still hold the same bright black. CLAUDE.md now states the
rule and names them as the sweep to do next.

`docs/demo.gif` is unchanged: no selector draws differently.

https://claude.ai/code/session_01KPBL2JHti6z3MSPQPiSh4C