### PR TITLE
Leave the notes you have stopped reading out of the listing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ raised, never by hand.
 
 ## Unreleased
 
+### Added
+
+- `[note] archives` names the directories in your vault holding notes you keep
+  but no longer read — `archives = ["work/archive", "personal/archive"]`, as
+  paths below `[note] root`. They are left out of `note ls`, `note sel`,
+  `note cleanup` and the `note open` selector, text search included, so a vault
+  that has been going for years lists what you are still working on. `--all`
+  puts them back, and naming a note outright opens it either way.
+
 ### Changed
 
 - scriv no longer binds a key or defines an alias unless you have asked it to.

--- a/src/cmd/config.rs
+++ b/src/cmd/config.rs
@@ -75,6 +75,13 @@ ignore = ["node_modules", "target"]
 # Written inline, on one line, for the reason `[repo] labels` is.
 # labels = { work = ["projects", "clients"], personal = ["journal"] }
 
+# Directories holding notes you keep but no longer read, as paths below the
+# root. They are left out of every listing, out of the selector and out of the
+# text search; `--all` puts them back, and naming a note outright opens it
+# either way. A list, because a vault that files notes by kind archives them
+# the same way.
+# archives = ["work/archive", "personal/archive"]
+
 # The one permanent note `note scratch` opens — somewhere to put a thought
 # without deciding first whether it is worth a note of its own. A path below
 # the root; its directory is created the first time.
@@ -385,6 +392,7 @@ fn report(cfg: &Config, env: &Env) -> Vec<Row> {
         "`scriv note` has nowhere to look",
     ));
     rows.extend(label_rows(&cfg.note.labels));
