### PR TITLE
Leave the log empty after a reset, whichever way the race went

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,8 @@ raised, never by hand.
   to Claude Code to work on, and `stats reset` forgets the lot.
 
   Nothing but the command's name is recorded: no arguments, no paths, no what
-  you picked. The log is `$XDG_DATA_HOME/scriv/stats`.
+  you picked, and `stats reset` does not record itself. The log is
+  `$XDG_DATA_HOME/scriv/stats`.
 
 ### Changed
 

--- a/src/cmd/stats.rs
+++ b/src/cmd/stats.rs
@@ -131,10 +131,15 @@ pub fn reset(ctx: &Ctx, yes: bool) -> Result<()> {
         ),
     }
 
-    match std::fs::remove_file(&ctx.stats_path) {
-        Ok(()) => {}
+    // Emptied rather than removed: this run has the log open already, and a
+    // file removed from under an open handle is one the next write brings
+    // back with a hole where the rows were.
+    match OpenOptions::new().write(true).open(&ctx.stats_path) {
+        Ok(file) => file
+            .set_len(0)
+            .map_err(|e| anyhow::anyhow!("emptying {}: {e}", ctx.stats_path.display()))?,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
-        Err(e) => bail!("removing {}: {e}", ctx.stats_path.display()),
+        Err(e) => bail!("emptying {}: {e}", ctx.stats_path.display()),
     }
     println!("forgot {} recorded runs", records.len());
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -871,6 +871,9 @@ enum StatsCmd {
     #[command(visible_alias = "list")]
     Show,
     /// Forget every run recorded so far
+    ///
+    /// The reset is not itself recorded, so what is left is nothing rather than
+    /// the command that did the forgetting.
     Reset {
         /// Do not ask first
         #[arg(short, long)]
@@ -935,6 +938,9 @@ fn run(cli: Cli, command: &str) -> anyhow::Result<()> {
 
     let result = dispatch(&ctx, cli.command);
 
+    if !stats::records(command) {
+        return result;
+    }
     recorder.finish(stats::Record {
         at: std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -333,6 +333,18 @@ pub fn improve_prompt(rows: &[TreeRow]) -> String {
     prompt
 }
 
+/// The one command whose run is not recorded.
+const RESET: &str = "stats reset";
+
+/// Whether a run is one to record.
+///
+/// Every run but the one that forgets every run: recording that would leave
+/// the log holding the command that had just emptied it, and the count it
+/// reports the next time would be of itself.
+pub fn records(command: &str) -> bool {
+    command != RESET
+}
+
 // --- the clock ----------------------------------------------------------------
 
 /// Nanoseconds this process has spent waiting for the person at the keyboard.
@@ -446,6 +458,16 @@ mod tests {
             ran_for(Duration::from_secs(1), Duration::from_secs(2)),
             Duration::ZERO
         );
+    }
+
+    /// A reset that recorded itself would empty the log and immediately put a
+    /// row back in it — and which of the two won was down to whether the log
+    /// had been opened yet.
+    #[test]
+    fn the_run_that_forgets_every_run_does_not_record_itself() {
+        assert!(!records("stats reset"));
+        assert!(records("stats show"));
+        assert!(records("repo sel"));
     }
 
     #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -2579,8 +2579,14 @@ fn reset_forgets_the_runs_and_says_how_many() {
 
     let run = sandbox.run(&["stats", "reset", "--yes"]);
     run.ok();
-    assert!(run.stdout.contains("forgot"), "{}", run.stdout);
-    assert!(!sandbox.stats_path().exists(), "{}", run.stdout);
+    // One run: the reset that was refused is a reset, and no reset records
+    // itself.
+    assert!(run.stdout.contains("forgot 1"), "{}", run.stdout);
+
+    // What is left is nothing at all, rather than the command that did the
+    // forgetting.
+    let left = std::fs::read_to_string(sandbox.stats_path()).unwrap_or_default();
+    assert_eq!(left, "", "the log kept a row");
 
     // And again, with nothing to forget.
     let again = sandbox.run(&["stats", "reset", "--yes"]);


### PR DESCRIPTION
`stats reset` removed the log while the run doing it held the log open to
record itself. Which of the two won — the unlink, or the recorder's `create` —
decided whether the file came back with a single row in it. CI caught it on the
release branch; the same test had passed locally.

- No reset records itself. Recording the run that forgets every run would put a
  row back the moment it emptied the log, and the count it reported next time
  would be of itself.
- The log is emptied rather than removed, so an open handle cannot bring it
  back.

Both are what the test asserts now, rather than what the machine happened to do.

`docs/demo.gif` is unchanged: no selector draws differently.

https://claude.ai/code/session_01KPBL2JHti6z3MSPQPiSh4C
