### PR TITLE
Name the process group after the tool it reads: ps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ raised, never by hand.
 
 ## Unreleased
 
+### Changed
+
+- `scriv proc` is `scriv ps`, after the tool it reads the process table with,
+  and the `pc` alias is gone with it: the name is two letters already. `scriv
+  proc` is a usage error now, so a shell function or a note that spelled it
+  needs the new name. The `proc-kill` action a key or an alias can be bound to
+  keeps its name, since renaming one silently breaks every config that named it.
+
 ### Fixed
 
 - Nothing scriv prints is bright black any more. `proc`, `project deps`,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,8 +176,8 @@ Rationale for code that does is a doc comment at the site — `ScratchRow`,
   thing rather than as the colour each command was written in.
 - **`NO_COLOR` is deliberately not read** — one switch for every tool, where
   `SCRIV_NO_COLOR` is one for this. Printing reads `ctx.color()`, never the tty.
-- **`repo`/`file`/`branch`/`worktree`/`pr`/`history` are registries; `edit` and
-  `project` are not.** A registry is a set, with `ls`/`sel` and verbs over it.
+- **`repo`/`file`/`branch`/`worktree`/`pr`/`ps`/`history` are registries; `edit`
+  and `project` are not.** A registry is a set, with `ls`/`sel` and verbs over it.
   `edit file`/`edit dir` name what is looked for below `$PWD` and `project`
   acts on `$PWD` itself, so none of them has an `ls` — do not add one. `repo
   open` is the sole exception, and only to skip a question it can already
@@ -185,7 +185,8 @@ Rationale for code that does is a doc comment at the site — `ScratchRow`,
 - **A verb is abbreviated in its own name, not an alias beside it.** `ls`, `sel`
   and `rm` get no long form (`list`, `co` and `switch` predate the rule). Groups
   take one letter — `r`, `f`, `b`, `w`, `e`, `h`, `c` — and two where the letter
-  is spoken for: `pc` and `pj`, as `p` meets `pr`.
+  is spoken for: `pj`, as `p` meets `pr`. `pr` and `ps` are spelled in two to
+  begin with and take no alias of their own.
 - **Key bindings and aliases are configuration, not code.** What `scriv init`
   emits comes from `[shell.bindings]` and `[shell.aliases]`, which name
   [`binding::ACTIONS`] rather than holding shell code — that is what lets one

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ mise use -g github:joakimen/scriv
 cargo install --git https://github.com/joakimen/scriv
 ```
 
-Supported platform: macOS on Apple Silicon. `scriv proc` depends on Darwin's
+Supported platform: macOS on Apple Silicon. `scriv ps` depends on Darwin's
 signal numbers, and the crate refuses to compile for any other target.
 
 External requirements: `git`, plus `gh` for `pr` and `repo clone`/`open`, `rg`
@@ -90,7 +90,7 @@ editor = "nvim"     # what `note` opens one with; unset, $VISUAL / $EDITOR
 | `scriv branch` | `ls` `sel` `checkout` `rm` |
 | `scriv worktree` | `ls` `sel` `add` `rm` |
 | `scriv pr` | `ls` `sel` `checkout` `open` `merge` |
-| `scriv proc` | `ls` `sel` `kill` |
+| `scriv ps` | `ls` `sel` `kill` |
 | `scriv history` | `ls` `sel` |
 | `scriv edit` | `file` `dir` — found below `$PWD`, opened in `$EDITOR` |
 | `scriv project` | `deps` `build` — over `$PWD`, whatever it is written in |
@@ -118,7 +118,7 @@ in turn. The fish integration calls `scriv project deps` `i`.
 `ls` prints the set, `sel` fuzzy-selects one entry, and the remaining verbs act
 on the selection. `sel` prints to stdout and composes: `cd (scriv repo sel)`.
 Groups abbreviate to one letter — `r`, `f`, `n`, `b`, `w`, `e`, `h`, `c` — with
-`pc` for `proc` and `pj` for `project`.
+`pj` for `project`; `ps` and `pr` are already two.
 
 ## Key bindings
 
@@ -137,7 +137,7 @@ Groups abbreviate to one letter — `r`, `f`, `n`, `b`, `w`, `e`, `h`, `c` — w
 | `f7` | check out a pull request |
 | `f10` | open a note from your vault |
 
-`scriv init fish` also defines `fe` (`scriv edit`), `kl` (`scriv proc kill
+`scriv init fish` also defines `fe` (`scriv edit`), `kl` (`scriv ps kill
 --force`), `i` (`scriv project deps`) and `b` (`scriv project build`), each
 passing its arguments through.
 