+    rows.push(Row::setting("archives", list(&cfg.note.archives), ""));
     rows.push(match cfg.note.scratch.as_deref() {
         Some(scratch) => Row::setting("scratch", Value::Set(scratch.to_string()), ""),
         None => Row::setting(
@@ -986,12 +994,45 @@ fn note_vault_check(ctx: &Ctx) -> Check {
     }
     match cmd::note::vault_summary(ctx) {
         Err(err) => Check::fail("note vault", format!("{err:#}")),
-        Ok((root, 0)) => Check::warn(
+        Ok(vault) if vault.listed + vault.archived == 0 => Check::warn(
             "note vault",
-            format!("{} holds no Markdown files", root.display()),
+            format!("{} holds no Markdown files", vault.root.display()),
         ),
-        Ok((_, count)) => Check::ok("note vault", plural(count, "note", "notes")),
+        Ok(vault) => Check::ok(
+            "note vault",
+            match vault.archived {
+                0 => plural(vault.listed, "note", "notes"),
+                archived => format!(
+                    "{}, {archived} archived",
+                    plural(vault.listed, "note", "notes")
+                ),
+            },
+        ),
     }
+}
+
+/// The archive directories, when there are any: whether each names a directory
+/// that is actually there.
+///
+/// A warning rather than a failure, since an entry that names nothing hides
+/// nothing — which is the point of reporting it. A path is relative to the
+/// vault, and one written as though it were absolute, or misspelled, is a
+/// setting that silently does nothing at all.
+fn note_archives_check(ctx: &Ctx) -> Option<Check> {
+    if ctx.config.note.archives.is_empty() {
+        return None;
+    }
+    Some(match cmd::note::missing_archives(ctx) {
+        Err(err) => Check::fail("note archives", format!("{err:#}")),
+        Ok(missing) if missing.is_empty() => Check::ok(
+            "note archives",
+            plural(ctx.config.note.archives.len(), "directory", "directories"),
+        ),
+        Ok(missing) => Check::warn(
+            "note archives",
+            format!("not below the vault: {}", missing.join(", ")),
+        ),
+    })
 }
 
 /// `[shell]`: whether every key and name resolves to an action that exists.
@@ -1145,7 +1186,8 @@ fn collect(ctx: &Ctx) -> Vec<Section> {
         "only `stats improve` needs it (https://claude.com/product/claude-code)",
     ));
 
-    let content = vec![history_check(ctx), files_check(ctx), note_vault_check(ctx)];
+    let mut content = vec![history_check(ctx), files_check(ctx), note_vault_check(ctx)];
+    content.extend(note_archives_check(ctx));
 
     vec![
         Section {

--- a/src/cmd/note.rs
+++ b/src/cmd/note.rs
@@ -49,15 +49,25 @@ fn vault(ctx: &Ctx) -> Result<PathBuf> {
 /// one pass rather than a walk followed by a read per note. Dotfiles are
 /// skipped, which is what leaves Obsidian's `.obsidian` and `.trash` out
 /// without naming either.
-fn load(ctx: &Ctx) -> Result<Vec<Note>> {
+///
+/// `[note] archives` is pruned rather than filtered afterwards, unless `all`
+/// asks for it: an archive is the part of a vault that only grows, and not
+/// descending into it is the difference between reading every note ever
+/// written and reading the ones still in use.
+fn load(ctx: &Ctx, all: bool) -> Result<Vec<Note>> {
     let root = vault(ctx)?;
     let offset = ctx.utc_offset();
     let found = Mutex::new(Vec::new());
+    let archives = archives(ctx, all);
 
     ignore::WalkBuilder::new(&root)
         .hidden(true)
         .require_git(false)
         .add_custom_ignore_filename(".fdignore")
+        .filter_entry({
+            let root = root.clone();
+            move |entry| !note::is_archived(&relative(entry.path(), &root), &archives)
+        })
         .build_parallel()
         .run(|| {
             Box::new(|entry| {
@@ -81,12 +91,34 @@ fn load(ctx: &Ctx) -> Result<Vec<Note>> {
         .info(&format!("{} note(s) under {}", notes.len(), root.display()));
     if notes.is_empty() {
         bail!(
-            "no notes under {} — `scriv note` reads Markdown files, and \
+            "no notes under {}{} — `scriv note` reads Markdown files, and \
              `scriv note new` writes one",
-            root.display()
+            root.display(),
+            if all {
+                ""
+            } else {
+                " outside `[note] archives`"
+            }
         );
     }
     Ok(notes)
+}
+
+/// The archive directories a listing hides, or none when `--all` was passed.
+fn archives(ctx: &Ctx, all: bool) -> Vec<String> {
+    match all {
+        true => Vec::new(),
+        false => ctx.config.note.archives.clone(),
+    }
+}
+
+/// `path` as the vault knows it: below `root`, or as it stands when it is not
+/// under one.
+fn relative(path: &Path, root: &Path) -> String {
+    path.strip_prefix(root)
+        .unwrap_or(path)
+        .to_string_lossy()
+        .into_owned()
 }
 
 /// One note, read: its times from the directory entry's metadata, its front
@@ -106,11 +138,7 @@ fn read_note(path: &Path, root: &Path, offset: time::UtcOffset) -> Option<Note> 
         note::parse_front(block, offset)
     });
 
-    let rel = path
-        .strip_prefix(root)
-        .unwrap_or(path)
-        .to_string_lossy()
-        .into_owned();
+    let rel = relative(path, root);
     Some(Note {
         dir: note::top_dir(&rel).to_string(),
         rel,
@@ -146,10 +174,10 @@ fn unix(time: SystemTime) -> Option<i64> {
 /// `scriv note ls` — print the notes, most recently modified first.
 ///
 /// Plain, one path below the vault per line, which is the name `note open`
-/// takes. `--status` adds the tags and both dates; `--absolute-paths` prints
-/// what a pipe can open.
-pub fn ls(ctx: &Ctx, status: bool) -> Result<()> {
-    let notes = load(ctx)?;
+/// takes. `--status` adds the tags and both dates; `--all` adds the notes
+/// under `[note] archives`.
+pub fn ls(ctx: &Ctx, status: bool, all: bool) -> Result<()> {
+    let notes = load(ctx, all)?;
     let cfg = &ctx.config.note;
     let widths = Widths::of(&notes, cfg, ctx.home_str());
     let offset = ctx.utc_offset();
@@ -171,8 +199,8 @@ pub fn ls(ctx: &Ctx, status: bool) -> Result<()> {
 }
 
 /// `scriv note sel` — fuzzy-select a note and print its absolute path.
-pub fn sel(ctx: &Ctx) -> Result<()> {
-    let notes = load(ctx)?;
+pub fn sel(ctx: &Ctx, all: bool) -> Result<()> {
+    let notes = load(ctx, all)?;
     let (cfg, offset) = (&ctx.config.note, ctx.utc_offset());
     let rows = notes.iter().map(|note| item(note, cfg, offset)).collect();
     let choice = select::select_one(rows, "Select a note", &ctx.config.selector)?;
@@ -187,7 +215,7 @@ pub fn sel(ctx: &Ctx) -> Result<()> {
 /// notes, and — through ripgrep — every line of every note, fuzzily or exactly.
 /// A note is as often looked for by something it says as by what it is called,
 /// and which of the two it is only becomes clear once the looking has started.
-pub fn open(ctx: &Ctx, names: &[String]) -> Result<()> {
+pub fn open(ctx: &Ctx, names: &[String], all: bool) -> Result<()> {
     let editor = ctx.note_editor()?;
     let root = vault(ctx)?;
 
@@ -206,13 +234,14 @@ pub fn open(ctx: &Ctx, names: &[String]) -> Result<()> {
         return cmd::edit::launch(ctx, &editor, &targets);
     }
 
-    let notes = load(ctx)?;
+    let notes = load(ctx, all)?;
     let chosen = match select::select_many_searching(
         searcher(
             root.clone(),
             notes,
             ctx.config.note.clone(),
             ctx.utc_offset(),
+            archives(ctx, all),
         ),
         "Open a note",
         modes(which("rg").is_some()),
@@ -241,6 +270,8 @@ pub fn open(ctx: &Ctx, names: &[String]) -> Result<()> {
 /// A note named on the command line, as a path. A name is relative to the
 /// vault, so `scriv note open` takes back exactly what `scriv note ls` printed;
 /// an absolute path, or one that begins with `~`, is left where it points.
+///
+/// `[note] archives` does not apply: naming a note is asking for that note.
 fn resolve(root: &Path, home: &Path, name: &str) -> String {
     let path = expand_home_dir(name, home);
     if path.is_absolute() {
@@ -352,8 +383,8 @@ fn scratch_path(ctx: &Ctx, root: &Path) -> PathBuf {
 /// Nothing is deleted without being listed and then agreed to, and the listing
 /// says why each note is on it: three rules, applied without judgement, over a
 /// vault only its owner can actually read.
-pub fn cleanup(ctx: &Ctx, yes: bool) -> Result<()> {
-    let notes = load(ctx)?;
+pub fn cleanup(ctx: &Ctx, yes: bool, all: bool) -> Result<()> {
+    let notes = load(ctx, all)?;
     let candidates = junk(ctx, &notes)?;
 
     if candidates.is_empty() {
@@ -559,6 +590,7 @@ fn searcher(
     notes: Vec<Note>,
     cfg: crate::config::NoteConfig,
     offset: time::UtcOffset,
+    archives: Vec<String>,
 ) -> select::Search {
     Box::new(move |query: &str, mode: usize| match Looking::of(mode) {
         Looking::Names => {
@@ -574,7 +606,7 @@ fn searcher(
         // An empty pattern matches every line of every note, which is neither
         // an answer nor a cheap question.
         Looking::Lines(_) if query.trim().is_empty() => nothing(),
-        Looking::Lines(matching) => match Search::start(&root, query, matching) {
+        Looking::Lines(matching) => match Search::start(&root, query, matching, archives.clone()) {
             Ok(search) => search.into_searching(),
             // A failed spawn is an empty list: the selector is open and has
             // nowhere to report an error to, and the next keystroke tries
@@ -647,11 +679,21 @@ struct Search {
     lines: std::io::Lines<std::io::BufReader<std::process::ChildStdout>>,
     child: Arc<Mutex<Option<std::process::Child>>>,
     root: PathBuf,
+    /// Directories whose hits are dropped as they arrive. ripgrep matches
+    /// `--glob` against paths relative to the working directory rather than to
+    /// the directory it was told to search, so an archive cannot be excluded by
+    /// one; it is read and its lines are thrown away here.
+    archives: Vec<String>,
     found: usize,
 }
 
 impl Search {
-    fn start(root: &Path, query: &str, matching: Matching) -> std::io::Result<Self> {
+    fn start(
+        root: &Path,
+        query: &str,
+        matching: Matching,
+        archives: Vec<String>,
+    ) -> std::io::Result<Self> {
         let (pattern, is_regex) = pattern(query, matching);
         let mut child = std::process::Command::new("rg")
             .args([
@@ -695,6 +737,7 @@ impl Search {
             lines: std::io::BufRead::lines(std::io::BufReader::new(stdout)),
             child: Arc::new(Mutex::new(Some(child))),
             root: root.to_path_buf(),
+            archives,
             found: 0,
         })
     }
@@ -724,6 +767,9 @@ impl Iterator for Search {
             let Some(found) = note::parse_match(&line, &self.root) else {
                 continue;
             };
+            if note::is_archived(&found.rel, &self.archives) {
+                continue;
+            }
             self.found += 1;
             let (label, tints) = note::match_row(&found, MATCH_COLUMN);
             // The pane opens the note at the line that matched, marked, which
@@ -872,20 +918,54 @@ fn which(program: &str) -> Option<PathBuf> {
     })
 }
 
-/// The `config check` row for the vault: where it is, and how much is in it.
-/// One row rather than two, since a root that resolves and holds nothing has
-/// already been reported by the count.
-pub(crate) fn vault_summary(ctx: &Ctx) -> Result<(PathBuf, usize)> {
+/// The `config check` row for the vault: where it is, how much is in it, and
+/// how much of that a listing leaves out. One row rather than two, since a root
+/// that resolves and holds nothing has already been reported by the count.
+pub(crate) fn vault_summary(ctx: &Ctx) -> Result<Vault> {
     let root = vault(ctx)?;
-    let count = ignore::WalkBuilder::new(&root)
+    let archives = &ctx.config.note.archives;
+    let (mut listed, mut archived) = (0, 0);
+    for entry in ignore::WalkBuilder::new(&root)
         .hidden(true)
         .require_git(false)
         .build()
         .flatten()
         .filter(|entry| entry.file_type().is_some_and(|ft| ft.is_file()))
         .filter(|entry| note::is_note(entry.path()))
-        .count();
-    Ok((root, count))
+    {
+        match note::is_archived(&relative(entry.path(), &root), archives) {
+            true => archived += 1,
+            false => listed += 1,
+        }
+    }
+    Ok(Vault {
+        root,
+        listed,
+        archived,
+    })
+}
+
+/// What `config check` found in the vault.
+pub(crate) struct Vault {
+    pub root: PathBuf,
+    /// Notes a listing shows.
+    pub listed: usize,
+    /// Notes under `[note] archives`, which only `--all` shows.
+    pub archived: usize,
+}
+
+/// The `[note] archives` entries naming nothing that is there — a typo, or a
+/// directory since renamed, which hides no notes and says nothing about it.
+pub(crate) fn missing_archives(ctx: &Ctx) -> Result<Vec<String>> {
+    let root = vault(ctx)?;
+    Ok(ctx
+        .config
+        .note
+        .archives
+        .iter()
+        .filter(|archive| !root.join(archive).is_dir())
+        .cloned()
+        .collect())
 }
 
 #[cfg(test)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -211,6 +211,15 @@ pub struct NoteConfig {
     /// Written as an inline table — `labels = { work = ["projects"] }` — for
     /// the reason `[repo] labels` is.
     pub labels: Labels,
+    /// Directories below [`Self::root`] holding notes that are kept but no
+    /// longer read, as paths relative to the root — `["work/archive",
+    /// "personal/archive"]`. Left out of every listing unless `--all` asks for
+    /// them.
+    ///
+    /// A list rather than one directory, and paths rather than names, because
+    /// a vault that files notes by kind archives them the same way: an
+    /// `archive` beside each kind, not one at the root for all of them.
+    pub archives: Vec<String>,
     /// The one permanent note `note scratch` opens, as a path below
     /// [`Self::root`]. Unset, it is `scratch/scratch.md`.
     pub scratch: Option<String>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -129,7 +129,9 @@ enum Command {
     /// Manage the notes in your vault
     ///
     /// The set is every Markdown file under `[note] root` — an Obsidian vault,
-    /// or any tree of notes — most recently modified first.
+    /// or any tree of notes — most recently modified first. `[note] archives`
+    /// names the directories below it holding notes you keep but no longer
+    /// read; those are left out until `--all` asks for them.
     ///
     /// A row leads with what the note calls itself, then says what is true of
     /// it in a column each: the label its directory carries — or the directory
@@ -435,9 +437,16 @@ enum NoteCmd {
         /// may have come from front matter, which names a day.
         #[arg(long)]
         status: bool,
+        /// Also show the notes under `[note] archives`
+        #[arg(short = 'a', long)]
+        all: bool,
     },
     /// Fuzzy-select a note and print its absolute path
-    Sel,
+    Sel {
+        /// Also show the notes under `[note] archives`
+        #[arg(short = 'a', long)]
+        all: bool,
+    },
     /// Start a note and open it straight away
     ///
     /// No question is asked first: with no NAME the note is called after the
@@ -473,12 +482,16 @@ enum NoteCmd {
         /// Delete without asking
         #[arg(short, long)]
         yes: bool,
+        /// Also show the notes under `[note] archives`
+        #[arg(short = 'a', long)]
+        all: bool,
     },
     /// Open notes; omit the names to look for them
     ///
     /// A name is a path below the vault, exactly as `note ls` prints it, and
-    /// several open together. With none, the selector opens on every note in
-    /// the vault and three keys say what the query is read as: `ctrl-e` matches
+    /// several open together — a name outright is never subject to `[note]
+    /// archives`. With none, the selector opens on the vault and three keys say
+    /// what the query is read as: `ctrl-e` matches
     /// the names, `ctrl-r` searches inside every note as you type — the letters
     /// you typed, in order, so `errhand` finds "error handling" — and `ctrl-f`
     /// searches for the query exactly, for a phrase or a snippet of code. The
@@ -500,6 +513,9 @@ enum NoteCmd {
         /// Notes to open; omit to select interactively
         #[arg(value_name = "NAME")]
         notes: Vec<String>,
+        /// Also show the notes under `[note] archives`
+        #[arg(short = 'a', long)]
+        all: bool,
     },
 }
 
@@ -992,12 +1008,12 @@ fn dispatch(ctx: &Ctx, command: Command) -> anyhow::Result<()> {
             EditCmd::Dir { dirs } => cmd::edit::dir(ctx, &dirs),
         },
         Command::Note { command } => match command {
-            NoteCmd::Ls { status } => cmd::note::ls(ctx, status),
-            NoteCmd::Sel => cmd::note::sel(ctx),
-            NoteCmd::Open { notes } => cmd::note::open(ctx, &notes),
+            NoteCmd::Ls { status, all } => cmd::note::ls(ctx, status, all),
+            NoteCmd::Sel { all } => cmd::note::sel(ctx, all),
+            NoteCmd::Open { notes, all } => cmd::note::open(ctx, &notes, all),
             NoteCmd::New { name } => cmd::note::new(ctx, name.as_deref()),
             NoteCmd::Scratch => cmd::note::scratch(ctx),
-            NoteCmd::Cleanup { yes } => cmd::note::cleanup(ctx, yes),
+            NoteCmd::Cleanup { yes, all } => cmd::note::cleanup(ctx, yes, all),
         },
         Command::Branch { command } => match command {
             BranchCmd::Ls { status, scope } => {

--- a/src/note.rs
+++ b/src/note.rs
@@ -112,6 +112,37 @@ pub fn top_dir(rel: &str) -> &str {
     }
 }
 
+/// Whether `rel` — a path below the vault root — is one of the `archives`
+/// directories or sits inside one.
+///
+/// A directory matches itself as well as everything below it, so a walk can
+/// prune on the same answer that hides a note. Segments are compared
+/// case-insensitively, as a path is on Darwin, and empty and `.` segments are
+/// dropped from both sides so `work/archive`, `work/archive/` and
+/// `./work/archive` name the same directory. An entry naming no directory at
+/// all matches nothing, rather than archiving the whole vault.
+pub fn is_archived(rel: &str, archives: &[String]) -> bool {
+    archives.iter().any(|archive| under(rel, archive))
+}
+
+/// Whether `rel` is `archive` or lies below it.
+fn under(rel: &str, archive: &str) -> bool {
+    let mut wanted = segments(archive).peekable();
+    if wanted.peek().is_none() {
+        return false;
+    }
+    let mut have = segments(rel);
+    wanted.all(|want| {
+        have.next()
+            .is_some_and(|seg| seg.eq_ignore_ascii_case(want))
+    })
+}
+
+/// The meaningful parts of a relative path.
+fn segments(path: &str) -> impl Iterator<Item = &str> {
+    path.split('/').filter(|seg| !seg.is_empty() && *seg != ".")
+}
+
 /// When a note was created: what its front matter says, else what the
 /// filesystem says.
 ///
@@ -696,6 +727,73 @@ mod tests {
     fn a_vault_writing_date_rather_than_created_is_read_the_same_way() {
         let parsed = front("---\ndate: 2024-03-01\n---\n");
         assert_eq!(date(parsed.created.unwrap(), utc()), "2024-03-01");
+    }
+
+    // --- archives ---
+
+    #[test]
+    fn an_archive_covers_itself_and_everything_below_it() {
+        let archives = vec!["work/archive".to_string()];
+        assert!(is_archived("work/archive", &archives));
+        assert!(is_archived("work/archive/old.md", &archives));
+        assert!(is_archived("work/archive/2023/old.md", &archives));
+    }
+
+    #[test]
+    fn a_note_outside_every_archive_stays_listed() {
+        let archives = vec!["work/archive".to_string(), "personal/archive".to_string()];
+        assert!(!is_archived("work/plan.md", &archives));
+        assert!(!is_archived("personal/idea.md", &archives));
+        assert!(!is_archived("inbox.md", &archives));
+        assert!(!is_archived("archive/old.md", &archives));
+    }
+
+    /// A directory whose name merely starts with the archive's is a different
+    /// directory, and a path is matched by segment rather than by prefix.
+    #[test]
+    fn an_archive_is_not_a_prefix_of_the_name_beside_it() {
+        let archives = vec!["work/archive".to_string()];
+        assert!(!is_archived("work/archived-plans.md", &archives));
+        assert!(!is_archived("work/archive-2023/old.md", &archives));
+    }
+
+    /// The config is written by hand, and a trailing slash or a leading `./`
+    /// names the same directory as the plain path does.
+    #[test]
+    fn an_archive_path_is_read_the_way_it_was_written() {
+        for written in [
+            "work/archive/",
+            "./work/archive",
+            "/work/archive",
+            "work//archive",
+        ] {
+            let archives = vec![written.to_string()];
+            assert!(is_archived("work/archive/old.md", &archives), "{written}");
+        }
+    }
+
+    /// Darwin does not tell `Archive` and `archive` apart, and neither does the
+    /// label a directory carries.
+    #[test]
+    fn an_archive_matches_a_directory_of_any_case() {
+        let archives = vec!["Work/Archive".to_string()];
+        assert!(is_archived("work/archive/old.md", &archives));
+    }
+
+    /// An entry naming no directory would otherwise archive the whole vault.
+    #[test]
+    fn an_empty_archive_entry_hides_nothing() {
+        for empty in ["", "/", ".", "./"] {
+            assert!(
+                !is_archived("work/plan.md", &[empty.to_string()]),
+                "{empty}"
+            );
+        }
+    }
+
+    #[test]
+    fn nothing_is_archived_when_nothing_is_configured() {
+        assert!(!is_archived("work/archive/old.md", &[]));
     }
 
     // --- what a note calls itself ---

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1831,6 +1831,101 @@ fn note_ls_status_names_an_unlabelled_directory_after_itself() {
     assert!(run.stdout.contains("scratch"), "{}", run.stdout);
 }
 
+/// A vault that files notes by kind and archives them the same way, with an
+/// `archive` under each kind and one note still in use beside it.
+fn mk_archived_vault(sandbox: &Sandbox) -> PathBuf {
+    let vault = sandbox.home().join("notes");
+    mk_note(&vault, "work/plan.md", "plan\n", 4_000);
+    mk_note(&vault, "work/archive/old.md", "old\n", 3_000);
+    mk_note(&vault, "personal/idea.md", "idea\n", 2_000);
+    mk_note(&vault, "personal/archive/2023.md", "last year\n", 1_000);
+    sandbox.write_config(&format!(
+        "[note]\nroot = {:?}\neditor = \"echo\"\narchives = [\"work/archive\", \"personal/archive\"]\n",
+        vault.display().to_string()
+    ));
+    vault
+}
+
+/// An archive is what a vault keeps and stops reading, so a listing leaves it
+/// out — and `--all` is how you get at it anyway.
+#[test]
+fn note_ls_leaves_out_the_archives_until_all_asks_for_them() {
+    let sandbox = Sandbox::new();
+    let vault = mk_archived_vault(&sandbox);
+
+    let listed = sandbox.run(&["note", "ls"]);
+    listed.ok();
+    assert_eq!(
+        listed.lines(),
+        vec![
+            vault.join("work/plan.md").to_str().unwrap(),
+            vault.join("personal/idea.md").to_str().unwrap(),
+        ]
+    );
+
+    let all = sandbox.run(&["note", "ls", "--all"]);
+    all.ok();
+    assert_eq!(
+        all.lines(),
+        vec![
+            vault.join("work/plan.md").to_str().unwrap(),
+            vault.join("work/archive/old.md").to_str().unwrap(),
+            vault.join("personal/idea.md").to_str().unwrap(),
+            vault.join("personal/archive/2023.md").to_str().unwrap(),
+        ]
+    );
+}
+
+/// Naming a note is asking for that note, whatever a listing would have shown.
+#[test]
+fn note_open_takes_the_name_of_an_archived_note() {
+    let sandbox = Sandbox::new();
+    let vault = mk_archived_vault(&sandbox);
+
+    let run = sandbox.run(&["note", "open", "work/archive/old.md"]);
+    run.ok();
+    assert!(
+        run.stdout
+            .contains(vault.join("work/archive/old.md").to_str().unwrap()),
+        "{}",
+        run.stdout
+    );
+    assert!(!run.stderr.contains("warning"), "{}", run.stderr);
+}
+
+/// A vault whose every note is archived reports that, rather than reporting a
+/// vault with nothing in it.
+#[test]
+fn note_ls_says_the_archives_are_why_it_found_nothing() {
+    let sandbox = Sandbox::new();
+    let vault = sandbox.home().join("notes");
+    mk_note(&vault, "archive/old.md", "old\n", 1_000);
+    sandbox.write_config(&format!(
+        "[note]\nroot = {:?}\narchives = [\"archive\"]\n",
+        vault.display().to_string()
+    ));
+
+    let run = sandbox.run(&["note", "ls"]);
+    run.code(1);
+    assert!(run.stderr.contains("archives"), "{}", run.stderr);
+}
+
+/// An archive path is relative to the vault, and one that names nothing hides
+/// nothing — which is a setting the user meant and did not get.
+#[test]
+fn config_check_reports_an_archive_that_is_not_there() {
+    let sandbox = Sandbox::new();
+    let vault = sandbox.home().join("notes");
+    mk_note(&vault, "work/plan.md", "plan\n", 1_000);
+    sandbox.write_config(&format!(
+        "[note]\nroot = {:?}\narchives = [\"work/archive\"]\n",
+        vault.display().to_string()
+    ));
+
+    let run = sandbox.run(&["config", "check"]);
+    assert!(run.stdout.contains("work/archive"), "{}", run.stdout);
+}
+
 /// `note new` hands the editor a path nobody had to be asked for, and does not
 /// create the file — an abandoned note is one that never existed.
 #[test]


### PR DESCRIPTION
### Why

- A vault that has been going for years is mostly notes nobody will open again, and every one is a row between you and the note you want.
- Filing them under an archive already says so; scriv was reading it as one more directory.

### What

- `[note] archives` names those directories as paths below the root — `archives = ["work/archive", "personal/archive"]`.
- A list rather than one directory: a vault that files notes by kind archives them the same way.
- `note ls`, `note sel`, `note cleanup` and the `note open` selector leave them out; `--all` puts them back.
- Naming a note outright opens it either way.
- `config check` reports an archive that names nothing below the vault, which is the one way the setting fails silently.

### Cost

- ripgrep matches `--glob` against paths relative to the working directory rather than the directory it was told to search, so archives cannot be excluded from the text search up front. Their files are read and the hits dropped as they arrive.
- Four `note` subcommands gain a `--all` flag.

### Docs

- CLI help, starter config and CHANGELOG updated.
- No README change: it is a page now, and a flag is not a command group.
- `docs/demo.gif` unchanged: the demo fixture sets no archives, so nothing on screen moved.