### PR TITLE
Count what scriv is used for, and what each command costs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,19 @@ raised, never by hand.
 
 ## Unreleased
 
+### Added
+
+- `scriv stats` counts scriv itself. Every run appends its command and how long
+  it took to a log, and `stats show` reads that back as a tree of every command
+  there is — with how often you have run each one and what a run of it costs —
+  so the commands going unused are as visible as the ones that are not. The
+  time you spend in a selector is taken out of the numbers: a list left open
+  over lunch is not a slow command. `stats improve` hands the busiest commands
+  to Claude Code to work on, and `stats reset` forgets the lot.
+
+  Nothing but the command's name is recorded: no arguments, no paths, no what
+  you picked. The log is `$XDG_DATA_HOME/scriv/stats`.
+
 ### Changed
 
 - `scriv proc` is `scriv ps`, after the tool it reads the process table with,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -184,9 +184,19 @@ Rationale for code that does is a doc comment at the site — `ScratchRow`,
   answer.
 - **A verb is abbreviated in its own name, not an alias beside it.** `ls`, `sel`
   and `rm` get no long form (`list`, `co` and `switch` predate the rule). Groups
-  take one letter — `r`, `f`, `b`, `w`, `e`, `h`, `c` — and two where the letter
+  take one letter — `r`, `f`, `b`, `w`, `e`, `h`, `c`, `s` — and two where the letter
   is spoken for: `pj`, as `p` meets `pr`. `pr` and `ps` are spelled in two to
   begin with and take no alias of their own.
+- **Anything that waits for a person binds [`stats::interacting`].** Every run
+  records what it cost, and a selector left open over lunch would otherwise be
+  recorded as a command that takes an hour. There are two such places — the
+  selector and the yes/no question — and a third would be a new one to bind it
+  in, not a reason to thread a clock through the call graph.
+- **The stats log is appended to, never rewritten.** One line per run, so two
+  scriv processes finishing at once cannot lose each other's row and a run that
+  is killed loses only itself. The totals are worked out when they are read.
+  Nothing but the command's name goes in it: no arguments, no paths, no what
+  was picked.
 - **Key bindings and aliases are configuration, not code.** What `scriv init`
   emits comes from `[shell.bindings]` and `[shell.aliases]`, which name
   [`binding::ACTIONS`] rather than holding shell code — that is what lets one

--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ signal numbers, and the crate refuses to compile for any other target.
 
 External requirements: `git`, plus `gh` for `pr` and `repo clone`/`open`, `rg`
 for `note rg`, `bat` for syntax-highlighted previews, a fish history file for
-`history`, and `$VISUAL` or `$EDITOR` for `edit` — or `[note] editor` for
-`note`. `scriv config check` reports on each. `project` runs whatever the
+`history`, `claude` for `stats improve`, and `$VISUAL` or `$EDITOR` for `edit` —
+or `[note] editor` for `note`. `scriv config check` reports on each. `project` runs whatever the
 project in front of it asks for, and reports a tool the machine does not have as
 a skip rather than a failure.
 
@@ -95,6 +95,7 @@ editor = "nvim"     # what `note` opens one with; unset, $VISUAL / $EDITOR
 | `scriv edit` | `file` `dir` — found below `$PWD`, opened in `$EDITOR` |
 | `scriv project` | `deps` `build` — over `$PWD`, whatever it is written in |
 | `scriv config` | `init` `print` `path` `check` |
+| `scriv stats` | `show` `reset` `improve` |
 | `scriv init` | `fish` and every other shell — see Setup |
 
 A note row is the day it was created and what it calls itself, tinted by the
@@ -115,10 +116,18 @@ grouped by the role each dependency is given. `build` runs the repository's own
 `task`, `make` or `just` where it has one, and otherwise builds each toolchain
 in turn. The fish integration calls `scriv project deps` `i`.
 
+`scriv stats` counts scriv itself. Every run appends its command and how long it
+took to a log — with the time you spent in a selector taken out, so a list left
+open over lunch is not a slow command — and `stats show` reads it back as a tree
+of every command there is, including the ones you have never run. Nothing but
+the command's name is recorded: no arguments, no paths, no what you picked.
+`stats improve` hands the busiest commands to Claude Code to work on, and
+`stats reset` forgets the lot.
+
 `ls` prints the set, `sel` fuzzy-selects one entry, and the remaining verbs act
 on the selection. `sel` prints to stdout and composes: `cd (scriv repo sel)`.
-Groups abbreviate to one letter — `r`, `f`, `n`, `b`, `w`, `e`, `h`, `c` — with
-`pj` for `project`; `ps` and `pr` are already two.
+Groups abbreviate to one letter — `r`, `f`, `n`, `b`, `w`, `e`, `h`, `c`, `s` —
+with `pj` for `project`; `ps` and `pr` are already two.
 
 ## Key bindings
 

--- a/src/cmd/config.rs
+++ b/src/cmd/config.rs
@@ -1137,6 +1137,12 @@ fn collect(ctx: &Ctx) -> Vec<Section> {
         false,
         "`project` runs a project's own tools through it (https://mise.jdx.dev)",
     ));
+    tools.push(tool_check(
+        "claude",
+        "claude",
+        false,
+        "only `stats improve` needs it (https://claude.com/product/claude-code)",
+    ));
 
     let content = vec![history_check(ctx), files_check(ctx), note_vault_check(ctx)];
 

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -14,4 +14,5 @@ pub mod pr;
 pub mod project;
 pub mod ps;
 pub mod repo;
+pub mod stats;
 pub mod worktree;

