### PR TITLE
Say how much of a run was scriv, and how much was what it waited on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,18 @@ raised, never by hand.
   now says so instead of looking like scriv being slow. `stats improve` hands
   that column on with the rest.
 
+### Changed
+
+- `stats improve` ranks the commands it hands over by the time scriv itself
+  spent, not by the wall clock. A build that waits on cargo and an editor
+  session used to head the list, where there was nothing for scriv to speed up.
+
+### Fixed
+
+- Time spent in the editor `scriv edit` opens is no longer counted as time the
+  command took, as time in a selector already was not. An afternoon in vim used
+  to make `edit` the most expensive command scriv had.
+
 ## v0.17.2
 
 *Released 2026-09-02*
@@ -33,9 +45,6 @@ raised, never by hand.
 
 ### Fixed
 
-- Time spent in the editor `scriv edit` opens is no longer counted as time the
-  command took, as time in a selector already was not. An afternoon in vim used
-  to make `edit` the most expensive command scriv had.
 - Opening a repository on GitHub — `repo open`, or `f1` in the `repo sel`
   selector — no longer waits on a call to the GitHub API before the browser
   opens. The same page, roughly half a second sooner.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,9 @@ raised, never by hand.
 
 - `stats show` has an `own` column beside the average: how much of a run was
   scriv's own work, with the subprocesses it waited on — `git`, `gh`, a build
-  tool, your editor — taken out. A command that is only slow because of what it
-  shells out to now says so instead of looking like scriv being slow.
-  `stats improve` hands that column on with the rest.
+  tool — taken out. A command that is only slow because of what it shells out to
+  now says so instead of looking like scriv being slow. `stats improve` hands
+  that column on with the rest.
 
 ## v0.17.2
 
@@ -33,6 +33,9 @@ raised, never by hand.
 
 ### Fixed
 
+- Time spent in the editor `scriv edit` opens is no longer counted as time the
+  command took, as time in a selector already was not. An afternoon in vim used
+  to make `edit` the most expensive command scriv had.
 - Opening a repository on GitHub — `repo open`, or `f1` in the `repo sel`
   selector — no longer waits on a call to the GitHub API before the browser
   opens. The same page, roughly half a second sooner.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ raised, never by hand.
 
 ## Unreleased
 
+### Added
+
+- `stats show` has an `own` column beside the average: how much of a run was
+  scriv's own work, with the subprocesses it waited on — `git`, `gh`, a build
+  tool, your editor — taken out. A command that is only slow because of what it
+  shells out to now says so instead of looking like scriv being slow.
+  `stats improve` hands that column on with the rest.
+
 ## v0.17.2
 
 *Released 2026-09-02*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -187,11 +187,16 @@ Rationale for code that does is a doc comment at the site — `ScratchRow`,
   take one letter — `r`, `f`, `b`, `w`, `e`, `h`, `c`, `s` — and two where the letter
   is spoken for: `pj`, as `p` meets `pr`. `pr` and `ps` are spelled in two to
   begin with and take no alias of their own.
-- **Anything that waits for a person binds [`stats::interacting`].** Every run
-  records what it cost, and a selector left open over lunch would otherwise be
-  recorded as a command that takes an hour. There are two such places — the
-  selector and the yes/no question — and a third would be a new one to bind it
-  in, not a reason to thread a clock through the call graph.
+- **Anything that waits for a person binds [`stats::interacting`], and
+  everything else scriv waits on binds [`stats::in_child`].** Every run records
+  what it cost, and a selector left open over lunch would otherwise be recorded
+  as a command that takes an hour. The first counter covers the selector, the
+  yes/no question, and the children that take the terminal and give it back
+  when the user is done — the editor, `stats improve`'s Claude Code session.
+  The second covers the work scriv delegates and is held up by: `git`, `gh`,
+  a build tool. A wait bound in neither is charged to scriv, and one bound in
+  both is charged twice. A new place to bind either is a new place to bind it,
+  not a reason to thread a clock through the call graph.
 - **The stats log is appended to, never rewritten.** One line per run, so two
   scriv processes finishing at once cannot lose each other's row and a run that
   is killed loses only itself. The totals are worked out when they are read.

--- a/README.md
+++ b/README.md
@@ -117,12 +117,12 @@ grouped by the role each dependency is given. `build` runs the repository's own
 in turn. The fish integration calls `scriv project deps` `i`.
 
 `scriv stats` counts scriv itself. Every run appends its command and how long it
-took to a log — with the time you spent in a selector taken out, so a list left
-open over lunch is not a slow command — and `stats show` reads it back as a tree
-of every command there is, including the ones you have never run. Beside the
-average sits `own`, the part of it that was scriv's own work rather than a
-subprocess it waited on, so a command that is slow because `git`, `gh` or your
-editor is slow says as much. Nothing but the command's name is recorded: no
+took to a log — with your own time taken out, whether you spent it in a selector
+or in the editor `scriv edit` opened, so neither left sitting is a slow command
+— and `stats show` reads it back as a tree of every command there is, including
+the ones you have never run. Beside the average sits `own`, the part of it that
+was scriv's own work rather than a subprocess it waited on, so a command that is
+slow because `git` or `gh` is slow says as much. Nothing but the command's name is recorded: no
 arguments, no paths, no what you picked.
 `stats improve` hands the busiest commands to Claude Code to work on, and
 `stats reset` forgets the lot.

--- a/README.md
+++ b/README.md
@@ -119,8 +119,11 @@ in turn. The fish integration calls `scriv project deps` `i`.
 `scriv stats` counts scriv itself. Every run appends its command and how long it
 took to a log — with the time you spent in a selector taken out, so a list left
 open over lunch is not a slow command — and `stats show` reads it back as a tree
-of every command there is, including the ones you have never run. Nothing but
-the command's name is recorded: no arguments, no paths, no what you picked.
+of every command there is, including the ones you have never run. Beside the
+average sits `own`, the part of it that was scriv's own work rather than a
+subprocess it waited on, so a command that is slow because `git`, `gh` or your
+editor is slow says as much. Nothing but the command's name is recorded: no
+arguments, no paths, no what you picked.
 `stats improve` hands the busiest commands to Claude Code to work on, and
 `stats reset` forgets the lot.
 