--- a/src/binding.rs
+++ b/src/binding.rs
@@ -110,7 +110,7 @@ pub const ACTIONS: &[Action] = &[
     Action {
         id: "proc-kill",
         description: "Fuzzy-select running processes and kill them",
-        args: &["proc", "kill", "--force"],
+        args: &["ps", "kill", "--force"],
         kind: Kind::Run,
     },
     Action {

--- a/src/cmd/config.rs
+++ b/src/cmd/config.rs
@@ -123,7 +123,7 @@ ignore = ["node_modules", "target"]
 # Names defined as shell functions, each passing its arguments through.
 # [shell.aliases]
 # fe = "edit"           # scriv edit
-# kl = "proc-kill"      # scriv proc kill --force
+# kl = "proc-kill"      # scriv ps kill --force
 # i  = "project-deps"   # scriv project deps
 # b  = "project-build"  # scriv project build
 
@@ -1126,7 +1126,7 @@ fn collect(ctx: &Ctx) -> Vec<Section> {
         "ps",
         "ps",
         true,
-        "`proc` reads the process table through it",
+        "`scriv ps` reads the process table through it",
     ));
     // The one row `project` earns: everything else it runs is whatever the
     // project in front of it asks for, and a missing one of those is already

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -11,7 +11,7 @@ pub mod file;
 pub mod history;
 pub mod note;
 pub mod pr;
-pub mod proc;
 pub mod project;
+pub mod ps;
 pub mod repo;
 pub mod worktree;

--- a/src/cmd/ps.rs
+++ b/src/cmd/ps.rs
@@ -1,4 +1,4 @@
-//! `scriv proc` — list, select and signal running processes.
+//! `scriv ps` — list, select and signal running processes.
 
 use std::io::ErrorKind;
 use std::process::{Command, Stdio};
@@ -80,7 +80,7 @@ fn spawn_error(err: std::io::Error) -> anyhow::Error {
     }
 }
 
