### PR TITLE
Read what is already typed in the mode you switch to

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,8 @@ raised, never by hand.
   and `ctrl-f` searches for the query exactly. Which of the two you want is
   rarely clear before the looking has started, and it no longer has to be:
   switching costs a keystroke rather than a second command. The mode in force is
-  named in the header, and switching empties the query, since a query means a
-  different thing in each of them.
+  named in the header, and what you have typed is read again in whichever mode
+  you switch to — a key is a second opinion on the same words.
 - Without `ripgrep`, `note open` offers the names and nothing else, where
   `note rg` used to refuse to open at all.
 - `scriv note open NAME` opens named notes without a selector, as `note edit`

--- a/README.md
+++ b/README.md
@@ -102,9 +102,10 @@ A note row is the day it was created and what it calls itself, tinted by the
 label its directory carries; everything else about it is in the preview pane.
 `note open` reads what you type three ways, each on a key: the names of the
 notes on `ctrl-e`, every line of every note on `ctrl-r`, and the same exactly on
-`ctrl-f` — for a phrase or a snippet of code. Switching empties the query, a
-search hit opens at its line, and several become a quickfix list. `note ls`
-prints absolute paths, one per line, for piping into whatever reads paths.
+`ctrl-f` — for a phrase or a snippet of code. A key rereads what you have
+already typed rather than clearing it, a search hit opens at its line, and
+several become a quickfix list. `note ls` prints absolute paths, one per line,
+for piping into whatever reads paths.
 
 Every preview pane shows the file as it is on disk, drawn by `bat` in
 `[selector] preview_theme` — Catppuccin Mocha unless you say otherwise.

--- a/src/main.rs
+++ b/src/main.rs
@@ -481,7 +481,8 @@ enum NoteCmd {
     /// the names, `ctrl-r` searches inside every note as you type — the letters
     /// you typed, in order, so `errhand` finds "error handling" — and `ctrl-f`
     /// searches for the query exactly, for a phrase or a snippet of code. The
-    /// header says which is in force, and switching empties the query.
+    /// header says which is in force, and what you have typed is read again in
+    /// whichever mode you switch to.
     ///
     /// Searching the text needs `ripgrep`; without it only the names are
     /// offered. `ctrl-q` switches to filtering what came back.

--- a/src/select.rs
+++ b/src/select.rs
@@ -628,9 +628,10 @@ pub type Search = Box<dyn FnMut(&str, usize) -> Searching + Send>;
 /// text. Deliberate keys also cost the same one keystroke and never leave a
 /// doubt about which mode is in force — which is the thing the header is for.
 ///
-/// Switching empties the query and the list with it. A query means a different
-/// thing in each mode, and rows left over from the one before it are answers to
-/// a question that is no longer being asked.
+/// The query survives the switch and is read again in the new mode. A mode key
+/// is a second opinion on what was already typed — the same words, looked for
+/// another way — so what the list holds changes and what is in the box does
+/// not.
 pub struct Mode {
     /// skim's spelling of the key — `ctrl-f`.
     pub key: &'static str,
@@ -1316,12 +1317,11 @@ fn binds(
     }
     // Each mode key searches again in its own mode and says so in the header,
     // which is the only place the current one can be read. The query goes with
-    // the old mode: `set-query` empties the box, and the empty reload it fires
-    // in turn is what leaves the list showing the new mode's answer to nothing
-    // rather than the old mode's answer to something.
+    // it: a mode key is a second opinion on what was already typed, and asking
+    // for one should not cost typing it again.
     for (index, mode) in modes.iter().enumerate() {
         binds.push(format!(
-            "{}:reload({MODE_MARKER}{index}{MODE_MARKER})+set-query()+set-header({})",
+            "{}:reload({MODE_MARKER}{index}{MODE_MARKER}{{q}})+set-header({})",
             mode.key,
             chosen_header(modes, index, header, " match"),
         ));
@@ -1570,20 +1570,19 @@ mod tests {
             );
         }
 
-        /// A query means a different thing in each mode, so the box is emptied
-        /// rather than re-read: the reload carries no `{q}`, and `set-query`
-        /// clears what the box still shows.
+        /// A mode key asks for a second opinion on what was already typed, so
+        /// the query is handed to the new mode rather than thrown away.
         #[test]
-        fn a_mode_key_leaves_the_query_and_the_list_empty() {
+        fn a_mode_key_carries_the_query_into_the_new_mode() {
             let modes = [Mode::new("ctrl-f", "fuzzy"), Mode::new("ctrl-x", "exact")];
             let binds = binds(&[], false, false, &modes, &Views::NONE, "");
             assert!(
-                binds.iter().all(|b| !b.contains("{q}")),
-                "a mode key carried the old query: {binds:?}"
+                binds.iter().all(|b| b.contains("{q}")),
+                "a mode key dropped the query: {binds:?}"
             );
             assert!(
-                binds.iter().all(|b| b.contains("set-query()")),
-                "a mode key left the old query on screen: {binds:?}"
+                binds.iter().all(|b| !b.contains("set-query")),
+                "a mode key rewrote the query box: {binds:?}"
             );
         }
 


### PR DESCRIPTION
A mode key in `note open` was clearing the query, so asking "and what does this
look like as a text search?" meant typing the words again.

- The query survives the switch and the new mode rebuilds the list from it.
- README, `--help` and the unreleased CHANGELOG entry say so.

Verified by driving the selector: `retro` typed in name mode, `ctrl-r` finds the
two lines that mention it, `ctrl-e` comes back to the one note called that.

`docs/demo.gif` is unchanged — the tape does not open a note selector.