### PR TITLE
Match a repository by its name, and let the list be narrowed to what is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,23 @@ raised, never by hand.
 
 ### Added
 
+- `ctrl-t` in the `repo clone` selector shows only the repositories you have not
+  cloned yet, and `ctrl-a` puts the whole list back. The header says which of
+  the two is in force.
+
+### Fixed
+
+- The `repo clone` and `repo sel` selectors match what you type against the
+  repository alone. A query used to reach the description, the tags and the
+  owner label as well, so a word in a description matched a row it had nothing
+  to do with — and the row was then scrolled sideways to show where it hit,
+  pushing the repository's own name off the screen.
+- `repo clone` says `loading repositories for <owner>` while it waits. It used
+  to count pages off as they arrived; they are fetched together and arrive in
+  whatever order they finish, so the count went up and down and read as a bug.
+
+### Added
+
 - `scriv stats` counts scriv itself. Every run appends its command and how long
   it took to a log, and `stats show` reads that back as a tree of every command
   there is — with how often you have run each one and what a run of it costs —

--- a/src/cmd/branch.rs
+++ b/src/cmd/branch.rs
@@ -155,7 +155,7 @@ fn select(ctx: &Ctx, branches: Vec<Branch>, filter: Filter, prompt: &str) -> Res
 
     let reload = {
         let (known, failure) = (Arc::clone(&known), Arc::clone(&failure));
-        Box::new(move || {
+        Box::new(move |_view| {
             // Fetched outside the lock: it is a network round trip, and holding
             // the list for it would make a second ctrl-r — or closing the
             // selector — wait on the remote rather than on the list.

--- a/src/cmd/history.rs
+++ b/src/cmd/history.rs
@@ -63,7 +63,10 @@ fn items(entries: &[Entry], offset: time::UtcOffset) -> Vec<SelectItem> {
             } else {
                 SelectItem::new(folded, entry.cmd.clone())
             };
-            item.prefix(format!("{}  ", history::stamp(entry.when, offset)))
+            item.prefix(
+                format!("{}  ", history::stamp(entry.when, offset)),
+                Vec::new(),
+            )
         })
         .collect()
 }

--- a/src/cmd/note.rs
+++ b/src/cmd/note.rs
@@ -245,7 +245,7 @@ fn items(ctx: &Ctx, notes: &[Note]) -> Vec<SelectItem> {
         .iter()
         .map(|note| {
             let item = SelectItem::new(note::row(note), note.path.to_string_lossy().into_owned())
-                .prefix(note::prefix(note, offset))
+                .prefix(note::prefix(note, offset), Vec::new())
                 .preview(Preview::File);
             match note::row_color(note, &cfg) {
                 Some(color) => item.color(color),

--- a/src/cmd/pr.rs
+++ b/src/cmd/pr.rs
@@ -302,7 +302,7 @@ fn select(
 
     let reload = {
         let (known, failure, state) = (Arc::clone(&known), Arc::clone(&failure), state.to_string());
-        Box::new(move || {
+        Box::new(move |_view| {
             // Asked for outside the lock: `gh` is a network round trip, and
             // holding the list for it would make a second ctrl-r wait on the
             // first rather than on GitHub.

--- a/src/cmd/repo.rs
+++ b/src/cmd/repo.rs
@@ -97,10 +97,23 @@ fn repo_rows(ctx: &Ctx, repos: &[FoundRepo]) -> Vec<SelectItem> {
                 RepoDisplay::Tilde => display_path(&abs, ctx.home_str(), false),
                 RepoDisplay::Full => abs.clone(),
             };
-            let row = format!("{label:<width$}  {shown}", label = repo.label);
-            let item = SelectItem::new(row, abs.clone()).preview(select::checkout_preview(&abs));
-            match colors.get(repo.label.as_str()) {
-                Some(&color) => item.color(color),
+            // The label is a column, not something anyone searches by: in the
+            // prefix it is drawn and not matched, so a query only ever reaches
+            // the repository itself.
+            let label = format!("{label:<width$}  ", label = repo.label);
+            let color = colors.get(repo.label.as_str()).copied();
+            let tints = color.map_or_else(Vec::new, |color| {
+                vec![Tint {
+                    range: 0..label.chars().count(),
+                    color,
+                }]
+            });
+
+            let item = SelectItem::new(shown, abs.clone())
+                .prefix(label, tints)
+                .preview(select::checkout_preview(&abs));
+            match color {
+                Some(color) => item.color(color),
                 None => item,
             }
         })
@@ -285,9 +298,9 @@ struct Widths {
 }
 
 impl Widths {
-    fn of(repos: &[Repo]) -> Self {
+    fn of<'a>(repos: impl Iterator<Item = &'a Repo> + Clone) -> Self {
         // Character counts, not bytes: a column is padded by characters.
-        let widest = |f: fn(&Repo) -> usize| repos.iter().map(f).max().unwrap_or(0);
+        let widest = |f: fn(&Repo) -> usize| repos.clone().map(f).max().unwrap_or(0);
         Self {
             name: widest(|r| r.name().chars().count()),
             tags: widest(|r| tag_column(r).chars().count()),
@@ -309,74 +322,140 @@ fn push_column(row: &mut String, text: &str, width: usize) {
     }
 }
 
-/// One row of the clone selector, and the columns of it that carry a colour.
+/// One row of the clone selector, split into what a query may match and what it
+/// may not.
 ///
-/// The two are built together because a tint is a character range into the row,
-/// and counting those ranges out a second time is how they drift.
+/// The three are built together because a tint is a character range into the
+/// part it belongs to, and counting those ranges out a second time is how they
+/// drift.
 ///
 /// Nothing tints the row as a whole. A line drawn in one colour reads as a
 /// statement about the repository, and neither "already on disk" nor "private"
 /// is one — the first is about this machine and the second about one column, so
 /// each colours only the thing it is true of.
-fn clone_row(repo: &Repo, present: bool, widths: &Widths) -> (String, Vec<Tint>) {
-    let mut row = String::new();
-    let mut tints = Vec::new();
+struct CloneRow {
+    /// The tick for a repository already on disk, ahead of the name.
+    mark: String,
+    mark_tints: Vec<Tint>,
+    /// The only part a query is matched against.
+    name: String,
+    /// The tags, the date it was last pushed to, and the description.
+    rest: String,
+    rest_tints: Vec<Tint>,
+}
 
-    row.push_str(if present { PRESENT_MARK } else { " " });
-    if present {
-        tints.push(Tint {
-            range: 0..row.chars().count(),
+fn clone_row(repo: &Repo, present: bool, widths: &Widths) -> CloneRow {
+    let mut mark = String::from(if present { PRESENT_MARK } else { " " });
+    let mark_tints = if present {
+        vec![Tint {
+            range: 0..mark.chars().count(),
             color: PRESENT_COLOR,
-        });
-    }
-    row.push(' ');
+        }]
+    } else {
+        Vec::new()
+    };
+    mark.push(' ');
 
-    push_column(&mut row, repo.name(), widths.name);
-    row.push_str("  ");
+    let mut name = String::new();
+    push_column(&mut name, repo.name(), widths.name);
 
+    let mut rest = String::from("  ");
+    let mut rest_tints = Vec::new();
     let visibility = repo.visibility();
-    let tags_at = row.chars().count();
+    let tags_at = rest.chars().count();
     for (index, tag) in repo.tags().iter().enumerate() {
         if index > 0 {
-            row.push(' ');
+            rest.push(' ');
         }
-        let at = row.chars().count();
-        row.push_str(tag);
+        let at = rest.chars().count();
+        rest.push_str(tag);
         if let Some(color) = visibility.color()
             && *tag == visibility.tag()
         {
-            tints.push(Tint {
-                range: at..row.chars().count(),
+            rest_tints.push(Tint {
+                range: at..rest.chars().count(),
                 color,
             });
         }
     }
-    for _ in (row.chars().count() - tags_at)..widths.tags {
-        row.push(' ');
+    for _ in (rest.chars().count() - tags_at)..widths.tags {
+        rest.push(' ');
     }
-    row.push_str("  ");
+    rest.push_str("  ");
 
-    push_column(&mut row, repo.pushed_date(), widths.pushed);
-    row.push_str("  ");
-    row.push_str(repo.description().trim());
+    push_column(&mut rest, repo.pushed_date(), widths.pushed);
+    rest.push_str("  ");
+    rest.push_str(repo.description().trim());
 
-    (row.trim_end().to_string(), tints)
+    CloneRow {
+        mark,
+        mark_tints,
+        name,
+        rest: rest.trim_end().to_string(),
+        rest_tints,
+    }
 }
 
-/// Build the repository rows, marking the ones already on disk. They stay
-/// listed rather than filtered out, since their absence would read as "this org
-/// does not have that repo".
+/// Which of an owner's repositories the clone selector is showing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CloneView {
+    /// Everything the owner has, cloned or not. What it opens on: a repository
+    /// missing from the list would read as "this org does not have that repo".
+    All,
+    /// Only the ones not already under the root — what there is left to clone.
+    Missing,
+}
+
+impl CloneView {
+    /// The view at `index` in [`CLONE_VIEWS`].
+    fn of(index: usize) -> Self {
+        match index {
+            1 => Self::Missing,
+            _ => Self::All,
+        }
+    }
+
+    /// Whether a repository belongs in this view. `present` is whether it is
+    /// already on disk.
+    fn shows(self, present: bool) -> bool {
+        match self {
+            Self::All => true,
+            Self::Missing => !present,
+        }
+    }
+}
+
+/// The keys the clone selector offers its views on, in the order the header
+/// lists them. `ctrl-a` displaces skim's own beginning-of-line, which in a
+/// one-line query is worth less than reaching the whole list again.
+const CLONE_VIEWS: &[select::Mode] = &[
+    select::Mode::new("ctrl-a", "all"),
+    select::Mode::new("ctrl-t", "missing"),
+];
+
+/// Build the repository rows for `view`, marking the ones already on disk.
 ///
-/// No preview pane: everything `gh repo list` returned that is worth seeing is
-/// now a column, and a pane that repeats the row is a pane nobody reads.
-fn repo_items(repos: &[Repo], root: &Path) -> Vec<SelectItem> {
-    let widths = Widths::of(repos);
-    repos
+/// Only the name is matched against: the tags, the date and the description sit
+/// in the row's suffix, so a query cannot find a repository by words nobody
+/// searches by — and cannot scroll the name off the row to show where it hit.
+///
+/// No preview pane: everything the listing returned that is worth seeing is
+/// already a column, and a pane that repeats the row is a pane nobody reads.
+fn repo_items(repos: &[Repo], root: &Path, view: CloneView) -> Vec<SelectItem> {
+    let shown: Vec<(&Repo, bool)> = repos
         .iter()
-        .map(|repo| {
-            let present = destination(root, repo.owner(), repo.name()).exists();
-            let (row, tints) = clone_row(repo, present, &widths);
-            SelectItem::new(row, repo.name_with_owner().to_string()).tints(tints)
+        .map(|repo| (repo, destination(root, repo.owner(), repo.name()).exists()))
+        .filter(|(_, present)| view.shows(*present))
+        .collect();
+
+    let widths = Widths::of(shown.iter().map(|(repo, _)| *repo));
+    shown
+        .iter()
+        .map(|(repo, present)| {
+            let row = clone_row(repo, *present, &widths);
+            SelectItem::new(row.name, repo.name_with_owner().to_string())
+                .prefix(row.mark, row.mark_tints)
+                .suffix(row.rest, row.rest_tints)
         })
         .collect()
 }
@@ -452,15 +531,17 @@ pub fn clone(ctx: &Ctx, target: Option<&str>, limit: usize, archived: bool) -> R
     check_slug(&owner)?;
 
     let repos = {
-        // The listing is several round trips to GitHub, so it says which one it
-        // is on rather than leaving the terminal blank for a second or two.
-        let spinner = term::spinner(&format!("listing {owner}"), ctx.color());
-        gh::list_repos(&owner, limit, archived, &|progress| {
-            spinner.say(format!(
-                "listing {owner} — page {} of {}",
-                progress.done, progress.total
-            ));
-        })?
+        // The pages are fetched together and arrive in whatever order they
+        // finish, so there is no honest count to report — only that the wait is
+        // this owner's listing.
+        let _spinner = term::spinner(
+            &format!(
+                "loading repositories for {}",
+                term::bold(&owner, ctx.color())
+            ),
+            ctx.color(),
+        );
+        gh::list_repos(&owner, limit, archived)?
     };
     ctx.log
         .info(&format!("{} repositories for {owner}", repos.len()));
@@ -473,11 +554,17 @@ pub fn clone(ctx: &Ctx, target: Option<&str>, limit: usize, archived: bool) -> R
         );
     }
 
-    let chosen = select::select_many(
-        repo_items(&repos, &root),
-        "Repositories to clone (tab to select several)",
-        &ctx.config.selector,
-    )?;
+    let chosen = {
+        let listed = repos.clone();
+        let here = root.clone();
+        select::select_many_viewing(
+            repo_items(&repos, &root, CloneView::All),
+            "Repositories to clone (tab to select several)",
+            &ctx.config.selector,
+            CLONE_VIEWS,
+            Box::new(move |view| repo_items(&listed, &here, CloneView::of(view))),
+        )?
+    };
     if chosen.is_empty() {
         return Ok(());
     }
@@ -651,17 +738,18 @@ mod tests {
         let root = tmp.path();
         std::fs::create_dir_all(root.join("acme/billing-api")).unwrap();
 
-        let items = repo_items(&repos(), root);
+        let items = repo_items(&repos(), root, CloneView::All);
         assert_eq!(items.len(), 2, "a present repo was dropped from the list");
+        let mark = |item: &SelectItem| item.prefix.clone().unwrap_or_default();
         assert!(
-            items[0].label.starts_with(PRESENT_MARK),
-            "{}",
-            items[0].label
+            mark(&items[0]).starts_with(PRESENT_MARK),
+            "{:?}",
+            mark(&items[0])
         );
         assert!(
-            !items[1].label.starts_with(PRESENT_MARK),
-            "{}",
-            items[1].label
+            !mark(&items[1]).starts_with(PRESENT_MARK),
+            "{:?}",
+            mark(&items[1])
         );
         // The value is still the slug, so selecting it is well-defined.
         assert_eq!(items[0].value(), "acme/billing-api");
@@ -672,62 +760,72 @@ mod tests {
         let tmp = tempfile::TempDir::new().unwrap();
         let root = tmp.path();
         std::fs::create_dir_all(root.join("acme/billing-api")).unwrap();
-        for item in repo_items(&repos(), root) {
+        for item in repo_items(&repos(), root, CloneView::All) {
             assert_eq!(item.color, None, "{} is drawn in one colour", item.label);
         }
     }
 
     #[test]
     fn the_mark_on_an_existing_clone_is_green_and_only_the_mark() {
-        let widths = Widths::of(&repos());
-        let (row, tints) = clone_row(&repos()[0], true, &widths);
-        assert_eq!(tint_of(&row, &tints, PRESENT_COLOR).as_deref(), Some("✓"));
+        let widths = Widths::of(repos().iter());
+        let row = clone_row(&repos()[0], true, &widths);
+        assert_eq!(
+            tint_of(&row.mark, &row.mark_tints, PRESENT_COLOR).as_deref(),
+            Some("✓")
+        );
         assert_eq!(PRESENT_COLOR, 2, "the mark is not green");
     }
 
     #[test]
     fn an_uncloned_repository_carries_no_mark() {
-        let widths = Widths::of(&repos());
-        let (row, tints) = clone_row(&repos()[0], false, &widths);
-        assert!(!row.starts_with(PRESENT_MARK), "{row}");
-        assert_eq!(tint_of(&row, &tints, PRESENT_COLOR), None);
+        let widths = Widths::of(repos().iter());
+        let row = clone_row(&repos()[0], false, &widths);
+        assert!(!row.mark.contains(PRESENT_MARK), "{:?}", row.mark);
+        assert!(row.mark_tints.is_empty());
     }
 
     #[test]
     fn only_the_visibility_word_takes_the_visibility_colour() {
-        let widths = Widths::of(&repos());
-        let (row, tints) = clone_row(&repos()[0], false, &widths);
+        let widths = Widths::of(repos().iter());
+        let row = clone_row(&repos()[0], false, &widths);
         let color = gh::Visibility::Private.color().unwrap();
-        assert_eq!(tint_of(&row, &tints, color).as_deref(), Some("private"));
+        assert_eq!(
+            tint_of(&row.rest, &row.rest_tints, color).as_deref(),
+            Some("private")
+        );
     }
 
     /// `archived` and `fork` share the tags column with the visibility word and
     /// say nothing about who can see the repository.
     #[test]
     fn the_other_tags_are_left_uncoloured() {
-        let widths = Widths::of(&repos());
-        let (row, tints) = clone_row(&repos()[1], false, &widths);
-        assert!(row.contains("archived fork"), "{row}");
-        assert!(tints.is_empty(), "a public repository is left bare: {row}");
+        let widths = Widths::of(repos().iter());
+        let row = clone_row(&repos()[1], false, &widths);
+        assert!(row.rest.contains("archived fork"), "{:?}", row.rest);
+        assert!(
+            row.rest_tints.is_empty(),
+            "a public repository is left bare: {:?}",
+            row.rest
+        );
     }
 
     #[test]
     fn the_row_carries_the_last_push_date_before_the_description() {
-        let widths = Widths::of(&repos());
-        let (row, _) = clone_row(&repos()[0], false, &widths);
-        let pushed = row.find("2026-07-27").expect(&row);
-        let description = row.find("Meters usage").expect(&row);
-        assert!(pushed < description, "{row}");
+        let widths = Widths::of(repos().iter());
+        let row = clone_row(&repos()[0], false, &widths);
+        let pushed = row.rest.find("2026-07-27").expect(&row.rest);
+        let description = row.rest.find("Meters usage").expect(&row.rest);
+        assert!(pushed < description, "{:?}", row.rest);
     }
 
     /// Every column is padded to the width of the whole list, so a row reads
     /// down the screen rather than only across.
     #[test]
     fn the_columns_line_up() {
-        let widths = Widths::of(&repos());
+        let widths = Widths::of(repos().iter());
         let rows: Vec<String> = repos()
             .iter()
-            .map(|repo| clone_row(repo, false, &widths).0)
+            .map(|repo| clone_row(repo, false, &widths).rest)
             .collect();
         let at = |row: &str, needle: &str| row.find(needle).map(|i| row[..i].chars().count());
         assert_eq!(
@@ -740,7 +838,7 @@ mod tests {
     #[test]
     fn nothing_previews_a_repository() {
         let tmp = tempfile::TempDir::new().unwrap();
-        for item in repo_items(&repos(), tmp.path()) {
+        for item in repo_items(&repos(), tmp.path(), CloneView::All) {
             assert!(item.preview.is_none(), "{} opens a pane", item.label);
         }
     }

--- a/src/gh.rs
+++ b/src/gh.rs
@@ -770,15 +770,6 @@ impl Source {
 /// page, empty on the rest — and the body.
 type Page = Result<(String, String)>;
 
-/// How far a listing has got, for a caller drawing progress.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct Progress {
-    /// Pages fetched so far, including this one.
-    pub done: usize,
-    /// Pages there are to fetch.
-    pub total: usize,
-}
-
 /// The last page of a listing, read from the `Link` header GitHub sends with
 /// the first — `<…page=4>; rel="last"`. One page when there is no such link,
 /// which is what a listing that fits in one says.
@@ -849,25 +840,18 @@ fn person_or_me(owner: &str) -> Source {
 
 /// Every repository belonging to `owner`, archived ones only when `archived`,
 /// and at most `limit` of them.
-///
-/// `on_page` is called as each page arrives, from whichever thread fetched it.
-pub fn list_repos(
-    owner: &str,
-    limit: usize,
-    archived: bool,
-    on_page: &(dyn Fn(Progress) + Sync),
-) -> Result<Vec<Repo>> {
+pub fn list_repos(owner: &str, limit: usize, archived: bool) -> Result<Vec<Repo>> {
     // Archived rows are dropped after the fact — GitHub's listing has no filter
     // for them — so the cap the limit imposes is on pages rather than on rows.
     let cap = limit.div_ceil(PAGE_SIZE).max(1);
     let speculative = cap.min(SPECULATIVE_PAGES);
 
     let org = Source::Org(owner.to_string());
-    let (source, mut bodies, last) = match first_pages(&org, speculative, on_page) {
+    let (source, mut bodies, last) = match first_pages(&org, speculative) {
         Ok((bodies, last)) => (org, bodies, last),
         Err(err) if is_not_found(&err) => {
             let source = person_or_me(owner);
-            let (bodies, last) = first_pages(&source, speculative, on_page)?;
+            let (bodies, last) = first_pages(&source, speculative)?;
             (source, bodies, last)
         }
         Err(err) => return Err(err),
@@ -875,7 +859,7 @@ pub fn list_repos(
 
     let wanted = last.min(cap);
     if wanted > speculative {
-        bodies.extend(fetch_pages(&source, speculative + 1..=wanted, on_page)?);
+        bodies.extend(fetch_pages(&source, speculative + 1..=wanted)?);
     }
 
     let mut repos = Vec::new();
@@ -896,12 +880,8 @@ pub fn list_repos(
 /// An error on the first page is the listing's error — there is no such owner,
 /// or no way to reach GitHub — and is returned rather than joined with the
 /// others, since it is the one the caller can act on.
-fn first_pages(
-    source: &Source,
-    pages: usize,
-    on_page: &(dyn Fn(Progress) + Sync),
-) -> Result<(Vec<String>, usize)> {
-    let mut fetched = fetch(source, 1..=pages, true, on_page);
+fn first_pages(source: &Source, pages: usize) -> Result<(Vec<String>, usize)> {
+    let mut fetched = fetch(source, 1..=pages, true);
     let first = fetched.remove(0)?;
     let last = last_page(&first.0);
 
@@ -913,12 +893,8 @@ fn first_pages(
 }
 
 /// Bodies of `pages`, in page order.
-fn fetch_pages(
-    source: &Source,
-    pages: std::ops::RangeInclusive<usize>,
-    on_page: &(dyn Fn(Progress) + Sync),
-) -> Result<Vec<String>> {
-    fetch(source, pages, false, on_page)
+fn fetch_pages(source: &Source, pages: std::ops::RangeInclusive<usize>) -> Result<Vec<String>> {
+    fetch(source, pages, false)
         .into_iter()
         .map(|page| page.map(|(_, body)| body))
         .collect()
@@ -927,12 +903,7 @@ fn fetch_pages(
 /// Fetch `pages` of `source`, [`PAGE_WORKERS`] at a time, and hand them back in
 /// page order. `headers` asks for the response headers as well, which only the
 /// first page's are read from.
-fn fetch(
-    source: &Source,
-    pages: std::ops::RangeInclusive<usize>,
-    headers: bool,
-    on_page: &(dyn Fn(Progress) + Sync),
-) -> Vec<Page> {
+fn fetch(source: &Source, pages: std::ops::RangeInclusive<usize>, headers: bool) -> Vec<Page> {
     let (first, last) = (*pages.start(), *pages.end());
     if first > last {
         return Vec::new();
@@ -940,7 +911,6 @@ fn fetch(
     let count = last - first + 1;
 
     let next = AtomicUsize::new(first);
-    let done = AtomicUsize::new(0);
     let fetched: Mutex<Vec<Option<Page>>> = Mutex::new((0..count).map(|_| None).collect());
 
     std::thread::scope(|scope| {
@@ -963,10 +933,6 @@ fn fetch(
                     if let Ok(mut fetched) = fetched.lock() {
                         fetched[page - first] = Some(result);
                     }
-                    on_page(Progress {
-                        done: done.fetch_add(1, Ordering::Relaxed) + 1,
-                        total: count,
-                    });
                 }
             });
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -341,6 +341,10 @@ enum RepoCmd {
     /// and the date it was last pushed to. Repositories you already have are
     /// marked with a green tick and skipped rather than re-cloned. Archived
     /// repositories are left out unless you ask for them.
+    ///
+    /// What you type is matched against the repository name alone, never the
+    /// columns beside it. `ctrl-t` narrows the list to what you have not cloned
+    /// yet and `ctrl-a` puts it back, as the selector's own header says.
     Clone {
         /// `owner` to select from, or `owner/repo` to clone directly
         #[arg(value_name = "OWNER[/REPO]")]

--- a/src/select.rs
+++ b/src/select.rs
@@ -177,10 +177,14 @@ pub struct Tint {
 /// theme), and `preview` fills the preview pane while the row is highlighted.
 pub struct SelectItem {
     pub label: String,
-    /// Drawn dim, ahead of the label, and *not* matched against — for a column
-    /// that identifies a row without being what one searches for, such as the
-    /// date on a history entry.
+    /// Drawn ahead of the label and *not* matched against — for a column that
+    /// identifies a row without being what one searches for, such as the date
+    /// on a history entry. Dim, unless [`SelectItem::prefix_tints`] says
+    /// otherwise.
     pub prefix: Option<String>,
+    /// Colours within the prefix, as character ranges into it. Indexed from
+    /// the start of the prefix, not of the row.
+    pub prefix_tints: Vec<Tint>,
     /// Drawn after the label and *not* matched against — [`SelectItem::prefix`]
     /// on the other side, for a column that belongs to the right-hand edge
     /// rather than the left. Dim, unless [`SelectItem::suffix_tints`] says
@@ -203,6 +207,7 @@ impl SelectItem {
         Self {
             label: text.into(),
             prefix: None,
+            prefix_tints: Vec::new(),
             suffix: None,
             suffix_tints: Vec::new(),
             value: None,
@@ -217,6 +222,7 @@ impl SelectItem {
         Self {
             label: label.into(),
             prefix: None,
+            prefix_tints: Vec::new(),
             suffix: None,
             suffix_tints: Vec::new(),
             value: Some(value.into()),
@@ -226,9 +232,11 @@ impl SelectItem {
         }
     }
 
-    /// Draw `prefix` dim, ahead of the label, outside what the query matches.
-    pub fn prefix(mut self, prefix: impl Into<String>) -> Self {
+    /// Draw `prefix` ahead of the label, outside what the query matches, with
+    /// `tints` colouring ranges of it.
+    pub fn prefix(mut self, prefix: impl Into<String>, tints: Vec<Tint>) -> Self {
         self.prefix = Some(prefix.into());
+        self.prefix_tints = tints;
         self
     }
 
@@ -346,7 +354,9 @@ impl SkimItem for SkItem {
         let dim = Style::default().fg(Color::Indexed(PREFIX_COLOR));
         let mut out = Line::default();
         if let Some(prefix) = &self.item.prefix {
-            out.push_span(Span::styled(prefix.clone(), dim));
+            let plain = Line::from(Span::styled(prefix.clone(), dim));
+            out.spans
+                .extend(tinted(plain, &self.item.prefix_tints, dim).spans);
         }
         out.spans.extend(line.spans);
         if let Some(suffix) = &self.item.suffix {
@@ -397,6 +407,7 @@ pub fn select_one_queried(
         reload: None,
         search: None,
         modes: &[],
+        views: &[],
         actions: &[],
     };
     run_selector(Feed::batch(items), run, cfg)?
@@ -445,12 +456,14 @@ pub struct Chosen {
     pub action: Option<&'static str>,
 }
 
-/// Fetches a fresh set of rows. Called on a background thread, so it may block
-/// for as long as the network takes.
+/// Fetches a fresh set of rows for the view at that index. Called on a
+/// background thread, so it may block for as long as the network takes.
+///
+/// A selector with no [`views`](Run::views) is always asked for view 0.
 ///
 /// Infallible by construction: a reload that fails should hand back the old
 /// rows and remember the error, which only the caller can do.
-pub type Reload = Box<dyn FnMut() -> Vec<SelectItem> + Send>;
+pub type Reload = Box<dyn FnMut(usize) -> Vec<SelectItem> + Send>;
 
 /// [`select_one`], with [`REFRESH_KEY`] bound to reloading the list in place.
 ///
@@ -471,6 +484,7 @@ pub fn select_one_reloading(
         reload: Some(reload),
         search: None,
         modes: &[],
+        views: &[],
         actions,
     };
     chosen(run_selector(Feed::batch(items), run, cfg)?)
@@ -490,6 +504,7 @@ pub fn select_one_acting(
         reload: None,
         search: None,
         modes: &[],
+        views: &[],
         actions,
     };
     chosen(run_selector(Feed::batch(items), run, cfg)?)
@@ -510,6 +525,9 @@ fn chosen(outcome: Outcome) -> Result<Chosen> {
 /// running a command, and it is calling a closure.
 struct ReloadCollector {
     reload: Arc<Mutex<Reload>>,
+    /// Which view the next reload produces. Held across reloads because only a
+    /// view *key* names one: [`REFRESH_KEY`] reloads whatever is on screen.
+    view: Arc<AtomicUsize>,
 }
 
 /// How often the counted thread looks up from waiting to see whether skim has
@@ -519,12 +537,16 @@ const RELOAD_POLL: Duration = Duration::from_millis(20);
 impl CommandCollector for ReloadCollector {
     fn invoke(
         &mut self,
-        _cmd: &str,
+        cmd: &str,
         components_to_stop: Arc<AtomicUsize>,
     ) -> (SkimItemReceiver, Sender<i32>) {
         let (tx_item, rx_item): (SkimItemSender, SkimItemReceiver) = unbounded();
         let (tx_interrupt, rx_interrupt) = unbounded::<i32>();
         let reload = Arc::clone(&self.reload);
+        if let (Some(view), _) = read_mode(cmd) {
+            self.view.store(view, Ordering::SeqCst);
+        }
+        let view = self.view.load(Ordering::SeqCst);
 
         // `ReaderControl::kill` *busy-waits* on this counter, so the counted
         // thread has to decrement promptly when asked. The reload itself
@@ -534,7 +556,7 @@ impl CommandCollector for ReloadCollector {
         std::thread::spawn(move || {
             let (tx_rows, rx_rows) = std::sync::mpsc::channel();
             std::thread::spawn(move || {
-                let rows = (reload.lock().expect("reload closure poisoned"))();
+                let rows = (reload.lock().expect("reload closure poisoned"))(view);
                 let _ = tx_rows.send(rows);
             });
 
@@ -770,6 +792,7 @@ pub fn select_many_searching(
         reload: None,
         search: Some(search),
         modes,
+        views: &[],
         actions: &[],
     };
     Ok(run_selector(Feed::none(true), run, cfg)?.values)
@@ -809,6 +832,27 @@ pub fn select_many(
     cfg: &SelectorConfig,
 ) -> Result<Vec<String>> {
     run(Feed::batch(items), prompt, true, cfg)
+}
+
+/// [`select_many`], with each of `views` on a key that swaps the whole list for
+/// the rows `rows` produces for it.
+///
+/// `items` is the first view, already built — the selector draws it without
+/// waiting for a reload. What each view is called, and the key that reaches it,
+/// is in the header for as long as the selector is open.
+pub fn select_many_viewing(
+    items: Vec<SelectItem>,
+    prompt: &str,
+    cfg: &SelectorConfig,
+    views: &'static [Mode],
+    rows: Reload,
+) -> Result<Vec<String>> {
+    let run = Run {
+        reload: Some(rows),
+        views,
+        ..Run::new(prompt, true)
+    };
+    Ok(run_selector(Feed::batch(items), run, cfg)?.values)
 }
 
 /// [`select_one`] over rows that arrive as they are found. No row exists when
@@ -946,6 +990,10 @@ struct Run<'a> {
     /// The ways `search` can read the query, each on a key of its own. The
     /// first is what the selector opens in.
     modes: &'static [Mode],
+    /// Whole lists on keys of their own, each swapping what the selector
+    /// shows. Fed by [`Run::reload`], which is asked for the view by index.
+    /// The first is what the selector opens in.
+    views: &'static [Mode],
     /// Keys that close the selector meaning something other than enter.
     actions: &'static [Action],
 }
@@ -959,6 +1007,7 @@ impl<'a> Run<'a> {
             reload: None,
             search: None,
             modes: &[],
+            views: &[],
             actions: &[],
         }
     }
@@ -1044,7 +1093,9 @@ fn run_selector(feed: Feed, run: Run, cfg: &SelectorConfig) -> Result<Outcome> {
         }
     }
 
-    let reloadable = run.reload.is_some();
+    // A selector whose reload exists to swap views has no refresh of its own:
+    // there is nothing behind the list to fetch again.
+    let reloadable = run.reload.is_some() && run.views.is_empty();
     let searching = run.search.is_some();
     let header = hints(actions, reloadable, multi, run.modes);
 
@@ -1068,22 +1119,28 @@ fn run_selector(feed: Feed, run: Run, cfg: &SelectorConfig) -> Result<Outcome> {
     if let Some(reload) = run.reload {
         let collector = ReloadCollector {
             reload: Arc::new(Mutex::new(reload)),
+            view: Arc::new(AtomicUsize::new(0)),
         };
+        // `no_clear_if_empty` keeps a refresh from flickering, but a view is
+        // asked for: one that holds nothing has to be seen to hold nothing.
         builder
-            .no_clear_if_empty(true)
+            .no_clear_if_empty(run.views.is_empty())
             .cmd_collector(Rc::new(RefCell::new(collector)) as Rc<RefCell<dyn CommandCollector>>);
     }
 
     // A searching selector opens in its first mode, and the header says so
     // from the outset rather than only after a key is pressed.
-    let opening = match run.modes.first() {
-        Some(_) => mode_header(run.modes, 0, &header),
-        None => header.clone(),
+    let opening = match (run.modes.first(), run.views.first()) {
+        (Some(_), _) => chosen_header(run.modes, 0, &header, " match"),
+        (_, Some(_)) => chosen_header(run.views, 0, &header, ""),
+        _ => header.clone(),
     };
     if !opening.is_empty() {
         builder.header(opening);
     }
-    let binds = binds(actions, reloadable, previewing, run.modes, &header);
+    let binds = binds(
+        actions, reloadable, previewing, run.modes, run.views, &header,
+    );
     if !binds.is_empty() {
         builder.bind(binds);
     }
@@ -1184,6 +1241,7 @@ fn binds(
     reloadable: bool,
     previewing: bool,
     modes: &[Mode],
+    views: &[Mode],
     header: &str,
 ) -> Vec<String> {
     let mut binds: Vec<String> = actions
@@ -1202,17 +1260,29 @@ fn binds(
         binds.push(format!(
             "{}:reload({MODE_MARKER}{index}{MODE_MARKER}{{q}})+set-header({})",
             mode.key,
-            mode_header(modes, index, header),
+            chosen_header(modes, index, header, " match"),
+        ));
+    }
+    // A view key reloads the list itself. The query is left out of the reload:
+    // it filters whatever comes back, and putting it in the template would
+    // hand the collector a search it does not run.
+    for (index, view) in views.iter().enumerate() {
+        binds.push(format!(
+            "{}:reload({MODE_MARKER}{index}{MODE_MARKER})+set-header({})",
+            view.key,
+            chosen_header(views, index, header, ""),
         ));
     }
     binds
 }
 
-/// The header while `chosen` is the mode in force: what the selector could
-/// already do, with the mode named at the front of it.
-fn mode_header(modes: &[Mode], chosen: usize, header: &str) -> String {
+/// The header while `chosen` is the one in force: what the selector could
+/// already do, with the mode or view named at the front of it and the keys to
+/// the others after it. `noun` is what the chosen one is called — a mode reads
+/// as "fuzzy match", a view as its own name.
+fn chosen_header(modes: &[Mode], chosen: usize, header: &str, noun: &str) -> String {
     let mut parts = vec![match modes.get(chosen) {
-        Some(mode) => format!("{} match", mode.label),
+        Some(mode) => format!("{}{noun}", mode.label),
         None => String::new(),
     }];
     for (index, mode) in modes.iter().enumerate() {
@@ -1394,17 +1464,44 @@ mod tests {
         #[test]
         fn a_mode_key_says_which_mode_it_put_the_selector_in() {
             let modes = [Mode::new("ctrl-f", "fuzzy"), Mode::new("ctrl-x", "exact")];
-            let header = mode_header(&modes, 0, "tab select");
+            let header = chosen_header(&modes, 0, "tab select", " match");
             assert!(header.starts_with("fuzzy match"), "{header}");
             assert!(header.contains("ctrl-x exact"), "{header}");
             assert!(!header.contains("ctrl-f"), "{header}");
             assert!(header.contains("tab select"), "{header}");
         }
 
+        /// A view is a whole list on a key, and the header is where the one in
+        /// force can be read — there is nothing else on screen that says it.
+        #[test]
+        fn a_view_key_reloads_the_list_and_names_the_view_it_chose() {
+            let views = [Mode::new("ctrl-a", "all"), Mode::new("ctrl-t", "missing")];
+            let binds = binds(&[], false, false, &[], &views, "tab select");
+
+            assert!(
+                binds
+                    .iter()
+                    .any(|b| b.starts_with("ctrl-t:reload(") && b.contains("missing")),
+                "{binds:?}"
+            );
+            // No `{q}`: the query filters what comes back rather than fetching
+            // it, so a view reload carries none.
+            assert!(
+                binds.iter().all(|b| !b.contains("{q}")),
+                "a view asked for a search: {binds:?}"
+            );
+
+            let header = chosen_header(&views, 1, "tab select", "");
+            assert!(header.starts_with("missing"), "{header}");
+            assert!(header.contains("ctrl-a all"), "{header}");
+            assert!(!header.contains("ctrl-t"), "{header}");
+            assert!(header.contains("tab select"), "{header}");
+        }
+
         #[test]
         fn every_mode_gets_a_key_that_searches_again_and_sets_the_header() {
             let modes = [Mode::new("ctrl-f", "fuzzy"), Mode::new("ctrl-x", "exact")];
-            let binds = binds(&[], false, false, &modes, "");
+            let binds = binds(&[], false, false, &modes, &[], "");
             assert!(
                 binds.iter().any(|b| b.starts_with("ctrl-f:reload(")),
                 "{binds:?}"
@@ -1532,7 +1629,7 @@ mod tests {
 
     #[test]
     fn a_prefix_is_drawn_dim_before_the_label() {
-        let item = SelectItem::plain("git status").prefix("2026-07-30 13:57  ");
+        let item = SelectItem::plain("git status").prefix("2026-07-30 13:57  ", Vec::new());
         let line = rendered(item, vec![]);
         assert_eq!(text_of(&line), "2026-07-30 13:57  git status");
         assert_eq!(line.spans[0].content, "2026-07-30 13:57  ");
@@ -1544,7 +1641,7 @@ mod tests {
         // Character 0 of the label: the `g` of `git`.
         let matched = Style::default().fg(Color::Indexed(1));
         let with = rendered(
-            SelectItem::plain("git status").prefix("2026-07-30 13:57  "),
+            SelectItem::plain("git status").prefix("2026-07-30 13:57  ", Vec::new()),
             vec![0],
         );
         let hit: String = with
@@ -1751,7 +1848,7 @@ mod tests {
     fn every_key_the_header_names_is_bound() {
         let actions = [Action::new("f2", "open"), Action::new("f7", "check out")];
         let header = hints(&actions, true, true, &[]);
-        let binds = binds(&actions, true, true, &[], &header);
+        let binds = binds(&actions, true, true, &[], &[], &header);
 
         for hint in header.split(HINT_SEPARATOR) {
             let key = hint.split(' ').next().expect("a hint with no key");
@@ -1771,7 +1868,7 @@ mod tests {
     #[test]
     fn an_action_key_closes_the_selector_and_the_preview_key_does_not() {
         let actions = [Action::new("f2", "open")];
-        let binds = binds(&actions, false, true, &[], "");
+        let binds = binds(&actions, false, true, &[], &[], "");
         assert!(binds.contains(&"f2:accept".to_string()), "{binds:?}");
         assert!(
             binds.contains(&format!("{PREVIEW_KEY}:toggle-preview")),
@@ -1781,7 +1878,7 @@ mod tests {
 
     #[test]
     fn a_plain_selector_binds_nothing_of_its_own() {
-        assert!(binds(&[], false, false, &[], "").is_empty());
+        assert!(binds(&[], false, false, &[], &[], "").is_empty());
     }
 
     #[test]
@@ -1800,10 +1897,11 @@ mod tests {
         let calls = Arc::new(AtomicUsize::new(0));
         let counter = Arc::clone(&calls);
         let mut collector = ReloadCollector {
-            reload: Arc::new(Mutex::new(Box::new(move || {
+            reload: Arc::new(Mutex::new(Box::new(move |_view| {
                 counter.fetch_add(1, Ordering::SeqCst);
                 vec![SelectItem::plain("fresh")]
             }))),
+            view: Arc::new(AtomicUsize::new(0)),
         };
 
         let components = Arc::new(AtomicUsize::new(0));
@@ -1822,15 +1920,43 @@ mod tests {
         }
     }
 
+    /// A view key names its view once; every reload after it — a refresh, or
+    /// skim re-running the template — has to stay in the view the user chose.
+    #[test]
+    fn a_view_marker_reaches_the_closure_and_the_next_reload_keeps_it() {
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let asked = Arc::clone(&seen);
+        let mut collector = ReloadCollector {
+            reload: Arc::new(Mutex::new(Box::new(move |view| {
+                asked.lock().expect("poisoned").push(view);
+                vec![SelectItem::plain("row")]
+            }))),
+            view: Arc::new(AtomicUsize::new(0)),
+        };
+
+        let components = Arc::new(AtomicUsize::new(0));
+        for command in ["", &format!("{MODE_MARKER}1{MODE_MARKER}"), ""] {
+            let (rx, _interrupt) = collector.invoke(command, Arc::clone(&components));
+            let _ = rx.recv();
+            while rx.recv().is_ok() {}
+        }
+        while components.load(Ordering::SeqCst) != 0 {
+            std::thread::yield_now();
+        }
+
+        assert_eq!(*seen.lock().expect("poisoned"), vec![0, 1, 1]);
+    }
+
     #[test]
     fn an_interrupted_reload_stops_without_waiting_for_the_work() {
         let (release, blocked) = std::sync::mpsc::channel::<()>();
         let mut collector = ReloadCollector {
-            reload: Arc::new(Mutex::new(Box::new(move || {
+            reload: Arc::new(Mutex::new(Box::new(move |_view| {
                 // Stands in for a fetch that has not come back yet.
                 let _ = blocked.recv();
                 vec![SelectItem::plain("late")]
             }))),
+            view: Arc::new(AtomicUsize::new(0)),
         };
 
         let components = Arc::new(AtomicUsize::new(0));


### PR DESCRIPTION
### The query reaches the name only

A query used to be matched against the whole row — the description, the tags,
the date, and in `repo sel` the owner label. So a word in a description matched
a row that had nothing to do with it, and the row was then scrolled sideways to
show where the match was, pushing the repository's own name off the screen.

The columns nobody searches by now sit in the row's prefix and suffix, which
skim draws and does not match. The name is always the leftmost thing matched,
so there is nothing for the row to scroll to.

### A view for what is not cloned yet

`ctrl-t` shows only the repositories missing from your root, `ctrl-a` the whole
list, and the header says which is in force. A view is a list on a key, fed by
the reload `ctrl-r` already used, so the two share one collector and one header.

### The wait says what it is

`loading repositories for <owner>`, rather than a page count. The pages are
fetched together and arrive in whatever order they finish, so the count went up
and down and read as a bug.

`docs/demo.gif` is unchanged: it records neither selector.
