### PR TITLE
Look for a note by its name or by what it says, without deciding first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,22 @@ raised, never by hand.
 
 ## Unreleased
 
+### Changed
+
+- `note edit` and `note rg` are now one command, `scriv note open`. The selector
+  opens on every note in the vault and three keys say what the query is read as:
+  `ctrl-e` matches the names, `ctrl-r` searches inside every note as you type,
+  and `ctrl-f` searches for the query exactly. Which of the two you want is
+  rarely clear before the looking has started, and it no longer has to be:
+  switching costs a keystroke rather than a second command. The mode in force is
+  named in the header, and switching empties the query, since a query means a
+  different thing in each of them.
+- Without `ripgrep`, `note open` offers the names and nothing else, where
+  `note rg` used to refuse to open at all.
+- `scriv note open NAME` opens named notes without a selector, as `note edit`
+  did. The query `note rg` took on the command line is gone — type it in the
+  selector instead.
+
 ## v0.18.0
 
 *Released 2026-09-02*

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Supported platform: macOS on Apple Silicon. `scriv ps` depends on Darwin's
 signal numbers, and the crate refuses to compile for any other target.
 
 External requirements: `git`, plus `gh` for `pr` and `repo clone`/`open`, `rg`
-for `note rg`, `bat` for syntax-highlighted previews, a fish history file for
+for searching inside notes, `bat` for syntax-highlighted previews, a fish history file for
 `history`, `claude` for `stats improve`, and `$VISUAL` or `$EDITOR` for `edit` —
 or `[note] editor` for `note`. `scriv config check` reports on each. `project` runs whatever the
 project in front of it asks for, and reports a tool the machine does not have as
@@ -86,7 +86,7 @@ editor = "nvim"     # what `note` opens one with; unset, $VISUAL / $EDITOR
 | --- | --- |
 | `scriv repo` | `ls` `sel` `open` `clone` |
 | `scriv file` | `ls` `sel` `add` `rm` `prune` |
-| `scriv note` | `ls` `sel` `new` `scratch` `edit` `rg` `cleanup` |
+| `scriv note` | `ls` `sel` `new` `scratch` `open` `cleanup` |
 | `scriv branch` | `ls` `sel` `checkout` `rm` |
 | `scriv worktree` | `ls` `sel` `add` `rm` |
 | `scriv pr` | `ls` `sel` `checkout` `open` `merge` |
@@ -100,9 +100,11 @@ editor = "nvim"     # what `note` opens one with; unset, $VISUAL / $EDITOR
 
 A note row is the day it was created and what it calls itself, tinted by the
 label its directory carries; everything else about it is in the preview pane.
-`note rg` searches inside every note as you type — fuzzily, or exactly on
-`ctrl-x` — and turns what you pick into a quickfix list. `note ls` prints
-absolute paths, one per line, for piping into whatever reads paths.
+`note open` reads what you type three ways, each on a key: the names of the
+notes on `ctrl-e`, every line of every note on `ctrl-r`, and the same exactly on
+`ctrl-f` — for a phrase or a snippet of code. Switching empties the query, a
+search hit opens at its line, and several become a quickfix list. `note ls`
+prints absolute paths, one per line, for piping into whatever reads paths.
 
 Every preview pane shows the file as it is on disk, drawn by `bat` in
 `[selector] preview_theme` — Catppuccin Mocha unless you say otherwise.

--- a/src/binding.rs
+++ b/src/binding.rs
@@ -83,8 +83,8 @@ pub const ACTIONS: &[Action] = &[
     },
     Action {
         id: "note-edit",
-        description: "Select a note and open it",
-        args: &["note", "edit"],
+        description: "Find a note by name or by what it says, and open it",
+        args: &["note", "open"],
         kind: Kind::Run,
     },
     Action {

--- a/src/cmd/config.rs
+++ b/src/cmd/config.rs
@@ -80,7 +80,7 @@ ignore = ["node_modules", "target"]
 # the root; its directory is created the first time.
 # scratch = "scratch/scratch.md"
 
-# What `note edit` launches, split on whitespace like $EDITOR. Its own setting
+# What `note open` launches, split on whitespace like $EDITOR. Its own setting
 # because a note is as often read as written — `glow` and `nvim` are both
 # answers. Unset, it is $VISUAL then $EDITOR, as `scriv edit` uses.
 # editor = "nvim"
@@ -963,7 +963,7 @@ fn editor_check(ctx: &Ctx) -> Check {
     }
 }
 
-/// The editor `note edit` will launch, when `[note] editor` names one of its
+/// The editor `note open` will launch, when `[note] editor` names one of its
 /// own. Unset, it is the editor the row above already reported, and a second
 /// row saying so is a second row saying so.
 fn note_editor_check(ctx: &Ctx) -> Option<Check> {
@@ -1119,7 +1119,8 @@ fn collect(ctx: &Ctx) -> Vec<Section> {
         "rg",
         "rg",
         false,
-        "only `note rg` needs it (https://github.com/BurntSushi/ripgrep)",
+        "without it `note open` looks at names only \
+         (https://github.com/BurntSushi/ripgrep)",
     ));
     // `kill` and `lsof` get no row: both ship in the same base system `ps`
     // does, and a report of three lines saying the same thing is one line.