--- a/src/cmd/stats.rs
+++ b/src/cmd/stats.rs
@@ -1,0 +1,176 @@
+//! `scriv stats` — what has been run, how often, and how long it took.
+//!
+//! The log is opened on a thread of its own while the command runs, so nothing
+//! about recording a run is in front of the user: by the time there is a record
+//! to write, the file is already open and the write is one append.
+
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::path::PathBuf;
+use std::sync::mpsc::{Sender, channel};
+use std::thread::JoinHandle;
+
+use anyhow::{Result, bail};
+
+use crate::{Ctx, stats, term};
+
+/// The open log, and the thread that owns it.
+///
+/// Failure is silent throughout: a tool that will not run because it cannot
+/// count its own runs is worse than one that misses a row.
+pub struct Recorder {
+    /// `None` when there was nowhere to write, which is the whole of what a
+    /// failure means here.
+    tx: Option<Sender<stats::Record>>,
+    thread: Option<JoinHandle<()>>,
+}
+
+impl Recorder {
+    /// Open the log in the background and hand back something to finish with.
+    pub fn start(path: PathBuf) -> Self {
+        let (tx, rx) = channel::<stats::Record>();
+        let thread = std::thread::spawn(move || {
+            let file = std::fs::create_dir_all(path.parent().unwrap_or(&path))
+                .ok()
+                .and_then(|()| {
+                    OpenOptions::new()
+                        .create(true)
+                        .append(true)
+                        .open(&path)
+                        .ok()
+                });
+            // Blocks until the command is done, which is what makes opening the
+            // file free: it happens while the command runs.
+            let Ok(record) = rx.recv() else {
+                return;
+            };
+            if let Some(mut file) = file {
+                let _ = file.write_all(stats::format(&record).as_bytes());
+            }
+        });
+        Self {
+            tx: Some(tx),
+            thread: Some(thread),
+        }
+    }
+
+    /// Record one run and wait for it to reach the disk — one append to a file
+    /// that has been open since the command started.
+    pub fn finish(mut self, record: stats::Record) {
+        if let Some(tx) = self.tx.take() {
+            let _ = tx.send(record);
+        }
+        if let Some(thread) = self.thread.take() {
+            let _ = thread.join();
+        }
+    }
+}
+
+impl Drop for Recorder {
+    /// A recorder dropped without finishing — a command that panicked — closes
+    /// the channel so the thread stops waiting for a record that is not coming.
+    fn drop(&mut self) {
+        self.tx.take();
+        if let Some(thread) = self.thread.take() {
+            let _ = thread.join();
+        }
+    }
+}
+
+/// Read the log, or nothing when there is not one yet.
+fn read(ctx: &Ctx) -> Result<Vec<stats::Record>> {
+    match std::fs::read_to_string(&ctx.stats_path) {
+        Ok(text) => Ok(stats::parse(&text)),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(Vec::new()),
+        Err(e) => bail!("reading {}: {e}", ctx.stats_path.display()),
+    }
+}
+
+/// The tree, with what each command has cost, for `show` and for `improve`.
+fn rows(ctx: &Ctx, command: &clap::Command) -> Result<Vec<stats::TreeRow>> {
+    let totals = stats::totals(&read(ctx)?);
+    Ok(stats::rows(&stats::tree(command), &totals))
+}
+
+/// `scriv stats show` — every command there is, with how often it has been run
+/// and what one run costs.
+pub fn show(ctx: &Ctx, command: &clap::Command) -> Result<()> {
+    let rows = rows(ctx, command)?;
+
+    let mut out = term::Listing::stdout();
+    for line in stats::render(&rows, ctx.color()) {
+        if !out.line(&line)? {
+            return Ok(());
+        }
+    }
+    out.finish()?;
+    Ok(())
+}
+
+/// `scriv stats reset` — forget every run recorded so far.
+pub fn reset(ctx: &Ctx, yes: bool) -> Result<()> {
+    let records = read(ctx)?;
+    if records.is_empty() {
+        println!("nothing recorded yet");
+        return Ok(());
+    }
+
+    match term::Confirm::resolve(yes) {
+        term::Confirm::Assumed => {}
+        term::Confirm::Ask => {
+            let question = format!("Forget {} recorded runs?", records.len());
+            let _waiting = stats::interacting();
+            if !term::confirm(&question)? {
+                println!("kept");
+                return Ok(());
+            }
+        }
+        term::Confirm::Impossible => bail!(
+            "{} recorded runs would be forgotten; pass --yes to do it without a terminal to ask at",
+            records.len()
+        ),
+    }
+
+    match std::fs::remove_file(&ctx.stats_path) {
+        Ok(()) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => bail!("removing {}: {e}", ctx.stats_path.display()),
+    }
+    println!("forgot {} recorded runs", records.len());
+    Ok(())
+}
+
+/// The program `improve` hands the prompt to.
+const CLAUDE: &str = "claude";
+
+/// `scriv stats improve` — hand the statistics to Claude Code, in the directory
+/// the user is standing in, and let it work on the commands worth the most.
+///
+/// Nothing is captured: Claude Code takes the terminal, as `scriv edit`'s
+/// editor does.
+pub fn improve(ctx: &Ctx, command: &clap::Command, dry_run: bool) -> Result<()> {
+    let rows = rows(ctx, command)?;
+    let prompt = stats::improve_prompt(&rows);
+
+    if dry_run {
+        println!("{prompt}");
+        return Ok(());
+    }
+    if stats::by_value(&rows).is_empty() {
+        bail!("nothing has been recorded yet, so there is nothing to improve");
+    }
+    if crate::cmd::config::on_path(CLAUDE).is_none() {
+        bail!("`{CLAUDE}` is not on PATH — https://claude.com/product/claude-code");
+    }
+
+    ctx.log
+        .info(&format!("handing {} rows to {CLAUDE}", rows.len()));
+    let status = std::process::Command::new(CLAUDE)
+        .arg(&prompt)
+        .status()
+        .map_err(|e| anyhow::anyhow!("running {CLAUDE}: {e}"))?;
+    if !status.success() {
+        return Err(crate::Reported(status.code().unwrap_or(1)).into());
+    }
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@ pub mod recent;
 pub mod repo;
 pub mod select;
 pub mod shell;
+pub mod stats;
 pub mod term;
 pub mod walk;
 
@@ -90,6 +91,8 @@ pub struct Ctx {
     pub legacy_kf_path: PathBuf,
     /// fish's history file, which `scriv history` reads.
     pub history_path: PathBuf,
+    /// The log every run appends itself to, which `scriv stats` reads.
+    pub stats_path: PathBuf,
     /// This machine's offset from UTC, for dating history entries.
     utc_offset: time::UtcOffset,
     /// The editor `scriv edit` launches, from the environment.
@@ -147,11 +150,10 @@ impl Ctx {
         let config = config::load_config(&config_path)?;
 
         // fish's data directory, a different XDG variable from the one above.
-        let history_path = history::history_path(
-            config.history.file.as_deref(),
-            std::env::var(history::XDG_DATA_ENV_VAR).ok().as_deref(),
-            &home,
-        );
+        let data_home = std::env::var(history::XDG_DATA_ENV_VAR).ok();
+        let history_path =
+            history::history_path(config.history.file.as_deref(), data_home.as_deref(), &home);
+        let stats_path = stats::path(data_home.as_deref(), &home);
 
         // Read at the top of the process because it cannot be read later:
         // `time` refuses to determine the local offset once the process is
@@ -188,6 +190,7 @@ impl Ctx {
             recent_path,
             legacy_kf_path,
             history_path,
+            stats_path,
             utc_offset,
             editor,
             note_editor,

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,14 +10,14 @@
 use std::process::ExitCode;
 
 use clap::builder::styling::{AnsiColor, Effects, Styles};
-use clap::{CommandFactory, Parser, Subcommand};
+use clap::{CommandFactory, FromArgMatches, Parser, Subcommand};
 use clap_complete::Shell;
 
 use scriv::gh::MergeMethod;
 use scriv::git::Filter;
 use scriv::select::Cancelled;
 use scriv::term::ColorChoice;
-use scriv::{Ctx, Reported, cmd, shell};
+use scriv::{Ctx, Reported, cmd, shell, stats};
 
 /// Usage examples appended to the top-level help. Three lines, and it stays
 /// three — see CLAUDE.md.
@@ -238,6 +238,19 @@ enum Command {
     Config {
         #[command(subcommand)]
         command: ConfigCmd,
+    },
+    /// What you run, how often, and how long it takes
+    ///
+    /// Every run appends one line to a log — the command, and how long it took
+    /// with the time you spent in a selector taken out — which `stats show`
+    /// reads back as a tree of every command there is.
+    ///
+    /// Nothing but the command's name is recorded: no arguments, no paths, no
+    /// what you picked.
+    #[command(visible_alias = "s")]
+    Stats {
+        #[command(subcommand)]
+        command: StatsCmd,
     },
     /// Print shell integration for `source`-ing
     ///
@@ -849,8 +862,42 @@ enum ConfigCmd {
     Check,
 }
 
+#[derive(Subcommand)]
+enum StatsCmd {
+    /// Print every command, with how often it has run and what it costs
+    ///
+    /// The whole tree, including the commands you have never run — which is
+    /// half of what the report is for.
+    #[command(visible_alias = "list")]
+    Show,
+    /// Forget every run recorded so far
+    Reset {
+        /// Do not ask first
+        #[arg(short, long)]
+        yes: bool,
+    },
+    /// Hand the statistics to Claude Code and let it improve what they point at
+    ///
+    /// Runs `claude` in the directory you are standing in, on a prompt built
+    /// from the commands worth the most — total time spent, which has both how
+    /// often a command runs and what each run costs in it. Run it from a scriv
+    /// checkout, since that is what it will be asked to change.
+    Improve {
+        /// Print the prompt instead of running anything
+        #[arg(short = 'n', long)]
+        dry_run: bool,
+    },
+}
+
 fn main() -> ExitCode {
-    match run(Cli::parse()) {
+    // Parsed through `ArgMatches` rather than straight into `Cli` so the run
+    // can be recorded under the name clap matched — `repo sel`, whatever alias
+    // was typed for it — without a second table of names to keep in step.
+    let matches = Cli::command().get_matches();
+    let command = command_path(&matches);
+    let cli = Cli::from_arg_matches(&matches).unwrap_or_else(|err| err.exit());
+
+    match run(cli, &command) {
         Ok(()) => ExitCode::SUCCESS,
         // A cancelled selector is a silent, conventional exit, not an error.
         Err(err) if err.is::<Cancelled>() => ExitCode::from(130),
@@ -866,30 +913,64 @@ fn main() -> ExitCode {
     }
 }
 
-fn run(cli: Cli) -> anyhow::Result<()> {
-    let ctx = Ctx::load(cli.config.as_deref(), cli.verbose, cli.color)?;
+/// The command clap matched, as the log spells it: the subcommands from the
+/// root down, joined by spaces, under their canonical names rather than the
+/// aliases they may have been typed as.
+fn command_path(matches: &clap::ArgMatches) -> String {
+    let mut path = Vec::new();
+    let mut node = matches;
+    while let Some((name, sub)) = node.subcommand() {
+        path.push(name.to_string());
+        node = sub;
+    }
+    path.join(" ")
+}
 
-    match cli.command {
+fn run(cli: Cli, command: &str) -> anyhow::Result<()> {
+    let started = std::time::Instant::now();
+    let ctx = Ctx::load(cli.config.as_deref(), cli.verbose, cli.color)?;
+    // Started before the command rather than after it: opening the log is what
+    // takes any time, and it happens while the command runs.
+    let recorder = cmd::stats::Recorder::start(ctx.stats_path.clone());
+
+    let result = dispatch(&ctx, cli.command);
+
+    recorder.finish(stats::Record {
+        at: std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|since| since.as_secs() as i64)
+            .unwrap_or_default(),
+        millis: stats::ran_for(started.elapsed(), stats::waited())
+            .as_millis()
+            .try_into()
+            .unwrap_or(u64::MAX),
+        command: command.to_string(),
+    });
+    result
+}
+
+fn dispatch(ctx: &Ctx, command: Command) -> anyhow::Result<()> {
+    match command {
         Command::Repo { command } => match command {
-            RepoCmd::Ls { absolute_paths } => cmd::repo::ls(&ctx, absolute_paths),
-            RepoCmd::Sel => cmd::repo::sel(&ctx),
-            RepoCmd::Open { select } => cmd::repo::open(&ctx, select),
+            RepoCmd::Ls { absolute_paths } => cmd::repo::ls(ctx, absolute_paths),
+            RepoCmd::Sel => cmd::repo::sel(ctx),
+            RepoCmd::Open { select } => cmd::repo::open(ctx, select),
             RepoCmd::Clone {
                 target,
                 limit,
                 archived,
-            } => cmd::repo::clone(&ctx, target.as_deref(), limit, archived),
+            } => cmd::repo::clone(ctx, target.as_deref(), limit, archived),
         },
         Command::File { command } => match command {
             FileCmd::Ls {
                 status,
                 missing,
                 exists,
-            } => cmd::file::ls(&ctx, status, missing, exists),
-            FileCmd::Sel => cmd::file::sel(&ctx),
-            FileCmd::Add { file } => cmd::file::add(&ctx, file.as_deref()),
-            FileCmd::Rm { file } => cmd::file::remove(&ctx, file.as_deref()),
-            FileCmd::Prune { yes } => cmd::file::prune(&ctx, yes),
+            } => cmd::file::ls(ctx, status, missing, exists),
+            FileCmd::Sel => cmd::file::sel(ctx),
+            FileCmd::Add { file } => cmd::file::add(ctx, file.as_deref()),
+            FileCmd::Rm { file } => cmd::file::remove(ctx, file.as_deref()),
+            FileCmd::Prune { yes } => cmd::file::prune(ctx, yes),
         },
         // No subcommand is `edit file`, dispatched through the same arm so
         // the two spellings cannot drift apart.
@@ -898,50 +979,48 @@ fn run(cli: Cli) -> anyhow::Result<()> {
             files,
             tracked,
         } => match command.unwrap_or(EditCmd::File { files, tracked }) {
-            EditCmd::File { files, tracked } => cmd::edit::file(&ctx, &files, tracked),
-            EditCmd::Dir { dirs } => cmd::edit::dir(&ctx, &dirs),
+            EditCmd::File { files, tracked } => cmd::edit::file(ctx, &files, tracked),
+            EditCmd::Dir { dirs } => cmd::edit::dir(ctx, &dirs),
         },
         Command::Note { command } => match command {
-            NoteCmd::Ls { status } => cmd::note::ls(&ctx, status),
-            NoteCmd::Sel => cmd::note::sel(&ctx),
-            NoteCmd::Edit { notes } => cmd::note::edit(&ctx, &notes),
-            NoteCmd::New { name } => cmd::note::new(&ctx, name.as_deref()),
-            NoteCmd::Rg { query } => cmd::note::rg(&ctx, query.as_deref()),
-            NoteCmd::Scratch => cmd::note::scratch(&ctx),
-            NoteCmd::Cleanup { yes } => cmd::note::cleanup(&ctx, yes),
+            NoteCmd::Ls { status } => cmd::note::ls(ctx, status),
+            NoteCmd::Sel => cmd::note::sel(ctx),
+            NoteCmd::Edit { notes } => cmd::note::edit(ctx, &notes),
+            NoteCmd::New { name } => cmd::note::new(ctx, name.as_deref()),
+            NoteCmd::Rg { query } => cmd::note::rg(ctx, query.as_deref()),
+            NoteCmd::Scratch => cmd::note::scratch(ctx),
+            NoteCmd::Cleanup { yes } => cmd::note::cleanup(ctx, yes),
         },
         Command::Branch { command } => match command {
             BranchCmd::Ls { status, scope } => {
-                cmd::branch::ls(&ctx, scope.filter(), status, scope.fetch)
+                cmd::branch::ls(ctx, scope.filter(), status, scope.fetch)
             }
-            BranchCmd::Sel { scope } => cmd::branch::sel(&ctx, scope.filter(), scope.fetch),
+            BranchCmd::Sel { scope } => cmd::branch::sel(ctx, scope.filter(), scope.fetch),
             BranchCmd::Checkout { branch, scope } => {
-                cmd::branch::checkout(&ctx, branch.as_deref(), scope.filter(), scope.fetch)
+                cmd::branch::checkout(ctx, branch.as_deref(), scope.filter(), scope.fetch)
             }
-            BranchCmd::Rm { branches, yes } => cmd::branch::rm(&ctx, &branches, yes),
+            BranchCmd::Rm { branches, yes } => cmd::branch::rm(ctx, &branches, yes),
         },
         Command::Worktree { command } => match command {
             WorktreeCmd::Ls {
                 absolute_paths,
                 status,
-            } => cmd::worktree::ls(&ctx, absolute_paths, status),
-            WorktreeCmd::Sel => cmd::worktree::sel(&ctx),
-            WorktreeCmd::Add { branch } => cmd::worktree::add(&ctx, branch.as_deref()),
-            WorktreeCmd::Rm { paths, force, yes } => {
-                cmd::worktree::remove(&ctx, &paths, force, yes)
-            }
+            } => cmd::worktree::ls(ctx, absolute_paths, status),
+            WorktreeCmd::Sel => cmd::worktree::sel(ctx),
+            WorktreeCmd::Add { branch } => cmd::worktree::add(ctx, branch.as_deref()),
+            WorktreeCmd::Rm { paths, force, yes } => cmd::worktree::remove(ctx, &paths, force, yes),
         },
         Command::Pr { command } => match command {
-            PrCmd::Ls { status, scope } => cmd::pr::ls(&ctx, &scope.state, scope.limit, status),
-            PrCmd::Sel { scope } => cmd::pr::sel(&ctx, &scope.state, scope.limit),
+            PrCmd::Ls { status, scope } => cmd::pr::ls(ctx, &scope.state, scope.limit, status),
+            PrCmd::Sel { scope } => cmd::pr::sel(ctx, &scope.state, scope.limit),
             PrCmd::Checkout { number, scope } => {
-                cmd::pr::checkout(&ctx, number, &scope.state, scope.limit)
+                cmd::pr::checkout(ctx, number, &scope.state, scope.limit)
             }
             PrCmd::Open {
                 number,
                 current,
                 scope,
-            } => cmd::pr::open(&ctx, number, current, &scope.state, scope.limit),
+            } => cmd::pr::open(ctx, number, current, &scope.state, scope.limit),
             PrCmd::Merge {
                 number,
                 method,
@@ -949,7 +1028,7 @@ fn run(cli: Cli) -> anyhow::Result<()> {
                 auto,
                 scope,
             } => cmd::pr::merge(
-                &ctx,
+                ctx,
                 number,
                 &scope.state,
                 scope.limit,
@@ -959,8 +1038,8 @@ fn run(cli: Cli) -> anyhow::Result<()> {
             ),
         },
         Command::Ps { command } => match command {
-            PsCmd::Ls { status, scope } => cmd::ps::ls(&ctx, status, scope.port),
-            PsCmd::Sel { scope } => cmd::ps::sel(&ctx, scope.port),
+            PsCmd::Ls { status, scope } => cmd::ps::ls(ctx, status, scope.port),
+            PsCmd::Sel { scope } => cmd::ps::sel(ctx, scope.port),
             PsCmd::Kill {
                 pids,
                 signal,
@@ -974,22 +1053,29 @@ fn run(cli: Cli) -> anyhow::Result<()> {
                 } else {
                     scriv::proc::Signal::parse(&signal)?
                 };
-                cmd::ps::kill(&ctx, &pids, signal, scope.port)
+                cmd::ps::kill(ctx, &pids, signal, scope.port)
             }
         },
         Command::History { command } => match command {
-            HistoryCmd::Ls { status } => cmd::history::ls(&ctx, status),
-            HistoryCmd::Sel { query, print0 } => cmd::history::sel(&ctx, query.as_deref(), print0),
+            HistoryCmd::Ls { status } => cmd::history::ls(ctx, status),
+            HistoryCmd::Sel { query, print0 } => cmd::history::sel(ctx, query.as_deref(), print0),
         },
         Command::Project { command } => match command {
-            ProjectCmd::Deps { dry_run, dump } => cmd::project::deps(&ctx, dry_run, dump),
-            ProjectCmd::Build { dry_run } => cmd::project::build(&ctx, dry_run),
+            ProjectCmd::Deps { dry_run, dump } => cmd::project::deps(ctx, dry_run, dump),
+            ProjectCmd::Build { dry_run } => cmd::project::build(ctx, dry_run),
         },
         Command::Config { command } => match command {
-            ConfigCmd::Init { force } => cmd::config::init(&ctx, force),
-            ConfigCmd::Print => cmd::config::print(&ctx),
-            ConfigCmd::Path => cmd::config::path(&ctx),
-            ConfigCmd::Check => cmd::config::check(&ctx),
+            ConfigCmd::Init { force } => cmd::config::init(ctx, force),
+            ConfigCmd::Print => cmd::config::print(ctx),
+            ConfigCmd::Path => cmd::config::path(ctx),
+            ConfigCmd::Check => cmd::config::check(ctx),
+        },
+        // The tree these report on is the clap command itself, which is the
+        // only place that knows every command there is.
+        Command::Stats { command } => match command {
+            StatsCmd::Show => cmd::stats::show(ctx, &Cli::command()),
+            StatsCmd::Reset { yes } => cmd::stats::reset(ctx, yes),
+            StatsCmd::Improve { dry_run } => cmd::stats::improve(ctx, &Cli::command(), dry_run),
         },
         // Emitted from the config, so this needs Ctx like everything else —
         // and the clap command besides, for the completions.

--- a/src/select.rs
+++ b/src/select.rs
@@ -1103,7 +1103,12 @@ fn run_selector(feed: Feed, run: Run, cfg: &SelectorConfig) -> Result<Outcome> {
     };
 
     let _room = room_for(&cfg.height);
-    let output = Skim::run_with(options, source).map_err(|e| anyhow!("running selector: {e}"))?;
+    // Everything from here until skim returns is the user's time, not scriv's,
+    // and `scriv stats` says so.
+    let output = {
+        let _waiting = crate::stats::interacting();
+        Skim::run_with(options, source).map_err(|e| anyhow!("running selector: {e}"))?
+    };
 
     if output.is_abort {
         return Err(Cancelled.into());

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -1,0 +1,605 @@
+//! What has been run, how often, and how long it took.
+//!
+//! I/O-free: [`crate::cmd::stats`] opens the log and appends to it. The only
+//! clock here is the one measuring a run, and the counter the selectors add
+//! their waiting to.
+//!
+//! Every run appends one line rather than rewriting a total, so two scriv
+//! processes finishing at the same moment cannot lose each other's row, and a
+//! run that is killed loses only itself.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, Instant};
+
+use crate::project::report::format_duration;
+use crate::term;
+
+/// The log every run appends to: `$XDG_DATA_HOME/scriv/stats`, falling back to
+/// `~/.local/share`, as the spec puts machine-written data.
+pub fn path(data_home: Option<&str>, home: &Path) -> PathBuf {
+    let base = data_home
+        .map(str::trim)
+        .filter(|dir| !dir.is_empty())
+        .map(PathBuf::from)
+        .unwrap_or_else(|| home.join(".local/share"));
+    base.join("scriv").join("stats")
+}
+
+/// One run: when it finished, how long it took with the time spent waiting for
+/// the person at the keyboard taken out, and which command it was.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Record {
+    /// Unix seconds.
+    pub at: i64,
+    pub millis: u64,
+    /// The command as it is spelled, subcommands included: `repo sel`.
+    pub command: String,
+}
+
+/// A record as its line of the log. Tab-separated with the command last, so a
+/// name that ever grows a space in it still needs no quoting.
+pub fn format(record: &Record) -> String {
+    format!("{}\t{}\t{}\n", record.at, record.millis, record.command)
+}
+
+/// Every record in `text`.
+///
+/// A line that does not parse is skipped rather than failing the read: the log
+/// is appended to by every run there has ever been, and one truncated row from
+/// a machine that lost power is not a reason to refuse the rest.
+pub fn parse(text: &str) -> Vec<Record> {
+    text.lines()
+        .filter_map(|line| {
+            let mut fields = line.splitn(3, '\t');
+            let at = fields.next()?.trim().parse().ok()?;
+            let millis = fields.next()?.trim().parse().ok()?;
+            let command = fields.next()?.trim();
+            if command.is_empty() {
+                return None;
+            }
+            Some(Record {
+                at,
+                millis,
+                command: command.to_string(),
+            })
+        })
+        .collect()
+}
+
+/// What one command adds up to over every run of it.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct Totals {
+    pub calls: u64,
+    /// Wall time over every run, which is what makes a command worth
+    /// improving: a fast one run all day costs more than a slow one run twice.
+    pub millis: u64,
+}
+
+impl Totals {
+    /// What one run of it costs on average, and nothing when it has never run.
+    pub fn average(&self) -> Option<Duration> {
+        (self.calls > 0).then(|| Duration::from_millis(self.millis / self.calls))
+    }
+
+    fn add(&mut self, other: Totals) {
+        self.calls += other.calls;
+        self.millis += other.millis;
+    }
+}
+
+/// What each command adds up to, by the name it was run under.
+pub fn totals(records: &[Record]) -> BTreeMap<String, Totals> {
+    let mut out: BTreeMap<String, Totals> = BTreeMap::new();
+    for record in records {
+        out.entry(record.command.clone()).or_default().add(Totals {
+            calls: 1,
+            millis: record.millis,
+        });
+    }
+    out
+}
+
+// --- the tree ----------------------------------------------------------------
+
+/// One command, and the commands under it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Node {
+    pub name: String,
+    pub children: Vec<Node>,
+}
+
+/// The command tree, as clap knows it.
+///
+/// Hidden commands are left out, and so is clap's own `help`: it is not one of
+/// scriv's commands, and the mirror of every other command it carries would
+/// draw the whole tree twice.
+pub fn tree(command: &clap::Command) -> Node {
+    Node {
+        name: command.get_name().to_string(),
+        children: command
+            .get_subcommands()
+            .filter(|sub| !sub.is_hide_set() && sub.get_name() != "help")
+            .map(tree)
+            .collect(),
+    }
+}
+
+/// One line of the report: the branch drawn to its left, the command's own
+/// name, and what it and everything under it add up to.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TreeRow {
+    /// The box-drawing that connects this row to the ones above it.
+    pub branch: String,
+    pub name: String,
+    /// The full command, as the log spells it.
+    pub command: String,
+    pub totals: Totals,
+    /// Whether anything below this row is counted in its totals, which is what
+    /// makes the number a sum rather than a count of its own runs.
+    pub is_group: bool,
+}
+
+/// The tree as rows, in the order they are drawn, each carrying the totals of
+/// the whole subtree below it.
+///
+/// The root is a row of its own: what the tool adds up to altogether.
+pub fn rows(node: &Node, totals: &BTreeMap<String, Totals>) -> Vec<TreeRow> {
+    let mut out = Vec::new();
+    walk(node, "", "", "", totals, &mut out);
+    out
+}
+
+/// Depth-first, building each row's branch from its parent's — `│  ` where the
+/// parent still has siblings below it, three spaces where it does not — and
+/// summing each subtree into its parent on the way back out.
+///
+/// `command` is what the log spells this row, which is empty at the root: a run
+/// is recorded as `repo sel`, not as `scriv repo sel`.
+fn walk(
+    node: &Node,
+    branch: &str,
+    below: &str,
+    command: &str,
+    totals: &BTreeMap<String, Totals>,
+    out: &mut Vec<TreeRow>,
+) -> Totals {
+    let index = out.len();
+    let mut own = totals.get(command).copied().unwrap_or_default();
+    out.push(TreeRow {
+        branch: branch.to_string(),
+        name: node.name.clone(),
+        command: command.to_string(),
+        totals: own,
+        is_group: !node.children.is_empty(),
+    });
+
+    let last = node.children.len().saturating_sub(1);
+    for (i, child) in node.children.iter().enumerate() {
+        let (glyph, gap) = if i == last {
+            ("└─ ", "   ")
+        } else {
+            ("├─ ", "│  ")
+        };
+        let path = if command.is_empty() {
+            child.name.clone()
+        } else {
+            format!("{command} {}", child.name)
+        };
+        own.add(walk(
+            child,
+            &format!("{below}{glyph}"),
+            &format!("{below}{gap}"),
+            &path,
+            totals,
+            out,
+        ));
+    }
+
+    out[index].totals = own;
+    own
+}
+
+/// The columns, as `stats show` prints them: the tree, how often each command
+/// has been run, and what one run of it costs.
+pub fn render(rows: &[TreeRow], color: bool) -> Vec<String> {
+    let cell = |row: &TreeRow| {
+        (
+            match row.totals.calls {
+                0 => "-".to_string(),
+                calls => calls.to_string(),
+            },
+            row.totals
+                .average()
+                .map(format_duration)
+                .unwrap_or_else(|| "-".to_string()),
+        )
+    };
+
+    let name_width = rows
+        .iter()
+        .map(|row| row.branch.chars().count() + row.name.chars().count())
+        .max()
+        .unwrap_or(0)
+        .max(HEADINGS.0.len());
+    let calls_width = rows
+        .iter()
+        .map(|row| cell(row).0.chars().count())
+        .max()
+        .unwrap_or(0)
+        .max(HEADINGS.1.len());
+
+    let mut out = vec![format!(
+        "{}  {}  {}",
+        term::bold(&pad(HEADINGS.0, name_width), color),
+        term::bold(&right(HEADINGS.1, calls_width), color),
+        term::bold(HEADINGS.2, color),
+    )];
+    out.extend(rows.iter().map(|row| {
+        let (calls, average) = cell(row);
+        let drawn = row.branch.chars().count() + row.name.chars().count();
+        format!(
+            "{}{}{}  {}  {}",
+            term::paint(&row.branch, term::SECONDARY, color),
+            // A command nobody has run is secondary text: the point of the
+            // report is the ones that are.
+            match row.totals.calls {
+                0 => term::paint(&row.name, term::SECONDARY, color),
+                _ => term::bold(&row.name, color),
+            },
+            " ".repeat(name_width.saturating_sub(drawn)),
+            term::paint(&right(&calls, calls_width), term::SECONDARY, color),
+            term::paint(&average, term::SECONDARY, color),
+        )
+        .trim_end()
+        .to_string()
+    }));
+    out
+}
+
+/// What the three columns are called.
+const HEADINGS: (&str, &str, &str) = ("command", "runs", "average");
+
+fn pad(text: &str, width: usize) -> String {
+    format!(
+        "{text}{}",
+        " ".repeat(width.saturating_sub(text.chars().count()))
+    )
+}
+
+fn right(text: &str, width: usize) -> String {
+    format!(
+        "{}{text}",
+        " ".repeat(width.saturating_sub(text.chars().count()))
+    )
+}
+
+// --- the prompt ---------------------------------------------------------------
+
+/// How many commands the hand-off names. Enough to see a pattern, few enough
+/// that the ones at the top are the ones being asked about.
+const IMPROVE_ROWS: usize = 10;
+
+/// The commands worth improving, in the order they are worth it: total time
+/// spent, which is the one number that has both how often a command is run and
+/// what each run costs in it.
+pub fn by_value(rows: &[TreeRow]) -> Vec<&TreeRow> {
+    let mut leaves: Vec<&TreeRow> = rows
+        .iter()
+        .filter(|row| !row.is_group && row.totals.calls > 0)
+        .collect();
+    leaves.sort_by(|a, b| {
+        b.totals
+            .millis
+            .cmp(&a.totals.millis)
+            .then_with(|| b.totals.calls.cmp(&a.totals.calls))
+            .then_with(|| a.command.cmp(&b.command))
+    });
+    leaves
+}
+
+/// What `stats improve` asks Claude Code to do, with the table it should read
+/// it against.
+pub fn improve_prompt(rows: &[TreeRow]) -> String {
+    let mut prompt = String::from(
+        "These are scriv's own usage statistics, gathered by `scriv stats`. \
+         Each row is a command, how many times it has been run, what one run \
+         costs on average, and what it has cost in total.\n\n\
+         | command | runs | average | total |\n| --- | --- | --- | --- |\n",
+    );
+    for row in by_value(rows).into_iter().take(IMPROVE_ROWS) {
+        prompt.push_str(&format!(
+            "| `scriv {}` | {} | {} | {} |\n",
+            row.command,
+            row.totals.calls,
+            row.totals
+                .average()
+                .map(format_duration)
+                .unwrap_or_else(|| "-".into()),
+            format_duration(Duration::from_millis(row.totals.millis)),
+        ));
+    }
+    prompt.push_str(
+        "\nThe rows are ordered by total time spent, which is where making \
+         scriv faster is worth the most. Time spent waiting for the user in a \
+         selector is already excluded from these numbers, so what is left is \
+         scriv's own work and what it waits on.\n\n\
+         Take the highest-value row you can actually improve, work out where \
+         its time goes, and implement the improvement. Measure before and \
+         after and say what the numbers were. Follow CLAUDE.md in this \
+         repository, including how work is branched and shipped.",
+    );
+    prompt
+}
+
+// --- the clock ----------------------------------------------------------------
+
+/// Nanoseconds this process has spent waiting for the person at the keyboard.
+///
+/// A process-wide counter rather than something threaded through every call:
+/// what it measures is a property of the process, the selector that adds to it
+/// is three call levels below the command being timed, and nothing decides
+/// anything by it.
+static WAITED: AtomicU64 = AtomicU64::new(0);
+
+/// Time spent in front of a person, counted from when this is bound until it is
+/// dropped. Bind it — `let _waiting = stats::interacting()`.
+#[must_use]
+pub struct Interaction(Instant);
+
+/// Start counting time that belongs to the user rather than to scriv.
+pub fn interacting() -> Interaction {
+    Interaction(Instant::now())
+}
+
+impl Drop for Interaction {
+    fn drop(&mut self) {
+        let waited = u64::try_from(self.0.elapsed().as_nanos()).unwrap_or(u64::MAX);
+        WAITED.fetch_add(waited, Ordering::Relaxed);
+    }
+}
+
+/// How long this process has waited for the person running it.
+pub fn waited() -> Duration {
+    Duration::from_nanos(WAITED.load(Ordering::Relaxed))
+}
+
+/// What the run itself took: the wall clock less the time the user spent
+/// deciding. A selector left open over lunch is not a slow command.
+pub fn ran_for(total: Duration, waited: Duration) -> Duration {
+    total.saturating_sub(waited)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn record(command: &str, millis: u64) -> Record {
+        Record {
+            at: 1_700_000_000,
+            millis,
+            command: command.to_string(),
+        }
+    }
+
+    #[test]
+    fn a_record_survives_the_round_trip_through_a_line() {
+        let written = format(&record("repo sel", 842));
+        assert_eq!(written, "1700000000\t842\trepo sel\n");
+        assert_eq!(parse(&written), vec![record("repo sel", 842)]);
+    }
+
+    /// The log is every run there has ever been, and a machine that lost power
+    /// mid-append is not a reason to refuse the rest of it.
+    #[test]
+    fn a_line_that_makes_no_sense_is_skipped_rather_than_failing_the_read() {
+        let records = parse(
+            "1700000000\t10\trepo ls\n\
+             nonsense\n\
+             \n\
+             1700000000\tnot-a-number\tpr ls\n\
+             1700000001\t20\t\n\
+             1700000002\t30\tconfig print\n\
+             1700000",
+        );
+        assert_eq!(
+            records
+                .iter()
+                .map(|r| r.command.as_str())
+                .collect::<Vec<_>>(),
+            ["repo ls", "config print"]
+        );
+    }
+
+    #[test]
+    fn totals_count_the_runs_and_add_up_what_they_cost() {
+        let totals = totals(&[
+            record("repo sel", 100),
+            record("repo sel", 300),
+            record("pr ls", 50),
+        ]);
+        assert_eq!(
+            totals["repo sel"],
+            Totals {
+                calls: 2,
+                millis: 400
+            }
+        );
+        assert_eq!(
+            totals["repo sel"].average(),
+            Some(Duration::from_millis(200))
+        );
+        assert_eq!(totals["pr ls"].calls, 1);
+        assert_eq!(Totals::default().average(), None, "no runs, no average");
+    }
+
+    /// A selector left open over lunch is not a slow command.
+    #[test]
+    fn what_the_user_spent_deciding_is_not_what_the_command_took() {
+        assert_eq!(
+            ran_for(Duration::from_secs(30), Duration::from_secs(29)),
+            Duration::from_secs(1)
+        );
+        // A clock that disagrees with itself is a zero, not a panic.
+        assert_eq!(
+            ran_for(Duration::from_secs(1), Duration::from_secs(2)),
+            Duration::ZERO
+        );
+    }
+
+    #[test]
+    fn the_log_is_under_the_data_directory_the_environment_names() {
+        assert_eq!(
+            path(Some("/data"), Path::new("/home/me")),
+            PathBuf::from("/data/scriv/stats")
+        );
+        // Unset, and empty, fall back to where the spec puts it.
+        for unset in [None, Some(""), Some("  ")] {
+            assert_eq!(
+                path(unset, Path::new("/home/me")),
+                PathBuf::from("/home/me/.local/share/scriv/stats")
+            );
+        }
+    }
+
+    fn cli() -> clap::Command {
+        clap::Command::new("scriv")
+            .subcommand(
+                clap::Command::new("repo")
+                    .subcommand(clap::Command::new("ls"))
+                    .subcommand(clap::Command::new("sel")),
+            )
+            .subcommand(clap::Command::new("edit"))
+            .subcommand(clap::Command::new("secret").hide(true))
+    }
+
+    /// The tree is every command there is, which is what makes the report say
+    /// what you are not using as well as what you are.
+    #[test]
+    fn the_tree_is_claps_own_without_what_it_hides() {
+        let tree = tree(&cli());
+        assert_eq!(tree.name, "scriv");
+        assert_eq!(
+            tree.children
+                .iter()
+                .map(|c| c.name.as_str())
+                .collect::<Vec<_>>(),
+            ["repo", "edit"],
+            "a hidden command is not one to report on"
+        );
+        assert_eq!(tree.children[0].children.len(), 2);
+    }
+
+    #[test]
+    fn a_row_is_named_as_the_log_spells_it_and_the_root_is_not_part_of_it() {
+        let rows = rows(&tree(&cli()), &BTreeMap::new());
+        let commands: Vec<&str> = rows.iter().map(|r| r.command.as_str()).collect();
+        assert_eq!(commands, ["", "repo", "repo ls", "repo sel", "edit"]);
+
+        let drawn: Vec<String> = rows
+            .iter()
+            .map(|r| format!("{}{}", r.branch, r.name))
+            .collect();
+        assert_eq!(
+            drawn,
+            ["scriv", "├─ repo", "│  ├─ ls", "│  └─ sel", "└─ edit"]
+        );
+    }
+
+    /// A group is what the commands under it come to, so the tree can be read
+    /// from the top: the root is the whole tool.
+    #[test]
+    fn a_group_adds_up_what_is_under_it() {
+        let totals = totals(&[
+            record("repo ls", 100),
+            record("repo sel", 300),
+            record("repo sel", 500),
+            record("edit", 40),
+        ]);
+        let rows = rows(&tree(&cli()), &totals);
+        let of = |command: &str| {
+            rows.iter()
+                .find(|r| r.command == command)
+                .unwrap_or_else(|| panic!("no {command} row"))
+                .totals
+        };
+
+        assert_eq!(of("repo sel").calls, 2);
+        assert_eq!(
+            of("repo"),
+            Totals {
+                calls: 3,
+                millis: 900
+            },
+            "a group is its children"
+        );
+        assert_eq!(
+            of(""),
+            Totals {
+                calls: 4,
+                millis: 940
+            },
+            "the root is everything"
+        );
+    }
+
+    #[test]
+    fn a_command_nobody_has_run_says_so_rather_than_showing_a_zero() {
+        let lines = render(&rows(&tree(&cli()), &BTreeMap::new()), false);
+        assert!(lines[0].starts_with("command"), "{:?}", lines[0]);
+        assert!(lines[1].contains(" - "), "{:?}", lines[1]);
+        for line in &lines {
+            assert!(!line.contains('\x1b'), "colour leaked into a plain report");
+            assert!(!line.ends_with(' '), "trailing padding: {line:?}");
+        }
+    }
+
+    #[test]
+    fn the_columns_line_up() {
+        let totals = totals(&[record("repo sel", 1234), record("edit", 5)]);
+        let lines = render(&rows(&tree(&cli()), &totals), false);
+        // Where the last field starts, counted in characters: the branch is
+        // drawn in box characters three bytes wide, so byte offsets would say
+        // rows that line up on screen do not.
+        let column = |line: &str| {
+            line.rsplit_once(' ')
+                .map(|(head, _)| head.chars().count() + 1)
+        };
+        let first = column(&lines[0]);
+        assert!(first.is_some());
+        for line in &lines {
+            assert_eq!(column(line), first, "{line}");
+        }
+    }
+
+    /// Total time spent is the one number with both how often a command runs
+    /// and what each run costs in it.
+    #[test]
+    fn the_commands_worth_improving_are_ordered_by_what_they_have_cost() {
+        let totals = totals(&[
+            // Slow, but run once.
+            record("repo ls", 900),
+            // Quick, but run all day.
+            record("repo sel", 200),
+            record("repo sel", 200),
+            record("repo sel", 200),
+            record("repo sel", 200),
+            record("repo sel", 200),
+            record("edit", 10),
+        ]);
+        let rows = rows(&tree(&cli()), &totals);
+
+        let ranked: Vec<&str> = by_value(&rows).iter().map(|r| r.command.as_str()).collect();
+        assert_eq!(ranked, ["repo sel", "repo ls", "edit"]);
+        // Groups are not rows to improve: `repo` is not a command anyone runs.
+        assert!(!ranked.contains(&"repo"), "{ranked:?}");
+
+        let prompt = improve_prompt(&rows);
+        assert!(
+            prompt.contains("`scriv repo sel` | 5 | 200ms | 1.0s"),
+            "{prompt}"
+        );
+        assert!(prompt.contains("CLAUDE.md"), "{prompt}");
+    }
+}

--- a/src/term.rs
+++ b/src/term.rs
@@ -132,6 +132,9 @@ pub fn is_yes(answer: &str) -> bool {
 /// Ask `question` on stderr, since stdout is a result, and read the answer
 /// from stdin. Whether there is anyone to answer is [`Confirm`]'s business.
 pub fn confirm(question: &str) -> std::io::Result<bool> {
+    // The wait is the user's, so it is not counted against the command that
+    // asked. See [`crate::stats::interacting`].
+    let _waiting = crate::stats::interacting();
     let mut err = std::io::stderr().lock();
     write!(err, "{question} [y/N] ")?;
     err.flush()?;

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -77,6 +77,11 @@ impl Sandbox {
         self.home().join(".config/scriv/config.toml")
     }
 
+    /// The log every run appends itself to.
+    fn stats_path(&self) -> PathBuf {
+        self.home().join(".local/share/scriv/stats")
+    }
+
     /// The known-files list, which lives beside the config file.
     fn files_path(&self) -> PathBuf {
         self.home().join(".config/scriv/files")
@@ -2504,4 +2509,96 @@ fn verbose_keeps_only_its_long_form() {
     sandbox.run(&["--verbose", "config", "path"]).ok();
     sandbox.run(&["config", "--verbose", "path"]).ok();
     sandbox.run(&["config", "path", "-v"]).code(2);
+}
+
+// --- stats ------------------------------------------------------------------
+
+#[test]
+fn every_run_records_itself_under_the_name_clap_matched() {
+    let sandbox = Sandbox::new();
+    sandbox.run(&["config", "path"]).ok();
+    // An alias is the same command, and is recorded as the command.
+    sandbox.run(&["c", "path"]).ok();
+
+    let log = std::fs::read_to_string(sandbox.stats_path()).expect("no stats log");
+    let commands: Vec<&str> = log
+        .lines()
+        .filter_map(|line| line.split('\t').nth(2))
+        .collect();
+    assert_eq!(commands, ["config path", "config path"], "{log}");
+}
+
+#[test]
+fn show_counts_what_has_run_and_names_what_has_not() {
+    let sandbox = Sandbox::new();
+    sandbox.run(&["config", "path"]).ok();
+    sandbox.run(&["config", "path"]).ok();
+
+    let run = sandbox.run(&["stats", "show"]);
+    run.ok();
+    let row = |name: &str| {
+        run.stdout
+            .lines()
+            .find(|line| line.contains(name))
+            .unwrap_or_else(|| panic!("no {name} row:\n{}", run.stdout))
+            .to_string()
+    };
+    assert!(row("path").contains(" 2 "), "{}", row("path"));
+    // The whole tree, so the report says what is going unused as well.
+    assert!(row("worktree").contains('-'), "{}", row("worktree"));
+    assert!(run.stdout.starts_with("command"), "{}", run.stdout);
+}
+
+/// The point of taking the selector's time out is that a command left waiting
+/// is not recorded as a slow one, and nothing else in a run takes seconds.
+#[test]
+fn a_run_is_recorded_in_milliseconds_rather_than_in_how_long_it_sat_there() {
+    let sandbox = Sandbox::new();
+    sandbox.run(&["config", "path"]).ok();
+
+    let log = std::fs::read_to_string(sandbox.stats_path()).unwrap();
+    let millis: u64 = log
+        .lines()
+        .next()
+        .and_then(|line| line.split('\t').nth(1))
+        .and_then(|millis| millis.parse().ok())
+        .unwrap_or_else(|| panic!("no duration in {log:?}"));
+    assert!(millis < 10_000, "{millis}ms for `config path`");
+}
+
+#[test]
+fn reset_forgets_the_runs_and_says_how_many() {
+    let sandbox = Sandbox::new();
+    sandbox.run(&["config", "path"]).ok();
+
+    // Without a terminal to ask at, it names the flag that skips the question.
+    let refused = sandbox.run(&["stats", "reset"]);
+    refused.code(1);
+    assert!(refused.stderr.contains("--yes"), "{}", refused.stderr);
+    assert!(sandbox.stats_path().exists(), "the log went anyway");
+
+    let run = sandbox.run(&["stats", "reset", "--yes"]);
+    run.ok();
+    assert!(run.stdout.contains("forgot"), "{}", run.stdout);
+    assert!(!sandbox.stats_path().exists(), "{}", run.stdout);
+
+    // And again, with nothing to forget.
+    let again = sandbox.run(&["stats", "reset", "--yes"]);
+    again.ok();
+    assert!(
+        again.stdout.contains("nothing recorded"),
+        "{}",
+        again.stdout
+    );
+}
+
+#[test]
+fn improve_prints_the_prompt_it_would_hand_over() {
+    let sandbox = Sandbox::new();
+    sandbox.run(&["config", "path"]).ok();
+
+    let run = sandbox.run(&["stats", "improve", "--dry-run"]);
+    run.ok();
+    assert!(run.stdout.contains("`scriv config path`"), "{}", run.stdout);
+    assert!(run.stdout.contains("| command | runs |"), "{}", run.stdout);
 }


### PR DESCRIPTION
`scriv stats` counts scriv itself.

### What it records

- One line per run: the command clap matched, and how long it took.
- Time spent in front of a person is taken out. There are two places scriv
  waits on one — the selector and the yes/no question — and both add their
  waiting to a counter the record subtracts.
- Nothing but the command's name: no arguments, no paths, no what was picked.

### The subcommands

- `show` draws every command there is as a tree, with how often each has run
  and what a run costs. Drawn from clap's own tree, so what is going unused is
  as much of the report as what is not.
- `reset` forgets the lot, after asking.
- `improve` hands the rows worth the most — total time spent, which has both
  how often a command runs and what each run costs in it — to Claude Code, in
  the directory you are standing in. `--dry-run` prints the prompt instead.

### Cost

The log is opened on a thread of its own while the command runs, so by the time
there is a record to write, the write is one append to a file already open. It
is appended to rather than rewritten, so two scriv processes finishing together
cannot lose each other's row.

`claude` joins the tools `config check` reports on. `docs/demo.gif` is
unchanged: no selector draws differently.

https://claude.ai/code/session_01KPBL2JHti6z3MSPQPiSh4C