### PR TITLE
Open a repository's GitHub page without asking the API for it first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ raised, never by hand.
 
 ## Unreleased
 
+### Fixed
+
+- Opening a repository on GitHub — `repo open`, or `f1` in the `repo sel`
+  selector — no longer waits on a call to the GitHub API before the browser
+  opens. The same page, roughly half a second sooner.
+
 ## v0.17.1
 
 *Released 2026-09-02*

--- a/src/gh.rs
+++ b/src/gh.rs
@@ -969,8 +969,12 @@ pub fn clone(name_with_owner: &str, dest: &Path) -> Result<()> {
 /// Open the GitHub page of the repository checked out at `dir`. Which
 /// repository that is comes from `dir`'s git remotes, not its path — a renamed
 /// clone or a fork makes the two disagree.
+///
+/// `gh browse` and not `gh repo view --web`, which reaches the same page: the
+/// latter fetches the repository's metadata over the API first and waits for
+/// it, so opening a browser tab costs a network round trip nothing here reads.
 pub fn view_repo_web(dir: &Path) -> Result<()> {
-    run_at(Some(dir), &["repo", "view", "--web"])
+    run_at(Some(dir), &["browse"])
 }
 
 /// Who the token belongs to. Asked of GitHub rather than of the config, since

--- a/src/main.rs
+++ b/src/main.rs
@@ -321,8 +321,7 @@ enum RepoCmd {
     ///
     /// Inside a repository, opens that one. Anywhere else, fuzzy-selects from
     /// every repository under your search paths. Either way it hands off to
-    /// `gh repo view --web`, which resolves the page from that checkout's git
-    /// remotes.
+    /// `gh browse`, which resolves the page from that checkout's git remotes.
     Open {
         /// Select a repository even when standing in one
         #[arg(short, long)]


### PR DESCRIPTION
`scriv repo open`, and `f1` in the `repo sel` selector, went through `gh repo view --web`. That command fetches the repository's metadata over GraphQL and waits for the response before it opens anything — a network round trip standing between a keypress and a browser tab, for data nothing here reads.

`gh browse` reaches the same URL from the checkout's git remotes without a request.

- `scriv repo open` in a checkout, ten runs with the browser stubbed: 599ms before, 159ms after.
- Same page either way — both hand the browser `https://github.com/joakimen/scriv`.
- `pr view --web` pays the same round trip; `gh browse <n>` would reach a pull request only through the `/issues/<n>` redirect, so it is left alone.
- Nothing changed on screen — no re-record.