--- a/src/cmd/config.rs
+++ b/src/cmd/config.rs
@@ -15,7 +15,7 @@ use anyhow::{Context, Result, bail};
 
 use crate::config::{Bindings, Config, Labels};
 use crate::path::{display_path, expand_home_dir};
-use crate::{Ctx, binding, cmd, files, gh, history, repo, term};
+use crate::{Ctx, binding, cmd, files, gh, history, repo, stats, term};
 
 /// A commented starter config. Settings are grouped by the command that reads
 /// them; users edit it to taste.
@@ -785,6 +785,7 @@ pub(crate) fn on_path(program: &str) -> Option<PathBuf> {
 
 /// The first line of `program --version`, for reporting which one is installed.
 fn version_of(program: &str) -> Option<String> {
+    let _child = stats::in_child();
     let output = Command::new(program)
         .arg("--version")
         .stdin(Stdio::null())

--- a/src/cmd/edit.rs
+++ b/src/cmd/edit.rs
@@ -16,7 +16,7 @@ use anyhow::{Result, anyhow, bail};
 
 use crate::path::{display_path, expand_tilde};
 use crate::select::{Preview, SelectItem, file_preview};
-use crate::{Ctx, Reported, files, select, walk};
+use crate::{Ctx, Reported, files, select, stats, walk};
 
 /// `scriv edit file [FILE]...` — open `paths`, or select interactively when
 /// empty.
@@ -150,6 +150,7 @@ pub(crate) fn launch(ctx: &Ctx, editor: &[String], targets: &[String]) -> Result
     ctx.log
         .info(&format!("opening {} file(s) with {program}", targets.len()));
 
+    let _child = stats::in_child();
     let status = Command::new(program)
         .args(args)
         // `--` first: the walk yields relative paths, so a file named `-c`

--- a/src/cmd/edit.rs
+++ b/src/cmd/edit.rs
@@ -150,7 +150,9 @@ pub(crate) fn launch(ctx: &Ctx, editor: &[String], targets: &[String]) -> Result
     ctx.log
         .info(&format!("opening {} file(s) with {program}", targets.len()));
 
-    let _child = stats::in_child();
+    // The editor owns the terminal until the user leaves it, which is their
+    // time in the same way a selector left open is.
+    let _waiting = stats::interacting();
     let status = Command::new(program)
         .args(args)
         // `--` first: the walk yields relative paths, so a file named `-c`

--- a/src/cmd/note.rs
+++ b/src/cmd/note.rs
@@ -15,7 +15,7 @@ use anyhow::{Context, Result, bail};
 use crate::note::{self, Note, Widths};
 use crate::path::expand_home_dir;
 use crate::select::{Preview, SelectItem};
-use crate::{Ctx, cmd, select, term};
+use crate::{Ctx, cmd, select, stats, term};
 
 /// How much of a note is read to find its front matter.
 ///
@@ -771,6 +771,7 @@ fn open_matches(ctx: &Ctx, editor: &[String], matches: &[note::Match]) -> Result
         command.push("copen".into());
     }
 
+    let _child = stats::in_child();
     let status = std::process::Command::new(program)
         .args(&command)
         .status()

--- a/src/cmd/note.rs
+++ b/src/cmd/note.rs
@@ -771,7 +771,9 @@ fn open_matches(ctx: &Ctx, editor: &[String], matches: &[note::Match]) -> Result
         command.push("copen".into());
     }
 
-    let _child = stats::in_child();
+    // The editor owns the terminal until the user leaves it, as in
+    // [`crate::cmd::edit::launch`].
+    let _waiting = stats::interacting();
     let status = std::process::Command::new(program)
         .args(&command)
         .status()

--- a/src/cmd/project.rs
+++ b/src/cmd/project.rs
@@ -17,7 +17,7 @@ use anyhow::{Context, Result, anyhow, bail};
 use crate::project::detect::{MANIFESTS, MISE_CONFIGS};
 use crate::project::report::{Outcome, Status};
 use crate::project::{Scan, Step, Toolchain, build, deps as manifests, detect, install, report};
-use crate::{Ctx, Reported, term};
+use crate::{Ctx, Reported, stats, term};
 
 /// For what scriv says about a command rather than what the command said.
 const DIM: u8 = term::SECONDARY;