-/// `scriv proc ls` — print the running processes, busiest first.
+/// `scriv ps ls` — print the running processes, busiest first.
 pub fn ls(ctx: &Ctx, status: bool, port: Option<u16>) -> Result<()> {
     let procs = processes(port)?;
     let width = proc::user_width(&procs);
@@ -99,7 +99,7 @@ pub fn ls(ctx: &Ctx, status: bool, port: Option<u16>) -> Result<()> {
     Ok(())
 }
 
-/// `scriv proc sel` — fuzzy-select a process and print its pid.
+/// `scriv ps sel` — fuzzy-select a process and print its pid.
 pub fn sel(ctx: &Ctx, port: Option<u16>) -> Result<()> {
     let procs = processes(port)?;
     if procs.is_empty() {
@@ -110,7 +110,7 @@ pub fn sel(ctx: &Ctx, port: Option<u16>) -> Result<()> {
     Ok(())
 }
 
-/// `scriv proc kill` — signal processes, by pid or interactively.
+/// `scriv ps kill` — signal processes, by pid or interactively.
 ///
 /// Several pids are signalled one at a time, so a refusal is reported against
 /// the row it belongs to and does not hide the ones that worked.

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@
 //! library crate.
 //!
 //! Top-level commands: `repo`, `file`, `note`, `branch`, `worktree`, `pr`,
-//! `proc` and `history` work with the things scriv finds; `edit` opens a file
+//! `ps` and `history` work with the things scriv finds; `edit` opens a file
 //! from the directory the user is in and `project` builds it; `config` manages
 //! its configuration; `init` prints shell integration.
 
@@ -196,10 +196,9 @@ enum Command {
     ///
     /// `--port` narrows all three verbs to what is listening on a TCP port,
     /// which is `lsof`'s answer rather than `ps`'s.
-    #[command(visible_alias = "pc")]
-    Proc {
+    Ps {
         #[command(subcommand)]
-        command: ProcCmd,
+        command: PsCmd,
     },
     /// Manage shell history
     ///
@@ -686,7 +685,7 @@ enum PrCmd {
     },
 }
 
-/// Narrow a `proc` listing to what holds a TCP port, shared by all three.
+/// Narrow a `ps` listing to what holds a TCP port, shared by all three.
 #[derive(clap::Args)]
 struct PortScope {
     /// Only the process listening on this TCP port
@@ -699,7 +698,7 @@ struct PortScope {
 }
 
 #[derive(Subcommand)]
-enum ProcCmd {
+enum PsCmd {
     /// List running processes, busiest first
     #[command(visible_alias = "list")]
     Ls {
@@ -959,10 +958,10 @@ fn run(cli: Cli) -> anyhow::Result<()> {
                 auto,
             ),
         },
-        Command::Proc { command } => match command {
-            ProcCmd::Ls { status, scope } => cmd::proc::ls(&ctx, status, scope.port),
-            ProcCmd::Sel { scope } => cmd::proc::sel(&ctx, scope.port),
-            ProcCmd::Kill {
+        Command::Ps { command } => match command {
+            PsCmd::Ls { status, scope } => cmd::ps::ls(&ctx, status, scope.port),
+            PsCmd::Sel { scope } => cmd::ps::sel(&ctx, scope.port),
+            PsCmd::Kill {
                 pids,
                 signal,
                 force,
@@ -975,7 +974,7 @@ fn run(cli: Cli) -> anyhow::Result<()> {
                 } else {
                     scriv::proc::Signal::parse(&signal)?
                 };
-                cmd::proc::kill(&ctx, &pids, signal, scope.port)
+                cmd::ps::kill(&ctx, &pids, signal, scope.port)
             }
         },
         Command::History { command } => match command {

--- a/src/proc.rs
+++ b/src/proc.rs
@@ -1,6 +1,6 @@
 //! Running processes: parsing `ps` output, ordering it, and rendering rows.
 //!
-//! No I/O — [`crate::cmd::proc`] runs `ps` and hands the text here. `ps` is
+//! No I/O — [`crate::cmd::ps`] runs `ps` and hands the text here. `ps` is
 //! spawned rather than the process table read directly because every supported
 //! platform ships it.
 
@@ -93,7 +93,7 @@ pub fn ancestry(processes: &[Process], pid: i32) -> HashSet<i32> {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Refusal {
     /// `0` or negative. To `kill(2)` these are process *groups*, not
-    /// processes: `scriv proc kill -- -1` would end the login session.
+    /// processes: `scriv ps kill -- -1` would end the login session.
     NotAProcess,
     /// scriv itself, or something that spawned it — the chain that runs up
     /// through the shell to the terminal emulator.
@@ -189,7 +189,7 @@ pub fn with_pids(procs: &[Process], pids: &[i32]) -> Vec<Process> {
 }
 
 /// A plain listing row: the pid and the command, one space apart, so
-/// `scriv proc ls | grep node | cut -d' ' -f1` reaches the pid.
+/// `scriv ps ls | grep node | cut -d' ' -f1` reaches the pid.
 pub fn plain_row(p: &Process) -> String {
     format!("{} {}", p.pid, p.command)
 }
@@ -250,7 +250,7 @@ pub fn preview(p: &Process) -> String {
     )
 }
 
-/// A signal `scriv proc kill` can send, named as `kill` names it. A closed set,
+/// A signal `scriv ps kill` can send, named as `kill` names it. A closed set,
 /// so an unusable signal is rejected before the selector opens.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Signal(&'static str);

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -392,10 +392,7 @@ mod tests {
     #[test]
     fn kl_sends_the_uncatchable_signal() {
         let out = defaults();
-        assert!(
-            out.contains("command scriv proc kill --force $argv"),
-            "{out}"
-        );
+        assert!(out.contains("command scriv ps kill --force $argv"), "{out}");
     }
 
     /// `commandline -f repaint` redraws from where fish believes the cursor is,

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -161,7 +161,7 @@ fn help_lists_every_top_level_command() {
     let run = sandbox.run(&["--help"]);
     run.ok();
     for command in [
-        "repo", "file", "edit", "branch", "worktree", "pr", "proc", "history", "project", "config",
+        "repo", "file", "edit", "branch", "worktree", "pr", "ps", "history", "project", "config",
         "init",
     ] {
         assert!(
@@ -218,7 +218,7 @@ fn help_names_the_aliases_the_binary_accepts() {
     let sandbox = Sandbox::new();
     let top = sandbox.run(&["--help"]);
     top.ok();
-    for alias in ["r", "f", "e", "b", "w", "pc", "h", "c"] {
+    for alias in ["r", "f", "e", "b", "w", "h", "c"] {
         assert!(
             top.stdout.contains(&format!("[aliases: {alias}]")),
             "`{alias}` is accepted but unmentioned:\n{}",
@@ -261,8 +261,8 @@ fn the_documented_abbreviations_resolve() {
         &["f", "--help"][..],
         &["h", "--help"][..],
         &["n", "--help"][..],
-        &["pc", "--help"][..],
         &["pj", "--help"][..],
+        &["ps", "--help"][..],
         &["branch", "co", "--help"][..],
         &["repo", "list", "--help"][..],
     ] {
@@ -358,7 +358,7 @@ fn pr_outside_a_repository_says_so_before_gh_does() {
 fn every_registry_exposes_sel() {
     let sandbox = Sandbox::new();
     for group in [
-        "repo", "file", "note", "branch", "worktree", "pr", "proc", "history",
+        "repo", "file", "note", "branch", "worktree", "pr", "ps", "history",
     ] {
         sandbox.run(&[group, "sel", "--help"]).ok();
     }
@@ -1268,9 +1268,9 @@ fn color_takes_only_the_three_conventional_values() {
 // --- processes --------------------------------------------------------------
 
 #[test]
-fn proc_ls_leads_every_row_with_a_pid() {
+fn ps_ls_leads_every_row_with_a_pid() {
     let sandbox = Sandbox::new();
-    let run = sandbox.run(&["proc", "ls"]);
+    let run = sandbox.run(&["ps", "ls"]);
     run.ok();
     let lines = run.lines();
     assert!(!lines.is_empty(), "listed no processes at all");
@@ -1283,9 +1283,9 @@ fn proc_ls_leads_every_row_with_a_pid() {
 }
 
 #[test]
-fn proc_ls_offers_neither_scriv_nor_the_process_that_ran_it() {
+fn ps_ls_offers_neither_scriv_nor_the_process_that_ran_it() {
     let sandbox = Sandbox::new();
-    let run = sandbox.run(&["proc", "ls"]);
+    let run = sandbox.run(&["ps", "ls"]);
     run.ok();
     let own = std::process::id().to_string();
     for line in run.lines() {
@@ -1301,7 +1301,7 @@ fn proc_ls_offers_neither_scriv_nor_the_process_that_ran_it() {
 fn a_port_nothing_holds_says_so_rather_than_listing_everything() {
     let sandbox = Sandbox::new();
     for verb in [&["ls"][..], &["sel"][..], &["kill"][..]] {
-        let mut args = vec!["proc"];
+        let mut args = vec!["ps"];
         args.extend_from_slice(verb);
         args.extend_from_slice(&["--port", "0"]);
         let run = sandbox.run(&args);
@@ -1323,15 +1323,15 @@ fn a_port_nothing_holds_says_so_rather_than_listing_everything() {
 #[test]
 fn a_port_has_to_be_one() {
     let sandbox = Sandbox::new();
-    sandbox.run(&["proc", "ls", "--port", "not-a-port"]).code(2);
-    sandbox.run(&["proc", "ls", "--port", "70000"]).code(2);
+    sandbox.run(&["ps", "ls", "--port", "not-a-port"]).code(2);
+    sandbox.run(&["ps", "ls", "--port", "70000"]).code(2);
 }
 
 #[test]
-fn proc_ls_status_adds_columns_ahead_of_the_command() {
+fn ps_ls_status_adds_columns_ahead_of_the_command() {
     let sandbox = Sandbox::new();
-    let plain = sandbox.run(&["proc", "ls"]);
-    let status = sandbox.run(&["proc", "ls", "--status"]);
+    let plain = sandbox.run(&["ps", "ls"]);
+    let status = sandbox.run(&["ps", "ls", "--status"]);
     plain.ok();
     status.ok();
     let widest_plain = plain.lines().iter().map(|l| l.len()).max().unwrap_or(0);
@@ -1344,20 +1344,20 @@ fn proc_ls_status_adds_columns_ahead_of_the_command() {
 }
 
 #[test]
-fn proc_ls_status_is_pipe_safe_by_default() {
+fn ps_ls_status_is_pipe_safe_by_default() {
     let sandbox = Sandbox::new();
-    let run = sandbox.run(&["proc", "ls", "--status"]);
+    let run = sandbox.run(&["ps", "ls", "--status"]);
     run.ok();
     assert!(!run.stdout.contains('\x1b'), "coloured a pipe");
-    let forced = sandbox.run(&["--color", "always", "proc", "ls", "--status"]);
+    let forced = sandbox.run(&["--color", "always", "ps", "ls", "--status"]);
     forced.ok();
     assert!(forced.stdout.contains('\x1b'), "--color always did nothing");
 }
 
 #[test]
-fn proc_kill_refuses_an_unknown_signal_before_selecting() {
+fn ps_kill_refuses_an_unknown_signal_before_selecting() {
     let sandbox = Sandbox::new();
-    let run = sandbox.run(&["proc", "kill", "--signal", "HUPP"]);
+    let run = sandbox.run(&["ps", "kill", "--signal", "HUPP"]);
     run.code(1);
     assert!(run.stderr.contains("unknown signal"), "{}", run.stderr);
     assert!(run.stderr.contains("known signals are"), "{}", run.stderr);
@@ -1366,10 +1366,10 @@ fn proc_kill_refuses_an_unknown_signal_before_selecting() {
 /// To `kill`, `0` and a negative number are process *groups*. Run for real,
 /// with a signal that would work, so the refusal is what the test proves.
 #[test]
-fn proc_kill_refuses_a_pid_that_is_really_a_process_group() {
+fn ps_kill_refuses_a_pid_that_is_really_a_process_group() {
     let sandbox = Sandbox::new();
     for pid in ["0", "-1"] {
-        let run = sandbox.run(&["proc", "kill", "--signal", "CONT", "--", pid]);
+        let run = sandbox.run(&["ps", "kill", "--signal", "CONT", "--", pid]);
         run.code(1);
         assert!(
             run.stderr.contains("refusing to signal"),
@@ -1381,10 +1381,10 @@ fn proc_kill_refuses_a_pid_that_is_really_a_process_group() {
 }
 
 #[test]
-fn proc_kill_still_accepts_an_ordinary_pid() {
+fn ps_kill_still_accepts_an_ordinary_pid() {
     let sandbox = Sandbox::new();
     // What matters is that scriv got as far as asking `kill`.
-    let run = sandbox.run(&["proc", "kill", "--signal", "CONT", "2147483646"]);
+    let run = sandbox.run(&["ps", "kill", "--signal", "CONT", "2147483646"]);
     assert!(
         !run.stderr.contains("refusing to signal"),
         "an ordinary pid was refused: {}",
@@ -1393,17 +1393,17 @@ fn proc_kill_still_accepts_an_ordinary_pid() {
 }
 
 #[test]
-fn proc_kill_will_not_take_a_signal_and_force_at_once() {
+fn ps_kill_will_not_take_a_signal_and_force_at_once() {
     let sandbox = Sandbox::new();
     sandbox
-        .run(&["proc", "kill", "--signal", "TERM", "--force"])
+        .run(&["ps", "kill", "--signal", "TERM", "--force"])
         .code(2);
 }
 
 /// Uses a child of the test's own making, so nothing on the machine is at
 /// risk.
 #[test]
-fn proc_kill_signals_the_pid_it_is_given() {
+fn ps_kill_signals_the_pid_it_is_given() {
     let sandbox = Sandbox::new();
     let mut child = Command::new("sleep")
         .arg("60")
@@ -1411,7 +1411,7 @@ fn proc_kill_signals_the_pid_it_is_given() {
         .expect("spawning a process to kill");
     let pid = child.id().to_string();
 
-    let run = sandbox.run(&["proc", "kill", &pid]);
+    let run = sandbox.run(&["ps", "kill", &pid]);
     run.ok();
     assert!(
         run.stdout.contains("sent TERM to"),
@@ -1427,7 +1427,7 @@ fn proc_kill_signals_the_pid_it_is_given() {
 }
 
 #[test]
-fn proc_kill_force_sends_kill() {
+fn ps_kill_force_sends_kill() {
     let sandbox = Sandbox::new();
     let mut child = Command::new("sleep")
         .arg("60")
@@ -1435,20 +1435,20 @@ fn proc_kill_force_sends_kill() {
         .expect("spawning a process to kill");
     let pid = child.id().to_string();
 
-    let run = sandbox.run(&["proc", "kill", "--force", &pid]);
+    let run = sandbox.run(&["ps", "kill", "--force", &pid]);
     run.ok();
     assert!(run.stdout.contains("sent KILL to"), "{}", run.stdout);
     child.wait().expect("waiting for the killed process");
 }
 
 #[test]
-fn proc_kill_passes_a_failure_through() {
+fn ps_kill_passes_a_failure_through() {
     let sandbox = Sandbox::new();
     let mut child = Command::new("sleep").arg("0").spawn().expect("spawning");
     let pid = child.id().to_string();
     child.wait().expect("reaping");
 
-    let run = sandbox.run(&["proc", "kill", &pid]);
+    let run = sandbox.run(&["ps", "kill", &pid]);
     assert_ne!(run.code, Some(0), "signalled a process that had exited");
     assert!(
         !run.stderr.contains("error: "),


### PR DESCRIPTION
`scriv proc` is `scriv ps`.

- The name is what a unix user already types for this, and it is two letters,
  so the `pc` alias goes with it.
- `scriv proc` is a usage error rather than a hidden alias.
- The `proc-kill` action keeps its name: renaming one silently breaks every
  config that bound it.

`docs/demo.gif` is unchanged: the demo never showed this group.

https://claude.ai/code/session_01KPBL2JHti6z3MSPQPiSh4C