--- a/src/cmd/note.rs
+++ b/src/cmd/note.rs
@@ -145,7 +145,7 @@ fn unix(time: SystemTime) -> Option<i64> {
 
 /// `scriv note ls` — print the notes, most recently modified first.
 ///
-/// Plain, one path below the vault per line, which is the name `note edit`
+/// Plain, one path below the vault per line, which is the name `note open`
 /// takes. `--status` adds the tags and both dates; `--absolute-paths` prints
 /// what a pipe can open.
 pub fn ls(ctx: &Ctx, status: bool) -> Result<()> {
@@ -173,23 +173,25 @@ pub fn ls(ctx: &Ctx, status: bool) -> Result<()> {
 /// `scriv note sel` — fuzzy-select a note and print its absolute path.
 pub fn sel(ctx: &Ctx) -> Result<()> {
     let notes = load(ctx)?;
-    let choice = select::select_one(items(ctx, &notes), "Select a note", &ctx.config.selector)?;
+    let (cfg, offset) = (&ctx.config.note, ctx.utc_offset());
+    let rows = notes.iter().map(|note| item(note, cfg, offset)).collect();
+    let choice = select::select_one(rows, "Select a note", &ctx.config.selector)?;
     println!("{choice}");
     Ok(())
 }
 
-/// `scriv note edit [NAME]...` — open notes in `[note] editor`, selecting them
+/// `scriv note open [NAME]...` — open notes in `[note] editor`, selecting them
 /// when none are named.
-pub fn edit(ctx: &Ctx, names: &[String]) -> Result<()> {
+///
+/// The selector is one list read three ways, each on a key: the names of the
+/// notes, and — through ripgrep — every line of every note, fuzzily or exactly.
+/// A note is as often looked for by something it says as by what it is called,
+/// and which of the two it is only becomes clear once the looking has started.
+pub fn open(ctx: &Ctx, names: &[String]) -> Result<()> {
     let editor = ctx.note_editor()?;
+    let root = vault(ctx)?;
 
-    let targets = if names.is_empty() {
-        match select_notes(ctx)? {
-            Some(targets) => targets,
-            None => return Ok(()),
-        }
-    } else {
-        let root = vault(ctx)?;
+    if !names.is_empty() {
         let targets: Vec<String> = names
             .iter()
             .map(|name| resolve(&root, ctx.home(), name))
@@ -201,17 +203,43 @@ pub fn edit(ctx: &Ctx, names: &[String]) -> Result<()> {
                 eprintln!("warning: no note called {name} — the editor will open it as a new file");
             }
         }
-        targets
-    };
+        return cmd::edit::launch(ctx, &editor, &targets);
+    }
 
-    if targets.is_empty() {
+    let notes = load(ctx)?;
+    let chosen = match select::select_many_searching(
+        searcher(
+            root.clone(),
+            notes,
+            ctx.config.note.clone(),
+            ctx.utc_offset(),
+        ),
+        "Open a note",
+        modes(which("rg").is_some()),
+        &ctx.config.selector,
+    ) {
+        Ok(chosen) => chosen,
+        Err(e) if e.is::<select::Cancelled>() => return Ok(()),
+        Err(e) => return Err(e),
+    };
+    if chosen.is_empty() {
         return Ok(());
     }
-    cmd::edit::launch(ctx, &editor, &targets)
+
+    // A mode key empties the list, so what came back is all of one kind: paths
+    // from the names, or places inside notes from a search.
+    let matches: Vec<note::Match> = chosen
+        .iter()
+        .filter_map(|value| note::decode_match(value, &root))
+        .collect();
+    if matches.is_empty() {
+        return cmd::edit::launch(ctx, &editor, &chosen);
+    }
+    open_matches(ctx, &editor, &matches)
 }
 
 /// A note named on the command line, as a path. A name is relative to the
-/// vault, so `scriv note edit` takes back exactly what `scriv note ls` printed;
+/// vault, so `scriv note open` takes back exactly what `scriv note ls` printed;
 /// an absolute path, or one that begins with `~`, is left where it points.
 fn resolve(root: &Path, home: &Path, name: &str) -> String {
     let path = expand_home_dir(name, home);
@@ -221,38 +249,21 @@ fn resolve(root: &Path, home: &Path, name: &str) -> String {
     root.join(path).to_string_lossy().into_owned()
 }
 
-/// Choose notes from the vault. `Ok(None)` when the user cancels.
-fn select_notes(ctx: &Ctx) -> Result<Option<Vec<String>>> {
-    let notes = load(ctx)?;
-    match select::select_many(items(ctx, &notes), "Edit a note", &ctx.config.selector) {
-        Ok(chosen) => Ok(Some(chosen)),
-        Err(e) if e.is::<select::Cancelled>() => Ok(None),
-        Err(e) => Err(e),
-    }
-}
-
-/// Selector rows: the day a note was created, dim and unsearchable, then what
-/// it calls itself — coloured by its label where its directory carries one.
+/// One selector row: the day a note was created, dim and unsearchable, then
+/// what it calls itself — coloured by its label where its directory carries
+/// one.
 ///
-/// Every pane is built when its row is highlighted rather than now — see
-/// [`Preview::Deferred`]. A vault read up front is one file read per note for
-/// panes the user scrolls past.
-fn items(ctx: &Ctx, notes: &[Note]) -> Vec<SelectItem> {
-    let cfg = ctx.config.note.clone();
-    let offset = ctx.utc_offset();
-
-    notes
-        .iter()
-        .map(|note| {
-            let item = SelectItem::new(note::row(note), note.path.to_string_lossy().into_owned())
-                .prefix(note::prefix(note, offset), Vec::new())
-                .preview(Preview::File);
-            match note::row_color(note, &cfg) {
-                Some(color) => item.color(color),
-                None => item,
-            }
-        })
-        .collect()
+/// The pane is built when the row is highlighted rather than now — see
+/// [`Preview::File`]. A vault read up front is one file read per note for panes
+/// the user scrolls past.
+fn item(note: &Note, cfg: &crate::config::NoteConfig, offset: time::UtcOffset) -> SelectItem {
+    let item = SelectItem::new(note::row(note), note.path.to_string_lossy().into_owned())
+        .prefix(note::prefix(note, offset), Vec::new())
+        .preview(Preview::File);
+    match note::row_color(note, cfg) {
+        Some(color) => item.color(color),
+        None => item,
+    }
 }
 
 /// `scriv note new [NAME]` — start a note and open it.
@@ -482,78 +493,103 @@ const MATCH_LIMIT: usize = 2000;
 /// still running and there is no widest yet.
 const MATCH_COLUMN: usize = 40;
 
-/// `scriv note rg [QUERY]` — search every note as you type, and open what you
-/// pick.
+/// The mode that needs nothing installed, named once because two lists hold it.
+const BY_NAME: select::Mode = select::Mode::new("ctrl-e", "name");
+
+/// The keys `note open` reads the query on, names first.
 ///
-/// The query goes to ripgrep rather than to the fuzzy matcher, so the list is
-/// every matching *line* in the vault rather than the notes whose names match.
-/// `tab` takes several; they become a quickfix list.
-pub fn rg(ctx: &Ctx, query: Option<&str>) -> Result<()> {
-    let root = vault(ctx)?;
-    let editor = ctx.note_editor()?;
-    if which("rg").is_none() {
-        bail!("`rg` is not on PATH — `scriv note rg` searches with ripgrep");
-    }
-
-    // A query given on the command line is where the selector opens, not a
-    // search run without one: what comes back is still chosen by hand.
-    let chosen = match select::select_many_searching(
-        searcher(root.clone()),
-        "Search notes",
-        query.unwrap_or_default(),
-        MODES,
-        &ctx.config.selector,
-    ) {
-        Ok(chosen) => chosen,
-        Err(e) if e.is::<select::Cancelled>() => return Ok(()),
-        Err(e) => return Err(e),
-    };
-
-    let matches: Vec<note::Match> = chosen
-        .iter()
-        .filter_map(|value| note::decode_match(value, &root))
-        .collect();
-    if matches.is_empty() {
-        return Ok(());
-    }
-    open_matches(ctx, &editor, &matches)
-}
-
-/// How `note rg` reads what is typed, fuzzy first.
+/// Names are the default because that is what a note is usually looked for by,
+/// and because the list is worth something before a key is pressed: an empty
+/// query is the whole vault, where an empty search is nothing.
 ///
-/// Fuzzy is the default because it is what a finder is for: typing `errhand`
-/// should find "error handling", and a search that only matches what was typed
-/// exactly makes the user do the remembering. Exact is the other key for when
-/// the query is a phrase, a path or a snippet of code, where subsequence
-/// matching finds a hundred lines that merely contain the letters.
+/// Of the two that search the text, fuzzy comes first for the reason a finder
+/// exists at all — typing `errhand` should find "error handling", and a search
+/// that only matches what was typed exactly makes the user do the remembering.
+/// Exact is the key for a phrase, a path or a snippet of code, where
+/// subsequence matching finds a hundred lines that merely contain the letters.
 const MODES: &[select::Mode] = &[
-    select::Mode::new("ctrl-f", "fuzzy"),
-    select::Mode::new("ctrl-x", "exact"),
+    BY_NAME,
+    select::Mode::new("ctrl-r", "text"),
+    select::Mode::new("ctrl-f", "exact"),
 ];
 
-/// The closure the selector calls on every keystroke: one ripgrep run per
-/// query, its rows streamed as ripgrep prints them.
-fn searcher(root: PathBuf) -> select::Search {
-    Box::new(move |query: &str, mode: usize| {
+/// The one mode left when ripgrep is not installed.
+///
+/// Offering the other two would be offering keys that find nothing and say
+/// nothing about why: the selector owns the screen and has nowhere to report a
+/// missing program to. Names need no ripgrep, so that much still works.
+const NAMES_ONLY: &[select::Mode] = &[BY_NAME];
+
+/// Which modes to offer, given whether ripgrep is on `PATH`.
+const fn modes(has_ripgrep: bool) -> &'static [select::Mode] {
+    match has_ripgrep {
+        true => MODES,
+        false => NAMES_ONLY,
+    }
+}
+
+/// What the query is matched against, and how.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Looking {
+    /// The names of the notes, already in hand and scored the way the selector
+    /// scores every other list.
+    Names,
+    /// Every line of every note, through ripgrep.
+    Lines(Matching),
+}
+
+impl Looking {
+    fn of(mode: usize) -> Self {
+        match mode {
+            0 => Self::Names,
+            1 => Self::Lines(Matching::Fuzzy),
+            _ => Self::Lines(Matching::Exact),
+        }
+    }
+}
+
+/// The closure the selector calls on every keystroke: the vault filtered by
+/// name, or one ripgrep run per query with its rows streamed as ripgrep prints
+/// them.
+///
+/// The notes are carried into it rather than re-read, so the name list costs
+/// nothing per keystroke and the vault is walked once for the whole selector.
+fn searcher(
+    root: PathBuf,
+    notes: Vec<Note>,
+    cfg: crate::config::NoteConfig,
+    offset: time::UtcOffset,
+) -> select::Search {
+    Box::new(move |query: &str, mode: usize| match Looking::of(mode) {
+        Looking::Names => {
+            let rows: Vec<SelectItem> = note::by_name(&notes, query)
+                .into_iter()
+                .map(|note| item(note, &cfg, offset))
+                .collect();
+            select::Searching {
+                rows: Box::new(rows.into_iter()),
+                stop: Box::new(|| {}),
+            }
+        }
         // An empty pattern matches every line of every note, which is neither
         // an answer nor a cheap question.
-        if query.trim().is_empty() {
-            return select::Searching {
-                rows: Box::new(std::iter::empty()),
-                stop: Box::new(|| {}),
-            };
-        }
-        match Search::start(&root, query, Matching::of(mode)) {
+        Looking::Lines(_) if query.trim().is_empty() => nothing(),
+        Looking::Lines(matching) => match Search::start(&root, query, matching) {
             Ok(search) => search.into_searching(),
             // A failed spawn is an empty list: the selector is open and has
             // nowhere to report an error to, and the next keystroke tries
             // again.
-            Err(_) => select::Searching {
-                rows: Box::new(std::iter::empty()),
-                stop: Box::new(|| {}),
-            },
-        }
+            Err(_) => nothing(),
+        },
     })
+}
+
+/// A search with no rows in it and nothing to call off.
+fn nothing() -> select::Searching {
+    select::Searching {
+        rows: Box::new(std::iter::empty()),
+        stop: Box::new(|| {}),
+    }
 }
 
 /// How a query becomes something ripgrep can look for.
@@ -563,15 +599,6 @@ enum Matching {
     Fuzzy,
     /// The query, as typed, meaning itself.
     Exact,
-}
-
-impl Matching {
-    fn of(mode: usize) -> Self {
-        match mode {
-            0 => Self::Fuzzy,
-            _ => Self::Exact,
-        }
-    }
 }
 
 /// The pattern ripgrep is given, and whether it is a regular expression.
@@ -1036,10 +1063,24 @@ mod search_tests {
         assert!(!is_regex, "an exact query would be read as a regex");
     }
 
+    /// The mode the selector opens in is the one that needs no ripgrep and has
+    /// something to show before a key is pressed.
     #[test]
-    fn the_first_mode_is_the_fuzzy_one() {
-        assert_eq!(Matching::of(0), Matching::Fuzzy);
-        assert_eq!(Matching::of(1), Matching::Exact);
-        assert_eq!(MODES[0].label, "fuzzy");
+    fn the_first_mode_is_the_one_that_reads_names() {
+        assert_eq!(Looking::of(0), Looking::Names);
+        assert_eq!(Looking::of(1), Looking::Lines(Matching::Fuzzy));
+        assert_eq!(Looking::of(2), Looking::Lines(Matching::Exact));
+        assert_eq!(MODES[0].label, "name");
+    }
+
+    /// Without ripgrep the two keys that would need it are not offered: they
+    /// would find nothing, and a selector has nowhere to say why.
+    #[test]
+    fn the_modes_that_search_the_text_are_offered_only_with_ripgrep() {
+        assert_eq!(modes(true).len(), 3);
+        assert_eq!(modes(false).len(), 1);
+        assert_eq!(modes(false)[0].label, "name");
+        // Whichever list is in force, mode 0 is the same one.
+        assert_eq!(Looking::of(0), Looking::Names);
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -214,7 +214,7 @@ pub struct NoteConfig {
     /// The one permanent note `note scratch` opens, as a path below
     /// [`Self::root`]. Unset, it is `scratch/scratch.md`.
     pub scratch: Option<String>,
-    /// What `note edit` launches, split on whitespace like `$EDITOR`. Unset, it
+    /// What `note open` launches, split on whitespace like `$EDITOR`. Unset, it
     /// is `$VISUAL` then `$EDITOR`.
     ///
     /// A key of its own because a note is not source: the thing that opens one

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,7 +97,7 @@ pub struct Ctx {
     utc_offset: time::UtcOffset,
     /// The editor `scriv edit` launches, from the environment.
     editor: Option<String>,
-    /// The command `scriv note edit` launches: `[note] editor`, else the one
+    /// The command `scriv note open` launches: `[note] editor`, else the one
     /// above. Resolved here so no command looks the environment up itself.
     note_editor: Option<String>,
     /// `GH_REPO`, which names the repository `gh` acts on when the working
@@ -226,14 +226,14 @@ impl Ctx {
         Ok(parts)
     }
 
-    /// The command `scriv note edit` launches, or `None` when neither
+    /// The command `scriv note open` launches, or `None` when neither
     /// `[note] editor` nor the environment names one. For reporting;
     /// [`Ctx::note_editor`] is what launching goes through.
     pub fn note_editor_setting(&self) -> Option<&str> {
         self.note_editor.as_deref()
     }
 
-    /// The command `scriv note edit` launches, split into program and
+    /// The command `scriv note open` launches, split into program and
     /// arguments.
     pub fn note_editor(&self) -> Result<Vec<String>> {
         let command = self

--- a/src/main.rs
+++ b/src/main.rs
@@ -473,35 +473,28 @@ enum NoteCmd {
         #[arg(short, long)]
         yes: bool,
     },
-    /// Search inside every note, as you type
+    /// Open notes; omit the names to look for them
     ///
-    /// The query goes to `ripgrep` rather than to the fuzzy matcher, so the
-    /// list is every matching *line* in the vault and it is rebuilt on each
-    /// keystroke. `ctrl-q` switches to filtering what came back.
+    /// A name is a path below the vault, exactly as `note ls` prints it, and
+    /// several open together. With none, the selector opens on every note in
+    /// the vault and three keys say what the query is read as: `ctrl-e` matches
+    /// the names, `ctrl-r` searches inside every note as you type — the letters
+    /// you typed, in order, so `errhand` finds "error handling" — and `ctrl-f`
+    /// searches for the query exactly, for a phrase or a snippet of code. The
+    /// header says which is in force, and switching empties the query.
     ///
-    /// Matching is fuzzy — the letters you typed, in order, anywhere on the
-    /// line — so `errhand` finds "error handling". `ctrl-x` searches for the
-    /// query exactly instead, for a phrase or a snippet of code, and `ctrl-f`
-    /// goes back; the header says which is in force.
+    /// Searching the text needs `ripgrep`; without it only the names are
+    /// offered. `ctrl-q` switches to filtering what came back.
     ///
-    /// `tab` takes several. What you pick opens at its line, and anything else
+    /// `tab` takes several. A search hit opens at its line, and anything else
     /// you picked lands in the quickfix list behind it — which needs a vim; any
     /// other editor is handed the files and no line numbers.
-    Rg {
-        /// Text to open the search with
-        #[arg(value_name = "QUERY", allow_hyphen_values = true)]
-        query: Option<String>,
-    },
-    /// Open notes; omit the names to select them
-    ///
-    /// `tab` selects several and they open together. A name is a path below the
-    /// vault, exactly as `note ls` prints it.
     ///
     /// The command is `[note] editor`, falling back to `$VISUAL` then
     /// `$EDITOR`. It is a setting of its own because a note is as often read as
     /// written — `glow` and `nvim` are both answers. The fish integration binds
     /// this to f10.
-    Edit {
+    Open {
         /// Notes to open; omit to select interactively
         #[arg(value_name = "NAME")]
         notes: Vec<String>,
@@ -998,9 +991,8 @@ fn dispatch(ctx: &Ctx, command: Command) -> anyhow::Result<()> {
         Command::Note { command } => match command {
             NoteCmd::Ls { status } => cmd::note::ls(ctx, status),
             NoteCmd::Sel => cmd::note::sel(ctx),
-            NoteCmd::Edit { notes } => cmd::note::edit(ctx, &notes),
+            NoteCmd::Open { notes } => cmd::note::open(ctx, &notes),
             NoteCmd::New { name } => cmd::note::new(ctx, name.as_deref()),
-            NoteCmd::Rg { query } => cmd::note::rg(ctx, query.as_deref()),
             NoteCmd::Scratch => cmd::note::scratch(ctx),
             NoteCmd::Cleanup { yes } => cmd::note::cleanup(ctx, yes),
         },

--- a/src/note.rs
+++ b/src/note.rs
@@ -488,6 +488,30 @@ pub fn newest_first(notes: &mut [Note]) {
     notes.sort_by(|a, b| b.modified.cmp(&a.modified).then_with(|| a.rel.cmp(&b.rel)));
 }
 
+/// The notes whose names match `query`, best first.
+///
+/// A searching selector hands what is typed to the search rather than to the
+/// fuzzy matcher, so a list of names already in memory has to be matched here.
+/// It goes through the selector's own scorer, which is what keeps this list
+/// ranked the way every other list in scriv is.
+///
+/// An empty query is every note, in the order [`newest_first`] left them: the
+/// whole vault is a useful answer to nothing typed yet, where an empty search
+/// of the text is not.
+pub fn by_name<'a>(notes: &'a [Note], query: &str) -> Vec<&'a Note> {
+    if query.trim().is_empty() {
+        return notes.iter().collect();
+    }
+    let mut scored: Vec<(i64, &Note)> = notes
+        .iter()
+        .filter_map(|note| crate::select::score(&row(note), query).map(|score| (score, note)))
+        .collect();
+    // Stable, so notes that score alike stay newest first rather than in
+    // whatever order the walk found them.
+    scored.sort_by_key(|(score, _)| std::cmp::Reverse(*score));
+    scored.into_iter().map(|(_, note)| note).collect()
+}
+
 /// Whether a path is one a note listing offers, by extension.
 pub fn is_note(path: &Path) -> bool {
     path.extension()
@@ -847,6 +871,55 @@ mod tests {
         let mut notes = vault();
         newest_first(&mut notes);
         assert_eq!(notes[0].rel, "work/meetings/standup.md");
+    }
+
+    /// The list is worth something before anything is typed: the whole vault,
+    /// in the order the listing already put it in.
+    #[test]
+    fn nothing_typed_matches_every_note_in_the_order_it_arrived() {
+        let notes = vault();
+        let matched = by_name(&notes, "  ");
+        assert_eq!(matched.len(), notes.len());
+        assert_eq!(matched[0].rel, notes[0].rel);
+    }
+
+    /// A query matches what the row shows — the title — and the letters need
+    /// only be in order, so `stnd` finds "standup".
+    #[test]
+    fn a_query_matches_the_name_the_row_shows() {
+        let notes = vault();
+        let matched = by_name(&notes, "stnd");
+        assert_eq!(matched.len(), 1);
+        assert_eq!(matched[0].rel, "work/meetings/standup.md");
+    }
+
+    #[test]
+    fn a_query_nothing_is_called_matches_nothing() {
+        assert!(by_name(&vault(), "zzzz").is_empty());
+    }
+
+    /// Notes that score alike keep the order the listing left them in, rather
+    /// than shuffling between keystrokes.
+    #[test]
+    fn notes_that_score_alike_stay_newest_first() {
+        let mut notes = vec![
+            Note {
+                modified: 0,
+                ..note("older-draft.md", Front::default())
+            },
+            Note {
+                modified: DAY,
+                ..note("newer-draft.md", Front::default())
+            },
+        ];
+        newest_first(&mut notes);
+
+        let matched = by_name(&notes, "draft");
+
+        assert_eq!(
+            matched.iter().map(|note| &note.rel).collect::<Vec<_>>(),
+            vec!["newer-draft.md", "older-draft.md"]
+        );
     }
 
     #[test]

--- a/src/select.rs
+++ b/src/select.rs
@@ -17,6 +17,7 @@ use std::time::{Duration, Instant};
 use anyhow::{Result, anyhow};
 use ratatui::style::{Color, Style};
 use ratatui::text::{Line, Span};
+use skim::fuzzy_matcher::FuzzyMatcher;
 use skim::prelude::*;
 
 use crate::config::SelectorConfig;
@@ -64,6 +65,19 @@ pub enum Preview {
     /// the same bar as a [`Preview::Command`] — local, bounded, tens of
     /// milliseconds — and ANSI escapes in what it returns are honoured.
     Deferred(Box<dyn Fn() -> String + Send + Sync>),
+}
+
+/// Score `choice` against `query` the way the selector scores what it matches
+/// itself, or `None` where the two do not match at all.
+///
+/// For a list a searching selector cannot rank on its own: the query has gone
+/// to the search, so a mode that filters something already in memory does its
+/// own matching, and going through skim's matcher is what keeps that list
+/// ordered like every other one.
+pub fn score(choice: &str, query: &str) -> Option<i64> {
+    static MATCHER: std::sync::LazyLock<SkimMatcherV2> =
+        std::sync::LazyLock::new(SkimMatcherV2::default);
+    MATCHER.fuzzy_match(choice, query)
 }
 
 /// Quote `arg` for the shell that runs a [`Preview::Command`], so a branch name
@@ -608,11 +622,15 @@ pub type Search = Box<dyn FnMut(&str, usize) -> Searching + Send>;
 
 /// One way a [`Search`] can read the query, offered on a key of its own.
 ///
-/// Two keys rather than one that toggles, because a header cannot be made to
-/// alternate: skim's `set-header` writes a fixed string, and a binding that
-/// rebinds itself to the opposite mode would have to contain its own text.
-/// Deliberate keys also cost the same one keystroke and never leave a doubt
-/// about which mode is in force — which is the thing the header is for.
+/// A key each rather than one that steps through them, because a header cannot
+/// be made to alternate: skim's `set-header` writes a fixed string, and a
+/// binding that rebinds itself to the next mode would have to contain its own
+/// text. Deliberate keys also cost the same one keystroke and never leave a
+/// doubt about which mode is in force — which is the thing the header is for.
+///
+/// Switching empties the query and the list with it. A query means a different
+/// thing in each mode, and rows left over from the one before it are answers to
+/// a question that is no longer being asked.
 pub struct Mode {
     /// skim's spelling of the key — `ctrl-f`.
     pub key: &'static str,
@@ -820,14 +838,13 @@ impl CommandCollector for SearchCollector {
 pub fn select_many_searching(
     search: Search,
     prompt: &str,
-    query: &str,
     modes: &'static [Mode],
     cfg: &SelectorConfig,
 ) -> Result<Vec<String>> {
     let run = Run {
         prompt,
         multi: true,
-        query,
+        query: "",
         reload: None,
         search: Some(search),
         modes,
@@ -1122,13 +1139,7 @@ fn run_selector(feed: Feed, run: Run, cfg: &SelectorConfig) -> Result<Outcome> {
     }
 
     if !run.query.is_empty() {
-        // Two different boxes: in a searching selector what is typed is the
-        // search, and skim keeps that under a name of its own.
-        if run.search.is_some() {
-            builder.cmd_query(run.query.to_string());
-        } else {
-            builder.query(run.query.to_string());
-        }
+        builder.query(run.query.to_string());
     }
 
     // A selector whose reload exists to step through views has no refresh of
@@ -1304,10 +1315,13 @@ fn binds(
         binds.extend(refresh_binds(header));
     }
     // Each mode key searches again in its own mode and says so in the header,
-    // which is the only place the current one can be read.
+    // which is the only place the current one can be read. The query goes with
+    // the old mode: `set-query` empties the box, and the empty reload it fires
+    // in turn is what leaves the list showing the new mode's answer to nothing
+    // rather than the old mode's answer to something.
     for (index, mode) in modes.iter().enumerate() {
         binds.push(format!(
-            "{}:reload({MODE_MARKER}{index}{MODE_MARKER}{{q}})+set-header({})",
+            "{}:reload({MODE_MARKER}{index}{MODE_MARKER})+set-query()+set-header({})",
             mode.key,
             chosen_header(modes, index, header, " match"),
         ));
@@ -1553,6 +1567,23 @@ mod tests {
             assert!(
                 binds.iter().all(|b| b.contains("set-header(")),
                 "a mode key that does not say so: {binds:?}"
+            );
+        }
+
+        /// A query means a different thing in each mode, so the box is emptied
+        /// rather than re-read: the reload carries no `{q}`, and `set-query`
+        /// clears what the box still shows.
+        #[test]
+        fn a_mode_key_leaves_the_query_and_the_list_empty() {
+            let modes = [Mode::new("ctrl-f", "fuzzy"), Mode::new("ctrl-x", "exact")];
+            let binds = binds(&[], false, false, &modes, &Views::NONE, "");
+            assert!(
+                binds.iter().all(|b| !b.contains("{q}")),
+                "a mode key carried the old query: {binds:?}"
+            );
+            assert!(
+                binds.iter().all(|b| b.contains("set-query()")),
+                "a mode key left the old query on screen: {binds:?}"
             );
         }
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1844,21 +1844,6 @@ fn note_new_never_hands_back_a_name_already_in_use() {
     );
 }
 
-/// The search needs ripgrep, and says so rather than opening an empty selector.
-#[test]
-fn note_rg_without_ripgrep_says_what_is_missing() {
-    let sandbox = Sandbox::new();
-    mk_vault(&sandbox);
-    let empty = sandbox.home().join("empty-path");
-    std::fs::create_dir_all(&empty).unwrap();
-    let run = sandbox.run_with_env(
-        &["note", "rg", "anything"],
-        &[("PATH", empty.to_str().unwrap())],
-    );
-    run.code(1);
-    assert!(run.stderr.contains("ripgrep"), "{}", run.stderr);
-}
-
 #[test]
 fn note_without_a_vault_says_which_key_is_missing() {
     let sandbox = Sandbox::new();
@@ -1880,10 +1865,10 @@ fn note_with_a_vault_that_is_not_there_says_so() {
 /// `[note] editor` is `echo` here, so what it was asked to open comes back on
 /// stdout. A name is a path below the vault — what `note ls` printed.
 #[test]
-fn note_edit_resolves_a_name_against_the_vault() {
+fn note_open_resolves_a_name_against_the_vault() {
     let sandbox = Sandbox::new();
     let vault = mk_vault(&sandbox);
-    let run = sandbox.run(&["note", "edit", "archive/old.md"]);
+    let run = sandbox.run(&["note", "open", "archive/old.md"]);
     run.ok();
     assert_eq!(
         run.stdout.trim(),
@@ -1891,10 +1876,27 @@ fn note_edit_resolves_a_name_against_the_vault() {
     );
 }
 
+/// Several names open together, in the order they were given.
+#[test]
+fn note_open_takes_several_names_at_once() {
+    let sandbox = Sandbox::new();
+    let vault = mk_vault(&sandbox);
+    let run = sandbox.run(&["note", "open", "inbox.md", "archive/old.md"]);
+    run.ok();
+    assert_eq!(
+        run.stdout.trim(),
+        format!(
+            "-- {} {}",
+            vault.join("inbox.md").display(),
+            vault.join("archive/old.md").display()
+        )
+    );
+}
+
 /// The key exists so a note can be opened by something other than the editor
 /// the rest of scriv uses; with none set, it is that editor.
 #[test]
-fn note_edit_falls_back_to_the_environment_editor() {
+fn note_open_falls_back_to_the_environment_editor() {
     let sandbox = Sandbox::new();
     let vault = sandbox.home().join("notes");
     mk_note(&vault, "a.md", "a\n", 1_000);
@@ -1903,7 +1905,7 @@ fn note_edit_falls_back_to_the_environment_editor() {
         vault.display().to_string()
     ));
 
-    let run = sandbox.run_with_env(&["note", "edit", "a.md"], &[("EDITOR", "echo")]);
+    let run = sandbox.run_with_env(&["note", "open", "a.md"], &[("EDITOR", "echo")]);
     run.ok();
     assert_eq!(
         run.stdout.trim(),
@@ -1920,7 +1922,8 @@ fn config_check_counts_the_notes_in_the_vault() {
     let run = sandbox.run(&["config", "check"]);
     assert!(run.stdout.contains("3 notes"), "{}", run.stdout);
     assert!(run.stdout.contains("note editor"), "{}", run.stdout);
-    // `note rg` shells out to it, so the report says whether it is there.
+    // `note open` shells out to it to search, so the report says whether it is
+    // there.
     assert!(run.stdout.contains("rg"), "{}", run.stdout);
     // So does every preview pane, which is where the theme is applied.
     assert!(run.stdout.contains("bat"), "{}", run.stdout);
@@ -1967,10 +1970,10 @@ fn note_scratch_goes_where_the_config_says() {
 /// A mistyped name would otherwise open a new, empty buffer and say nothing,
 /// which is how a typo becomes a second note.
 #[test]
-fn note_edit_warns_when_the_note_named_is_not_there() {
+fn note_open_warns_when_the_note_named_is_not_there() {
     let sandbox = Sandbox::new();
     mk_vault(&sandbox);
-    let run = sandbox.run(&["note", "edit", "inbx.md"]);
+    let run = sandbox.run(&["note", "open", "inbx.md"]);
     run.ok();
     assert!(
         run.stderr.contains("no note called inbx.md"),
@@ -2116,7 +2119,7 @@ fn every_note_command_survives_a_vault_that_is_not_ascii() {
 
     sandbox.run(&["note", "ls"]).ok();
     sandbox.run(&["note", "ls", "--status"]).ok();
-    sandbox.run(&["note", "edit", "øvelser.md"]).ok();
+    sandbox.run(&["note", "open", "øvelser.md"]).ok();
     sandbox.run(&["note", "new", "Løsningsforslag"]).ok();
     sandbox.run(&["note", "scratch"]).ok();
     sandbox.run(&["config", "check"]);


### PR DESCRIPTION
`note edit` and `note rg` were the same question asked two ways. They are now
`note open`: one selector, three keys.

### What changes

- `ctrl-e` matches the names, `ctrl-r` searches every line of every note as you
  type, `ctrl-f` searches for the query exactly.
- Names are the mode it opens in, and the only one offered without `ripgrep`.
- Switching modes empties the query and the list — a query means a different
  thing in each of them.
- `note open NAME...` opens named notes without a selector, as `note edit` did.
- The query `note rg` took on the command line is gone; type it in the selector.

### Costs

- Between the two search modes, changing how the query is read now costs
  retyping it. That is the same rule applied to every switch rather than a rule
  per pair.
- The header runs to five hints and clips on a narrow pane beside an open
  preview, where four fitted.

### Docs

- README's command table and note prose, the starter config, `--help`, and
  CHANGELOG are updated. The `note-edit` binding id is unchanged and now runs
  `note open`, so nobody's config breaks.
- `docs/demo.gif` is unchanged: the tape does not open a note selector.

### Verified

Driven through VHS against a throwaway vault — every mode switch, both ways of
opening what was picked.