@@ -284,6 +284,7 @@ fn command(step: &Step, dir: &Path) -> Command {
 }
 
 fn capture(step: &Step, dir: &Path) -> io::Result<Finished> {
+    let _child = stats::in_child();
     let result = command(step, dir).stdin(Stdio::null()).output()?;
 
     Ok(Finished {
@@ -296,6 +297,7 @@ fn capture(step: &Step, dir: &Path) -> io::Result<Finished> {
 /// separate threads so a child that fills one pipe does not block writing to
 /// the other.
 fn stream(step: &Step, dir: &Path, prefix: &str) -> io::Result<Finished> {
+    let _child = stats::in_child();
     let mut child = command(step, dir)
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
@@ -368,6 +370,7 @@ fn details(outcomes: &[Outcome]) {
 
 /// Run a build step with the terminal handed to it, and pass its status on.
 fn inherit(step: &Step, dir: &Path) -> Result<()> {
+    let _child = stats::in_child();
     let status = command(step, dir)
         .status()
         .map_err(|error| match error.kind() {

--- a/src/cmd/ps.rs
+++ b/src/cmd/ps.rs
@@ -7,7 +7,7 @@ use anyhow::{Result, anyhow, bail};
 
 use crate::proc::{self, Process, Signal};
 use crate::select::{Preview, SelectItem};
-use crate::{Ctx, Reported, select, term};
+use crate::{Ctx, Reported, select, stats, term};
 
 /// The whole process table, as `ps` reported it. One call serves the listing,
 /// the selector rows and every preview pane.
@@ -15,6 +15,7 @@ use crate::{Ctx, Reported, select, term};
 /// Unfiltered, because the entries that must never be *offered* are the ones
 /// [`proc::refuse`] has to recognise when a pid is named on the command line.
 fn table() -> Result<Vec<Process>> {
+    let _child = stats::in_child();
     let output = Command::new("ps")
         .args(proc::PS_ARGS)
         .stdin(Stdio::null())
@@ -59,6 +60,7 @@ fn processes(port: Option<u16>) -> Result<Vec<Process>> {
 /// an answer rather than a failure — hence reading the status only far enough
 /// to tell that apart from `lsof` being absent.
 fn listeners(port: u16) -> Result<Vec<i32>> {
+    let _child = stats::in_child();
     let output = Command::new("lsof")
         .args(proc::lsof_args(port))
         .stdin(Stdio::null())
@@ -200,6 +202,7 @@ fn rows(procs: &[Process]) -> Vec<SelectItem> {
 
 /// Send `signal` to one pid, letting `kill` report its own failures.
 fn send(signal: Signal, pid: i32) -> Result<(), ()> {
+    let _child = stats::in_child();
     let status = Command::new("kill")
         .arg(format!("-{}", signal.name()))
         .arg(pid.to_string())

--- a/src/cmd/stats.rs
+++ b/src/cmd/stats.rs
@@ -170,7 +170,9 @@ pub fn improve(ctx: &Ctx, command: &clap::Command, dry_run: bool) -> Result<()> 
 
     ctx.log
         .info(&format!("handing {} rows to {CLAUDE}", rows.len()));
-    let _child = stats::in_child();
+    // Claude Code takes the terminal and the user works in it, so the session
+    // is their time rather than a subprocess scriv is held up by.
+    let _waiting = stats::interacting();
     let status = std::process::Command::new(CLAUDE)
         .arg(&prompt)
         .status()

--- a/src/cmd/stats.rs
+++ b/src/cmd/stats.rs
@@ -170,6 +170,7 @@ pub fn improve(ctx: &Ctx, command: &clap::Command, dry_run: bool) -> Result<()> 
 
     ctx.log
         .info(&format!("handing {} rows to {CLAUDE}", rows.len()));
+    let _child = stats::in_child();
     let status = std::process::Command::new(CLAUDE)
         .arg(&prompt)
         .status()

--- a/src/gh.rs
+++ b/src/gh.rs
@@ -17,6 +17,7 @@ use anyhow::{Context, Result, anyhow, bail};
 use serde::Deserialize;
 
 use crate::Reported;
+use crate::stats;
 use crate::term;
 
 /// JSON fields requested from `gh pr list`. `body`, `statusCheckRollup` and
@@ -949,6 +950,7 @@ fn fetch(source: &Source, pages: std::ops::RangeInclusive<usize>, headers: bool)
 /// Clone `owner/repo` into `dest`. Output is captured because clones run
 /// concurrently, and returned on failure so the caller can attribute it.
 pub fn clone(name_with_owner: &str, dest: &Path) -> Result<()> {
+    let _child = stats::in_child();
     let output = Command::new("gh")
         .args(["repo", "clone", name_with_owner, &dest.to_string_lossy()])
         .stdin(Stdio::null())
@@ -1011,6 +1013,7 @@ pub fn owners() -> Result<Vec<String>> {
 /// A network round trip, and therefore for `config check` alone — nothing on a
 /// keystroke path may ask this.
 pub fn authenticated() -> bool {
+    let _child = stats::in_child();
     Command::new("gh")
         .args(["auth", "status", "--active"])
         .stdin(Stdio::null())
@@ -1029,6 +1032,7 @@ fn run(args: &[&str]) -> Result<()> {
 /// [`run`], optionally somewhere else. Most `gh` subcommands resolve which
 /// repository they are about from the directory they run in.
 fn run_at(dir: Option<&Path>, args: &[&str]) -> Result<()> {
+    let _child = stats::in_child();
     let mut cmd = Command::new("gh");
     cmd.args(args);
     if let Some(dir) = dir {
@@ -1042,6 +1046,7 @@ fn run_at(dir: Option<&Path>, args: &[&str]) -> Result<()> {
 }
 
 fn capture(args: &[&str]) -> Result<String> {
+    let _child = stats::in_child();
     let output = Command::new("gh")
         .args(args)
         .stdin(Stdio::null())

--- a/src/git.rs
+++ b/src/git.rs
@@ -17,6 +17,7 @@ use std::process::{Command, Stdio};
 use anyhow::{Context, Result, anyhow, bail};
 
 use crate::Reported;
+use crate::stats;
 
 /// Field separator in the `for-each-ref` format. ASCII unit separator, so
 /// commit subjects containing tabs or pipes cannot split a row.
@@ -555,6 +556,7 @@ fn spawn_error(err: std::io::Error) -> anyhow::Error {
 
 /// Run git with `args`, capturing stdout.
 fn capture(args: &[&str]) -> Result<String> {
+    let _child = stats::in_child();
     let output = Command::new("git")
         .args(args)
         .stdin(Stdio::null())
@@ -577,6 +579,7 @@ fn capture(args: &[&str]) -> Result<String> {
 /// Run git with `args`, letting it write straight to the terminal. A failure is
 /// [`Reported`], since git has already said why.
 fn passthrough(args: &[&str]) -> Result<()> {
+    let _child = stats::in_child();
     let status = Command::new("git")
         .args(args)
         .status()
@@ -600,6 +603,7 @@ fn passthrough_onto_stderr(args: &[&str]) -> Result<()> {
         .as_fd()
         .try_clone_to_owned()
         .context("duplicating stderr")?;
+    let _child = stats::in_child();
     let status = Command::new("git")
         .args(args)
         .stdout(Stdio::from(stderr))
@@ -614,6 +618,7 @@ fn passthrough_onto_stderr(args: &[&str]) -> Result<()> {
 /// Fail early, and with a better message than git's, when the working
 /// directory is not inside a repository.
 pub fn ensure_repo() -> Result<()> {
+    let _child = stats::in_child();
     let inside = Command::new("git")
         .args(["rev-parse", "--is-inside-work-tree"])
         .stdin(Stdio::null())
@@ -639,6 +644,7 @@ pub fn repo_root() -> Option<PathBuf> {
 /// One `rev-parse` answers both questions, so a command that needs the root
 /// does not also spawn git to be told it is in a repository at all.
 pub fn require_repo_root() -> Result<PathBuf> {
+    let _child = stats::in_child();
     let output = Command::new("git")
         .args(["rev-parse", "--show-toplevel"])
         .stdin(Stdio::null())
@@ -658,6 +664,7 @@ pub fn require_repo_root() -> Result<PathBuf> {
 /// `HEAD`: there is no branch, and so nothing a pull request could be opened
 /// from. Absence is an answer rather than an error, as in [`repo_root`].
 pub fn current_branch() -> Option<String> {
+    let _child = stats::in_child();
     let output = Command::new("git")
         .args(["rev-parse", "--abbrev-ref", "HEAD"])
         .stdin(Stdio::null())
@@ -745,6 +752,7 @@ pub fn add_worktree(path: &Path, source: &TreeSource) -> Result<()> {
 
 /// Whether git already ignores `path`, by any of the rules it consults.
 fn is_ignored(path: &Path) -> bool {
+    let _child = stats::in_child();
     Command::new("git")
         .args(["check-ignore", "--quiet", "--"])
         .arg(path)

--- a/src/main.rs
+++ b/src/main.rs
@@ -953,6 +953,10 @@ fn run(cli: Cli, command: &str) -> anyhow::Result<()> {
             .as_millis()
             .try_into()
             .unwrap_or(u64::MAX),
+        child_millis: stats::child_time()
+            .as_millis()
+            .try_into()
+            .unwrap_or(u64::MAX),
         command: command.to_string(),
     });
     result

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -28,12 +28,16 @@ pub fn path(data_home: Option<&str>, home: &Path) -> PathBuf {
 }
 
 /// One run: when it finished, how long it took with the time spent waiting for
-/// the person at the keyboard taken out, and which command it was.
+/// the person at the keyboard taken out, how much of that went on subprocesses,
+/// and which command it was.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Record {
     /// Unix seconds.
     pub at: i64,
     pub millis: u64,
+    /// How much of `millis` was spent waiting for a subprocess to finish —
+    /// `git`, `gh`, a build tool, an editor.
+    pub child_millis: u64,
     /// The command as it is spelled, subcommands included: `repo sel`.
     pub command: String,
 }
@@ -41,7 +45,10 @@ pub struct Record {
 /// A record as its line of the log. Tab-separated with the command last, so a
 /// name that ever grows a space in it still needs no quoting.
 pub fn format(record: &Record) -> String {
-    format!("{}\t{}\t{}\n", record.at, record.millis, record.command)
+    format!(
+        "{}\t{}\t{}\t{}\n",
+        record.at, record.millis, record.child_millis, record.command
+    )
 }
 
 /// Every record in `text`.
@@ -49,23 +56,32 @@ pub fn format(record: &Record) -> String {
 /// A line that does not parse is skipped rather than failing the read: the log
 /// is appended to by every run there has ever been, and one truncated row from
 /// a machine that lost power is not a reason to refuse the rest.
+///
+/// Rows written before the subprocess column existed carry three fields and are
+/// read as having spent none. The third field tells the two apart: a number
+/// there is the column, anything else is the command.
 pub fn parse(text: &str) -> Vec<Record> {
-    text.lines()
-        .filter_map(|line| {
-            let mut fields = line.splitn(3, '\t');
-            let at = fields.next()?.trim().parse().ok()?;
-            let millis = fields.next()?.trim().parse().ok()?;
-            let command = fields.next()?.trim();
-            if command.is_empty() {
-                return None;
-            }
-            Some(Record {
-                at,
-                millis,
-                command: command.to_string(),
-            })
-        })
-        .collect()
+    text.lines().filter_map(parse_line).collect()
+}
+
+fn parse_line(line: &str) -> Option<Record> {
+    let mut fields = line.splitn(4, '\t');
+    let at = fields.next()?.trim().parse().ok()?;
+    let millis = fields.next()?.trim().parse().ok()?;
+    let third = fields.next()?.trim();
+    let (child_millis, command) = match (third.parse(), fields.next()) {
+        (Ok(child), Some(command)) => (child, command.trim()),
+        _ => (0, third),
+    };
+    if command.is_empty() {
+        return None;
+    }
+    Some(Record {
+        at,
+        millis,
+        child_millis,
+        command: command.to_string(),
+    })
 }
 
 /// What one command adds up to over every run of it.
@@ -75,6 +91,8 @@ pub struct Totals {
     /// Wall time over every run, which is what makes a command worth
     /// improving: a fast one run all day costs more than a slow one run twice.
     pub millis: u64,
+    /// How much of [`Self::millis`] went on waiting for subprocesses.
+    pub child_millis: u64,
 }
 
 impl Totals {
@@ -83,9 +101,22 @@ impl Totals {
         (self.calls > 0).then(|| Duration::from_millis(self.millis / self.calls))
     }
 
+    /// What one run costs in scriv's own code, with the subprocesses it waited
+    /// on taken out.
+    ///
+    /// A lower bound rather than an exact figure: two children waited on at
+    /// once are each counted in full, so a command that fans out reads as doing
+    /// less of its own work than it does.
+    pub fn own_average(&self) -> Option<Duration> {
+        (self.calls > 0).then(|| {
+            Duration::from_millis(self.millis.saturating_sub(self.child_millis) / self.calls)
+        })
+    }
+
     fn add(&mut self, other: Totals) {
         self.calls += other.calls;
         self.millis += other.millis;
+        self.child_millis += other.child_millis;
     }
 }
 
@@ -96,6 +127,7 @@ pub fn totals(records: &[Record]) -> BTreeMap<String, Totals> {
         out.entry(record.command.clone()).or_default().add(Totals {
             calls: 1,
             millis: record.millis,
+            child_millis: record.child_millis,
         });
     }
     out
@@ -202,18 +234,22 @@ fn walk(
 }
 
 /// The columns, as `stats show` prints them: the tree, how often each command
-/// has been run, and what one run of it costs.
+/// has been run, what one run of it costs, and how much of that is scriv's own
+/// work rather than a subprocess it waited on.
 pub fn render(rows: &[TreeRow], color: bool) -> Vec<String> {
+    let duration = |value: Option<Duration>| {
+        value
+            .map(format_duration)
+            .unwrap_or_else(|| "-".to_string())
+    };
     let cell = |row: &TreeRow| {
         (
             match row.totals.calls {
                 0 => "-".to_string(),
                 calls => calls.to_string(),
             },
-            row.totals
-                .average()
-                .map(format_duration)
-                .unwrap_or_else(|| "-".to_string()),
+            duration(row.totals.average()),
+            duration(row.totals.own_average()),
         )
     };
 
@@ -229,18 +265,25 @@ pub fn render(rows: &[TreeRow], color: bool) -> Vec<String> {
         .max()
         .unwrap_or(0)
         .max(HEADINGS.1.len());
+    let average_width = rows
+        .iter()
+        .map(|row| cell(row).1.chars().count())
+        .max()
+        .unwrap_or(0)
+        .max(HEADINGS.2.len());
 
     let mut out = vec![format!(
-        "{}  {}  {}",
+        "{}  {}  {}  {}",
         term::bold(&pad(HEADINGS.0, name_width), color),
         term::bold(&right(HEADINGS.1, calls_width), color),
-        term::bold(HEADINGS.2, color),
+        term::bold(&right(HEADINGS.2, average_width), color),
+        term::bold(HEADINGS.3, color),
     )];
     out.extend(rows.iter().map(|row| {
-        let (calls, average) = cell(row);
+        let (calls, average, own) = cell(row);
         let drawn = row.branch.chars().count() + row.name.chars().count();
         format!(
-            "{}{}{}  {}  {}",
+            "{}{}{}  {}  {}  {}",
             term::paint(&row.branch, term::SECONDARY, color),
             // A command nobody has run is secondary text: the point of the
             // report is the ones that are.
@@ -250,7 +293,8 @@ pub fn render(rows: &[TreeRow], color: bool) -> Vec<String> {
             },
             " ".repeat(name_width.saturating_sub(drawn)),
             term::paint(&right(&calls, calls_width), term::SECONDARY, color),
-            term::paint(&average, term::SECONDARY, color),
+            term::paint(&right(&average, average_width), term::SECONDARY, color),
+            term::paint(&own, term::SECONDARY, color),
         )
         .trim_end()
         .to_string()
@@ -258,8 +302,9 @@ pub fn render(rows: &[TreeRow], color: bool) -> Vec<String> {
     out
 }
 
-/// What the three columns are called.
-const HEADINGS: (&str, &str, &str) = ("command", "runs", "average");
+/// What the four columns are called. `own` is the average with the time spent
+/// waiting on subprocesses taken out.
+const HEADINGS: (&str, &str, &str, &str) = ("command", "runs", "average", "own");
 
 fn pad(text: &str, width: usize) -> String {
     format!(
@@ -305,26 +350,37 @@ pub fn improve_prompt(rows: &[TreeRow]) -> String {
     let mut prompt = String::from(
         "These are scriv's own usage statistics, gathered by `scriv stats`. \
          Each row is a command, how many times it has been run, what one run \
-         costs on average, and what it has cost in total.\n\n\
-         | command | runs | average | total |\n| --- | --- | --- | --- |\n",
+         costs on average, how much of that average is scriv's own work, and \
+         what the command has cost in total.\n\n\
+         | command | runs | average | own | total |\n\
+         | --- | --- | --- | --- | --- |\n",
     );
     for row in by_value(rows).into_iter().take(IMPROVE_ROWS) {
+        let duration =
+            |value: Option<Duration>| value.map(format_duration).unwrap_or_else(|| "-".into());
         prompt.push_str(&format!(
-            "| `scriv {}` | {} | {} | {} |\n",
+            "| `scriv {}` | {} | {} | {} | {} |\n",
             row.command,
             row.totals.calls,
-            row.totals
-                .average()
-                .map(format_duration)
-                .unwrap_or_else(|| "-".into()),
+            duration(row.totals.average()),
+            duration(row.totals.own_average()),
             format_duration(Duration::from_millis(row.totals.millis)),
         ));
     }
     prompt.push_str(
         "\nThe rows are ordered by total time spent, which is where making \
          scriv faster is worth the most. Time spent waiting for the user in a \
-         selector is already excluded from these numbers, so what is left is \
-         scriv's own work and what it waits on.\n\n\
+         selector is already excluded from these numbers. `own` takes out the \
+         subprocesses a run waited on as well — `git`, `gh`, a build tool, an \
+         editor — so it is what is left for scriv's own code to answer for.\n\n\
+         A row whose `own` is far below its average spends its time in \
+         something scriv shells out to. That is not a reason to pass it over: \
+         which subprocess gets called, and with which arguments, is scriv's \
+         choice, and a cheaper one that reaches the same answer is often \
+         there. Beware the average as well — a handful of slow runs among many \
+         fast ones raises it without there being anything slow about the \
+         command, so look at the log itself before concluding where the time \
+         went.\n\n\
          Take the highest-value row you can actually improve, work out where \
          its time goes, and implement the improvement. Measure before and \
          after and say what the numbers were. Follow CLAUDE.md in this \
@@ -377,6 +433,37 @@ pub fn waited() -> Duration {
     Duration::from_nanos(WAITED.load(Ordering::Relaxed))
 }
 
+/// Nanoseconds this process has spent waiting for subprocesses to finish.
+static IN_CHILD: AtomicU64 = AtomicU64::new(0);
+
+/// Time spent waiting for a spawned process, counted from when this is bound
+/// until it is dropped. Bind it — `let _child = stats::in_child()`.
+///
+/// Bound around the wait, not around the spawn, so a child that scriv starts
+/// and reads from while it runs is counted for as long as scriv is held up by
+/// it. A counter rather than a value threaded through the call graph, for the
+/// reason [`Interaction`] is one, and independent of it: a child spawned while
+/// a selector is open is counted by both.
+#[must_use]
+pub struct Child(Instant);
+
+/// Start counting time that belongs to a subprocess rather than to scriv.
+pub fn in_child() -> Child {
+    Child(Instant::now())
+}
+
+impl Drop for Child {
+    fn drop(&mut self) {
+        let spent = u64::try_from(self.0.elapsed().as_nanos()).unwrap_or(u64::MAX);
+        IN_CHILD.fetch_add(spent, Ordering::Relaxed);
+    }
+}
+
+/// How long this process has spent waiting for the ones it spawned.
+pub fn child_time() -> Duration {
+    Duration::from_nanos(IN_CHILD.load(Ordering::Relaxed))
+}
+
 /// What the run itself took: the wall clock less the time the user spent
 /// deciding. A selector left open over lunch is not a slow command.
 pub fn ran_for(total: Duration, waited: Duration) -> Duration {
@@ -387,19 +474,50 @@ pub fn ran_for(total: Duration, waited: Duration) -> Duration {
 mod tests {
     use super::*;
 
+    /// A run that spent `child_millis` of its `millis` waiting on a subprocess.
+    fn child_record(command: &str, millis: u64, child_millis: u64) -> Record {
+        Record {
+            child_millis,
+            ..record(command, millis)
+        }
+    }
+
     fn record(command: &str, millis: u64) -> Record {
         Record {
             at: 1_700_000_000,
             millis,
+            child_millis: 0,
             command: command.to_string(),
         }
     }
 
     #[test]
     fn a_record_survives_the_round_trip_through_a_line() {
-        let written = format(&record("repo sel", 842));
-        assert_eq!(written, "1700000000\t842\trepo sel\n");
-        assert_eq!(parse(&written), vec![record("repo sel", 842)]);
+        let mut written_record = record("repo sel", 842);
+        written_record.child_millis = 800;
+        let written = format(&written_record);
+        assert_eq!(written, "1700000000\t842\t800\trepo sel\n");
+        assert_eq!(parse(&written), vec![written_record]);
+    }
+
+    /// The log outlives the format: every run ever recorded is in it, and the
+    /// rows written before subprocesses were counted still have to read back.
+    #[test]
+    fn a_row_from_before_the_subprocess_column_reads_as_having_spent_none() {
+        assert_eq!(
+            parse("1700000000\t842\trepo sel\n"),
+            vec![record("repo sel", 842)]
+        );
+    }
+
+    /// A command name is the one field that could be mistaken for the column
+    /// ahead of it, and a command named for a number is still a command.
+    #[test]
+    fn a_command_that_looks_like_a_number_is_still_read_as_the_command() {
+        let records = parse("1700000000\t842\t404\n");
+        assert_eq!(records.len(), 1, "{records:?}");
+        assert_eq!(records[0].command, "404");
+        assert_eq!(records[0].child_millis, 0);
     }
 
     /// The log is every run there has ever been, and a machine that lost power
@@ -435,7 +553,8 @@ mod tests {
             totals["repo sel"],
             Totals {
                 calls: 2,
-                millis: 400
+                millis: 400,
+                child_millis: 0
             }
         );
         assert_eq!(
@@ -552,7 +671,8 @@ mod tests {
             of("repo"),
             Totals {
                 calls: 3,
-                millis: 900
+                millis: 900,
+                child_millis: 0
             },
             "a group is its children"
         );
@@ -560,10 +680,32 @@ mod tests {
             of(""),
             Totals {
                 calls: 4,
-                millis: 940
+                millis: 940,
+                child_millis: 0
             },
             "the root is everything"
         );
+    }
+
+    /// The whole point of the column: a command that is slow because of what
+    /// it shells out to has to be told apart from one that is slow itself.
+    #[test]
+    fn what_a_run_spent_in_a_subprocess_comes_off_its_own_time() {
+        let totals = totals(&[
+            child_record("repo open", 600, 540),
+            child_record("repo open", 400, 360),
+        ]);
+        let repo_open = totals["repo open"];
+        assert_eq!(repo_open.average(), Some(Duration::from_millis(500)));
+        assert_eq!(repo_open.own_average(), Some(Duration::from_millis(50)));
+    }
+
+    /// Two children waited on at once are each counted in full, so the tally
+    /// can exceed the run. The floor is zero rather than an underflow.
+    #[test]
+    fn a_run_that_waited_on_more_than_it_lasted_owns_none_of_it() {
+        let totals = totals(&[child_record("pr ls", 100, 180)]);
+        assert_eq!(totals["pr ls"].own_average(), Some(Duration::ZERO));
     }
 
     #[test]
@@ -608,18 +750,24 @@ mod tests {
             record("repo sel", 200),
             record("repo sel", 200),
             record("repo sel", 200),
-            record("edit", 10),
+            // Slow, and none of it scriv's: the editor held the terminal.
+            child_record("edit", 3_000, 2_990),
         ]);
         let rows = rows(&tree(&cli()), &totals);
 
         let ranked: Vec<&str> = by_value(&rows).iter().map(|r| r.command.as_str()).collect();
-        assert_eq!(ranked, ["repo sel", "repo ls", "edit"]);
+        assert_eq!(ranked, ["edit", "repo sel", "repo ls"]);
         // Groups are not rows to improve: `repo` is not a command anyone runs.
         assert!(!ranked.contains(&"repo"), "{ranked:?}");
 
         let prompt = improve_prompt(&rows);
         assert!(
-            prompt.contains("`scriv repo sel` | 5 | 200ms | 1.0s"),
+            prompt.contains("`scriv repo sel` | 5 | 200ms | 200ms | 1.0s"),
+            "{prompt}"
+        );
+        // The row that only looks expensive says so in the column beside it.
+        assert!(
+            prompt.contains("`scriv edit` | 1 | 3.0s | 10ms |"),
             "{prompt}"
         );
         assert!(prompt.contains("CLAUDE.md"), "{prompt}");

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -101,6 +101,14 @@ impl Totals {
         (self.calls > 0).then(|| Duration::from_millis(self.millis / self.calls))
     }
 
+    /// Time in scriv's own code over every run, with the subprocesses it waited
+    /// on taken out. What [`crate::stats::by_value`] ranks on.
+    ///
+    /// Carries the same lower-bound caveat as [`Self::own_average`].
+    pub fn own_millis(&self) -> u64 {
+        self.millis.saturating_sub(self.child_millis)
+    }
+
     /// What one run costs in scriv's own code, with the subprocesses it waited
     /// on taken out.
     ///
@@ -108,9 +116,7 @@ impl Totals {
     /// once are each counted in full, so a command that fans out reads as doing
     /// less of its own work than it does.
     pub fn own_average(&self) -> Option<Duration> {
-        (self.calls > 0).then(|| {
-            Duration::from_millis(self.millis.saturating_sub(self.child_millis) / self.calls)
-        })
+        (self.calls > 0).then(|| Duration::from_millis(self.own_millis() / self.calls))
     }
 
     fn add(&mut self, other: Totals) {
@@ -326,9 +332,14 @@ fn right(text: &str, width: usize) -> String {
 /// that the ones at the top are the ones being asked about.
 const IMPROVE_ROWS: usize = 10;
 
-/// The commands worth improving, in the order they are worth it: total time
-/// spent, which is the one number that has both how often a command is run and
-/// what each run costs in it.
+/// The commands worth improving, in the order they are worth it: time spent in
+/// scriv's own code, which has both how often a command is run and what each
+/// run costs in it, and none of what a subprocess or the user spent.
+///
+/// Wall time put the build tool and the editor at the top, where there is
+/// nothing for scriv to do about either. What a subprocess costs is still
+/// worth reading — which one gets called is scriv's choice — so the total
+/// stays a column rather than the sort key.
 pub fn by_value(rows: &[TreeRow]) -> Vec<&TreeRow> {
     let mut leaves: Vec<&TreeRow> = rows
         .iter()
@@ -336,8 +347,9 @@ pub fn by_value(rows: &[TreeRow]) -> Vec<&TreeRow> {
         .collect();
     leaves.sort_by(|a, b| {
         b.totals
-            .millis
-            .cmp(&a.totals.millis)
+            .own_millis()
+            .cmp(&a.totals.own_millis())
+            .then_with(|| b.totals.millis.cmp(&a.totals.millis))
             .then_with(|| b.totals.calls.cmp(&a.totals.calls))
             .then_with(|| a.command.cmp(&b.command))
     });
@@ -368,19 +380,22 @@ pub fn improve_prompt(rows: &[TreeRow]) -> String {
         ));
     }
     prompt.push_str(
-        "\nThe rows are ordered by total time spent, which is where making \
-         scriv faster is worth the most. Time spent waiting for the user in a \
-         selector is already excluded from these numbers. `own` takes out the \
-         subprocesses a run waited on as well — `git`, `gh`, a build tool, an \
-         editor — so it is what is left for scriv's own code to answer for.\n\n\
-         A row whose `own` is far below its average spends its time in \
-         something scriv shells out to. That is not a reason to pass it over: \
-         which subprocess gets called, and with which arguments, is scriv's \
-         choice, and a cheaper one that reaches the same answer is often \
-         there. Beware the average as well — a handful of slow runs among many \
-         fast ones raises it without there being anything slow about the \
-         command, so look at the log itself before concluding where the time \
-         went.\n\n\
+        "\nTime you spent deciding — in a selector, at a yes/no question, in \
+         the editor a command opened — is already out of every number here. \
+         `own` takes out the subprocesses a run waited on as well, so it is \
+         what is left for scriv's own code to answer for, and `total` is what \
+         the command cost including them.\n\n\
+         The rows are ordered by `own` × runs, which is where making scriv \
+         faster is worth the most: ordering by total put a build tool and an \
+         editor at the top, and neither is scriv's to speed up.\n\n\
+         Read the `total` column anyway. A row whose `own` is a sliver of it \
+         spends its time in something scriv shells out to, and which \
+         subprocess gets called, with which arguments, is still scriv's \
+         choice — a cheaper one that reaches the same answer is often there, \
+         and the ordering will have buried that row. Beware the average as \
+         well: a handful of slow runs among many fast ones raises it without \
+         there being anything slow about the command, so read the log itself \
+         before concluding where the time went.\n\n\
          Take the highest-value row you can actually improve, work out where \
          its time goes, and implement the improvement. Measure before and \
          after and say what the numbers were. Follow CLAUDE.md in this \
@@ -698,6 +713,26 @@ mod tests {
 
     /// The whole point of the column: a command that is slow because of what
     /// it shells out to has to be told apart from one that is slow itself.
+    /// The row that is expensive only because of what it shells out to still
+    /// has to be findable: it sinks in the ranking, so the total is what says
+    /// there is something there.
+    #[test]
+    fn a_row_that_is_all_subprocess_keeps_its_total_while_losing_its_place() {
+        let totals = totals(&[
+            child_record("repo ls", 9_000, 8_980),
+            record("repo sel", 40),
+        ]);
+        let rows = rows(&tree(&cli()), &totals);
+        let ranked: Vec<&str> = by_value(&rows).iter().map(|r| r.command.as_str()).collect();
+        assert_eq!(ranked, ["repo sel", "repo ls"]);
+
+        let prompt = improve_prompt(&rows);
+        assert!(
+            prompt.contains("`scriv repo ls` | 1 | 9.0s | 20ms | 9.0s"),
+            "{prompt}"
+        );
+    }
+
     #[test]
     fn what_a_run_spent_in_a_subprocess_comes_off_its_own_time() {
         let totals = totals(&[
@@ -765,7 +800,9 @@ mod tests {
         let rows = rows(&tree(&cli()), &totals);
 
         let ranked: Vec<&str> = by_value(&rows).iter().map(|r| r.command.as_str()).collect();
-        assert_eq!(ranked, ["edit", "repo sel", "repo ls"]);
+        // `edit` cost the most wall clock and is last: 2.99 of its 3 seconds
+        // were the editor's, and scriv cannot make those go faster.
+        assert_eq!(ranked, ["repo sel", "repo ls", "edit"]);
         // Groups are not rows to improve: `repo` is not a command anyone runs.
         assert!(!ranked.contains(&"repo"), "{ranked:?}");
 

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -413,6 +413,11 @@ static WAITED: AtomicU64 = AtomicU64::new(0);
 
 /// Time spent in front of a person, counted from when this is bound until it is
 /// dropped. Bind it — `let _waiting = stats::interacting()`.
+///
+/// A child the user works in — an editor, a Claude Code session — is bound here
+/// rather than as a [`Child`]: scriv hands over the terminal and waits, which
+/// makes the wait the user's however long they stay. A child scriv is merely
+/// held up by is the other one.
 #[must_use]
 pub struct Interaction(Instant);
 
@@ -444,6 +449,10 @@ static IN_CHILD: AtomicU64 = AtomicU64::new(0);
 /// it. A counter rather than a value threaded through the call graph, for the
 /// reason [`Interaction`] is one, and independent of it: a child spawned while
 /// a selector is open is counted by both.
+///
+/// Work scriv delegated, not a terminal it handed over — an editor is an
+/// [`Interaction`], and counting it here as well would charge the user's
+/// afternoon in vim to `git`.
 #[must_use]
 pub struct Child(Instant);
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -2567,6 +2567,39 @@ fn a_run_is_recorded_in_milliseconds_rather_than_in_how_long_it_sat_there() {
     assert!(millis < 10_000, "{millis}ms for `config path`");
 }
 
+/// An editor holds the terminal for as long as the user stays in it, which is
+/// their time and not the command's. Counted, it made `edit` the most expensive
+/// command scriv had.
+#[cfg(unix)]
+#[test]
+fn the_time_spent_in_an_editor_is_not_the_time_the_command_took() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let sandbox = Sandbox::new();
+    let editor = sandbox.home().join("slow-editor");
+    std::fs::write(&editor, "#!/bin/sh\nsleep 1\n").unwrap();
+    std::fs::set_permissions(&editor, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+    sandbox
+        .run_with_env(
+            &["edit", "notes.md"],
+            &[("EDITOR", &editor.to_string_lossy())],
+        )
+        .ok();
+
+    let log = std::fs::read_to_string(sandbox.stats_path()).unwrap();
+    let millis: u64 = log
+        .lines()
+        .next()
+        .and_then(|line| line.split('\t').nth(1))
+        .and_then(|millis| millis.parse().ok())
+        .unwrap_or_else(|| panic!("no duration in {log:?}"));
+    assert!(
+        millis < 500,
+        "the editor's second was charged to `edit`: {millis}ms"
+    );
+}
+
 #[test]
 fn reset_forgets_the_runs_and_says_how_many() {
     let sandbox = Sandbox::new();

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -2523,7 +2523,7 @@ fn every_run_records_itself_under_the_name_clap_matched() {
     let log = std::fs::read_to_string(sandbox.stats_path()).expect("no stats log");
     let commands: Vec<&str> = log
         .lines()
-        .filter_map(|line| line.split('\t').nth(2))
+        .filter_map(|line| line.split('\t').nth(3))
         .collect();
     assert_eq!(commands, ["config path", "config path"], "{log}");
 }
@@ -2544,6 +2544,7 @@ fn show_counts_what_has_run_and_names_what_has_not() {
             .to_string()
     };
     assert!(row("path").contains(" 2 "), "{}", row("path"));
+    assert!(run.stdout.contains("own"), "no own column:\n{}", run.stdout);
     // The whole tree, so the report says what is going unused as well.
     assert!(row("worktree").contains('-'), "{}", row("worktree"));
     assert!(run.stdout.starts_with("command"), "{}", run.stdout);


### PR DESCRIPTION
Every run recorded one number, and it counted two things that are not scriv: the subprocesses a command waits on, and the editor it hands the terminal to. `project build` topped the report by total time for cargo's 18.5 seconds, and `edit` for an afternoon in vim — neither of them scriv's to fix.

### Two waits, told apart

`interacting`, which already bracketed the selector and the yes/no question, now also brackets the children that take the terminal and give it back when the user is done — the editor, the note editor, `stats improve`'s Claude Code session. That time leaves the recorded total, as a selector left open already did.

A second counter, `in_child`, brackets what is left: the work scriv delegates and is held up by. `git`, `gh`, a build tool. That becomes a column.

```
command   runs  average  own
repo open    1     90ms  4ms
branch ls    1     16ms  0ms
edit         1      3ms  3ms
```

`edit` there opened an editor that sat for two seconds.

### Costs

- The log gains a field. Rows written before it read back as having spent none; an older scriv reads its command out of the wrong column.
- `own` is a lower bound. Two children waited on at once are each counted in full, so a command that fans out reads as doing less of its own work than it does.
- A wait bound in neither counter is charged to scriv, and one bound in both is charged twice. `CLAUDE.md` carries the rule.
- Streaming children the user is really waiting on — ripgrep behind the note search — are left uncounted rather than counted as scriv being held up.

### Notes

- `own` stays beside the total rather than replacing it. A slow subprocess is still usually scriv's to fix by calling a cheaper one; ranking by scriv's own time alone would have hidden `repo open` paying a GitHub API round trip for a URL it could read off the git remotes.
- `stats improve` hands the column on, and warns that an average built from a few slow runs among many fast ones is not a slow command.
- The demo does not show `stats` — no re-record.